### PR TITLE
Adding branch to build pipeline

### DIFF
--- a/packages/applications-service-api/azure-applications-service-api-build.yml
+++ b/packages/applications-service-api/azure-applications-service-api-build.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
       - main
+      - feature/APS_414_manually_implement_connectivity
   paths:
     include:
       - packages/applications-service-api


### PR DESCRIPTION
This is temporarily required in order for me to test branch APS_414_manually_implement_connectivity. It will be removed prior to the PR for that branch.

All this does is tell Azure DevOps to build any commits to this branch allowing me to release the branch to dev in order to test connectivity.