### PR TITLE
Remove variable from service connection name

### DIFF
--- a/pipelines/common/common-ci.yml
+++ b/pipelines/common/common-ci.yml
@@ -35,7 +35,7 @@ extends:
       - task: AzureCLI@2
         displayName: Build and Push Docker Image to ACR
         inputs:
-          azureSubscription: $(projectName)-tooling
+          azureSubscription: applications-service-tooling
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |


### PR DESCRIPTION
- Remove variable from service connection name as Microsoft do not allow these to be dynamic for some reason