### PR TITLE
Fixed an issue where registration confirmation email is not sent

### DIFF
--- a/packages/applications-service-api/__tests__/unit/controllers/interested-party.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/interested-party.test.js
@@ -354,7 +354,7 @@ describe('updateComments', () => {
   it('should update comments for party', async () => {
     const req = httpMocks.createRequest({
       params: {
-        ID: 30000120,
+        ID: '30000120',
       },
       body: {
         comments: [


### PR DESCRIPTION
Fixed an issue where if a user saves and exits, then returns and completes registration with their original comment unchanged, they do not receive a confirmation email. This is because the code was relying upon the number of rows affected by a MySQL UPDATE.  In the event the comment is the same as what is already persisted, the number of rows is affected is returned as 0.