### PR TITLE
ASB-259: Content update under H1 on 'Over 18' pages

### DIFF
--- a/packages/forms-web-app/src/views/register/agent/are-they-18-over.njk
+++ b/packages/forms-web-app/src/views/register/agent/are-they-18-over.njk
@@ -34,7 +34,7 @@
                 }
             },
             hint: {
-                test: "You can still register for them if they are under 18, but we will process their personal details in a different way."
+                text: "You can still register for them if they are under 18, but we will process their personal details in a different way."
             },
             idPrefix: "over-18",
             name: "over-18",


### PR DESCRIPTION
Corrected hint text parameter name so hint text will get correctly displayed