### PR TITLE
Fix CD pipeline deploying all envs when triggered by CI pipeline

### DIFF
--- a/pipelines/applications-service-api/applications-service-api-cd.yml
+++ b/pipelines/applications-service-api/applications-service-api-cd.yml
@@ -45,7 +45,7 @@ extends:
     projectName: $(projectName) 
     releaseVersion: $(version.MajorMinor)
     repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}:
+    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
       environments:
         - name: Dev
     ${{ else }}:

--- a/pipelines/forms-web-app/forms-web-app-cd.yml
+++ b/pipelines/forms-web-app/forms-web-app-cd.yml
@@ -45,7 +45,7 @@ extends:
     projectName: $(projectName) 
     releaseVersion: $(version.MajorMinor)
     repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}:
+    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
       environments:
         - name: Dev
     ${{ else }}:


### PR DESCRIPTION
The CD pipeline was triggering when the CI pipeline completed on the `main` branch. However, it was triggering for all environments instead of just Dev. This is because the condition was missing the 'ResourceTrigger' reason.