### PR TITLE
ASB-123: Corrected implementation to only require 1 character as the minimum length

### DIFF
--- a/e2e-tests/cypress/integration/registration/organisation/what-is-your-job-title-or-volunteer-role.feature
+++ b/e2e-tests/cypress/integration/registration/organisation/what-is-your-job-title-or-volunteer-role.feature
@@ -23,8 +23,10 @@ Feature: What is your job title or volunteer role? page
     Then I am on the "what is your email address? organisation" page
 
     Examples:
-      | text                                                              |
-      | Administration Officer                                            |
-      | qJr3qypBAeTMVBPLUHa3hDAM8FwKiVMZqCJLAHgyewrjFv9cmc5CG9VETkzE8ypB  |
+      | text                                                             |
+      | Administration Officer                                           |
+      | AO                                                               |
+      | CIO                                                              |
+      | qJr3qypBAeTMVBPLUHa3hDAM8FwKiVMZqCJLAHgyewrjFv9cmc5CG9VETkzE8ypB |
       | Some long job title or volunteer role within maximum characters! |
 

--- a/packages/forms-web-app/src/validators/register/organisation/role.js
+++ b/packages/forms-web-app/src/validators/register/organisation/role.js
@@ -4,7 +4,7 @@ const rules = () => {
   return [
     body('role').notEmpty().withMessage('Enter your job title or volunteer role'),
     body('role')
-      .isLength({ min: 3, max: 64 })
+      .isLength({ min: 1, max: 64 })
       .withMessage('Your job title or volunteer role must be 64 characters or less'),
   ];
 };


### PR DESCRIPTION
Also added a few more examples to acceptance tests to prove job titles with 2 and 3 characters are accepted.