### PR TITLE
ASB-153: Got cookie information page working

### DIFF
--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -15,6 +15,8 @@ const fileSizeDisplayHelper = require('./lib/file-size-display-helper');
 const filterByKey = require('./lib/filter-by-key');
 const addKeyValuePair = require('./lib/add-key-value-pair');
 const renderTemplateFilter = require('./lib/render-template-filter');
+const flashMessageCleanupMiddleware = require('./middleware/flash-message-cleanup');
+const flashMessageToNunjucks = require('./middleware/flash-message-to-nunjucks');
 const removeUnwantedCookiesMiddelware = require('./middleware/remove-unwanted-cookies');
 require('express-async-errors');
 
@@ -92,6 +94,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(session(sessionConfig()));
+app.use(flashMessageCleanupMiddleware);
+app.use(flashMessageToNunjucks(env));
 app.use(removeUnwantedCookiesMiddelware);
 app.use('/public', express.static(path.join(__dirname, 'public')));
 app.use(

--- a/packages/forms-web-app/src/middleware/flash-message-cleanup.js
+++ b/packages/forms-web-app/src/middleware/flash-message-cleanup.js
@@ -1,0 +1,22 @@
+/**
+ * Using the session to allow messages to persist over an HTTP redirect.
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+module.exports = (req, res, next) => {
+  /**
+   * Take any messages from the current session - this will have been set on the user's previous
+   * request.
+   */
+  const flashMessages = req.session.flashMessages || [];
+
+  // reset the `req.session.flashMessages` container
+  req.session.flashMessages = [];
+
+  // store the messages for one time use on the current request.
+  res.locals.flashMessages = flashMessages;
+
+  next();
+};

--- a/packages/forms-web-app/src/middleware/flash-message-to-nunjucks.js
+++ b/packages/forms-web-app/src/middleware/flash-message-to-nunjucks.js
@@ -1,0 +1,11 @@
+/**
+ * Take any flash messages from the current request and make them available globally to nunjucks.
+ *
+ * @param env
+ * @returns {(function(*, *, *): void)|*}
+ */
+module.exports = (env) => (req, res, next) => {
+  env.addGlobal('flashMessages', res.locals.flashMessages || []);
+
+  next();
+};

--- a/packages/forms-web-app/src/views/components/flash-message.njk
+++ b/packages/forms-web-app/src/views/components/flash-message.njk
@@ -1,0 +1,13 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{%- if flashMessages.length > 0 -%}
+  <div data-cy="flash-message-container">
+    {%- for flashMessage in flashMessages -%}
+      {{- govukNotificationBanner({
+        type: flashMessage.type,
+        html: flashMessage.template.path | render(flashMessage.template.vars | default({})),
+        attributes: { "data-cy": "flash-message-%1-%2" | replace('%1', flashMessage.type) | replace('%2', loop.index) }
+      }) -}}
+    {%- endfor -%}
+  </div>
+{%- endif -%}

--- a/packages/forms-web-app/src/views/cookies.njk
+++ b/packages/forms-web-app/src/views/cookies.njk
@@ -58,19 +58,23 @@
               </span>
               </div>
 
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                Do you want to accept analytics cookies?
+              </legend>
+
               {{ govukRadios({
                 idPrefix: "usage-cookies",
                 name: "usage-cookies",
                 items: [
                   {
                     value: "on",
-                    text: "On",
+                    text: "Yes",
                     attributes: { "data-cy":"usage-cookies-yes"},
                     checked: cookiePolicy.usage == true
                   },
                   {
                     value: "off",
-                    text: "Off",
+                    text: "No",
                     attributes: { "data-cy":"usage-cookies-no"},
                     checked: cookiePolicy.usage == false
                   }

--- a/packages/forms-web-app/src/views/layouts/layout.njk
+++ b/packages/forms-web-app/src/views/layouts/layout.njk
@@ -58,7 +58,7 @@
   {% set tc_href = host + 'terms-and-conditions' %}
   {% set sm_href = host + 'sitemap' %}
   {% set ac_href = host + 'accessibility' %}
-  {% set ck_href = host + 'cookies-info' %}
+  {% set ck_href = host + 'cookies' %}
 {% endif %}
 
 {% block footer %}
@@ -90,7 +90,7 @@
                 attributes: { "data-cy":"Cookies" }
               }
             ]
-      }) 
+      })
     }}
 {% endblock %}
 

--- a/packages/forms-web-app/src/views/layouts/main.njk
+++ b/packages/forms-web-app/src/views/layouts/main.njk
@@ -80,7 +80,7 @@
   {% set tc_href = host + 'terms-and-conditions' %}
   {% set sm_href = host + 'sitemap' %}
   {% set ac_href = host + 'accessibility' %}
-  {% set ck_href = host + 'cookies-info' %}
+  {% set ck_href = host + 'cookies' %}
 {% endif %}
 
 {% block footer %}
@@ -112,6 +112,6 @@
                 attributes: { "data-cy":"Cookies" }
               }
             ]
-      }) 
+      })
     }}
 {% endblock %}

--- a/packages/forms-web-app/src/views/messages/cookies-updated-successfully.njk
+++ b/packages/forms-web-app/src/views/messages/cookies-updated-successfully.njk
@@ -1,0 +1,9 @@
+<h2 class="govuk-notification-banner__heading" data-cy="cookies-updated-heading-text">
+  Your cookie settings were saved
+</h2>
+<div class="govuk-notification-banner__body" data-cy="cookies-updated-body-text">
+  <p>Government services may set additional cookies and, if so, will have their own cookie policy and banner.</p>
+  {% if previousPagePath and previousPagePath !== '' and previousPagePath !== "/cookies" %}
+    <p><a href="{{ previousPagePath }}" data-cy="cookies-updated-go-back-link">Go back to the page you were looking at</a>.</p>
+  {% endif %}
+</div>


### PR DESCRIPTION
Brought across some missing aspects from Appeals service.

Took liberty of adding question and changing option labels on cookie information page to make it clearer what question is being asked of the user which more closely aligns with the latest thinking in the GOV.UK Design System cookie component.