### PR TITLE
Changed DB config to be sourced exclusively from environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ services:
       SERVER_SHOW_ERRORS: 'true'
       TRIALIST_DATA_PATH: /opt/app/data/trialists.json
       NODE_ENV: local
+      MYSQL_USERNAME: pins
+      MYSQL_PASSWORD: pins
+      MYSQL_DATABASE: ipclive
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+      MYSQL_DIALECT: mysql
       DOCUMENTS_PER_PAGE: '20'
       DOCUMENTS_HOST: https://nitestaz.planninginspectorate.gov.uk/wp-content/ipc/uploads/projects/
       SRV_NOTIFY_BASE_URL: https://api.notifications.service.gov.uk/

--- a/packages/applications-service-api/database/config/config.js
+++ b/packages/applications-service-api/database/config/config.js
@@ -1,30 +1,10 @@
 const config = {
-  local: {
-    username: 'pins',
-    password: 'pins',
-    database: 'ipclive',
-    host: 'db',
-    dialect: 'mysql',
-  },
-  development: {
-    username: process.env.MYSQL_USERNAME,
-    password: process.env.MYSQL_PASSWORD,
-    database: process.env.MYSQL_DATABASE,
-    host: process.env.MYSQL_HOST,
-    port: process.env.MYSQL_PORT,
-    dialect: process.env.MYSQL_DIALECT,
-  },
+  username: process.env.MYSQL_USERNAME,
+  password: process.env.MYSQL_PASSWORD,
+  database: process.env.MYSQL_DATABASE,
+  host: process.env.MYSQL_HOST,
+  port: process.env.MYSQL_PORT,
+  dialect: process.env.MYSQL_DIALECT,
 };
 
-const getConfig = () => {
-  switch (process.env.NODE_ENV) {
-    case 'development':
-      return config.development;
-    case 'local':
-      return config.local;
-    default:
-      return config.local;
-  }
-};
-
-module.exports = getConfig();
+module.exports = config;


### PR DESCRIPTION
Changed DB config to be sourced exclusively from environment variables instead of trying to manage environment variations within app code.   Updated docker-compose file used locally to provide relevant values for the MYSQL_ environment variables.

This resolves an issue which was uncovered when deploying to a new development environment with `NODE_ENV` set to something other than `development`, in this case it was set to `production` yet ended up with "local" database configuration values 🙈