### PR TITLE
ASB-185: Handle no documents available vs no documents found properly

### DIFF
--- a/packages/applications-service-api/__tests__/unit/controllers/document-filter.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/document-filter.test.js
@@ -8,10 +8,10 @@ const { getFilters, getOrderedDocuments } = require('../../../src/services/docum
 jest.mock('../../../src/services/document.service');
 
 getFilters.mockImplementation(() => Promise.resolve([]));
-getOrderedDocuments.mockImplementation(() => Promise.resolve({ rows: [] }));
+getOrderedDocuments.mockImplementation(() => Promise.resolve({ rows: [], count: 0 }));
 
 describe('getV2Documents', () => {
-  it('should return no documents found when type if everything_else no document exist', async () => {
+  it('should return empty list when type if everything_else no document exist', async () => {
     const req = httpMocks.createRequest({
       query: {
         caseRef: 'EN000000',
@@ -21,10 +21,17 @@ describe('getV2Documents', () => {
 
     const res = httpMocks.createResponse();
     await getV2Documents(req, res);
-    expect(res._getStatusCode()).toEqual(StatusCodes.NOT_FOUND);
+    expect(res._getStatusCode()).toEqual(StatusCodes.OK);
     expect(res._getData()).toEqual({
-      code: StatusCodes.NOT_FOUND,
-      errors: ['No documents found'],
+      documents: [],
+      totalItems: 0,
+      itemsPerPage: 20,
+      totalPages: 1,
+      currentPage: 1,
+      filters: {
+        stageFilters: [],
+        typeFilters: [],
+      },
     });
   });
 });

--- a/packages/applications-service-api/__tests__/unit/controllers/documents.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/documents.test.js
@@ -556,7 +556,7 @@ describe('getV2Documents', () => {
     expect(res._getStatusCode()).toEqual(StatusCodes.OK);
     expect(data).toEqual(v2DocumentListWrapperNoResults);
   });
-  
+
   it('should return internal server error', async () => {
     const req = httpMocks.createRequest({
       query: {

--- a/packages/applications-service-api/__tests__/unit/controllers/documents.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/documents.test.js
@@ -379,6 +379,18 @@ const mockDataForSearch = {
   ],
 };
 
+const v2DocumentListWrapperNoResults = {
+  documents: [],
+  totalItems: 0,
+  itemsPerPage: 3,
+  totalPages: 1,
+  currentPage: 1,
+  filters: {
+    stageFilters: [],
+    typeFilters: [],
+  },
+};
+
 jest.mock('../../../src/models', () => {
   // eslint-disable-next-line global-require
   const SequelizeMock = require('sequelize-mock');
@@ -402,7 +414,7 @@ jest.mock('../../../src/models', () => {
         return Document.build({ ...mockDataForSearch });
       }
       if (caseRef === 'EN000000') {
-        return Document.build({ rows: [] });
+        return Document.build({ rows: [], count: 0 });
       }
       if (caseRef === 'ENF0000F') {
         return null;
@@ -516,6 +528,7 @@ describe('getV2Documents', () => {
     expect(res._getStatusCode()).toEqual(StatusCodes.OK);
     expect(data).toEqual(v2DocumentListWrapper);
   });
+
   it('should return required query parameter missing', async () => {
     const req = httpMocks.createRequest({
       query: {},
@@ -530,7 +543,7 @@ describe('getV2Documents', () => {
     }
   });
 
-  it('should return documents not found', async () => {
+  it('should return an empty list when no documents found', async () => {
     const req = httpMocks.createRequest({
       query: {
         caseRef: 'EN000000',
@@ -539,9 +552,11 @@ describe('getV2Documents', () => {
 
     const res = httpMocks.createResponse();
     await getV2Documents(req, res);
-    expect(res._getStatusCode()).toEqual(StatusCodes.NOT_FOUND);
-    expect(res._getData()).toEqual({ code: StatusCodes.NOT_FOUND, errors: ['No documents found'] });
+    const data = res._getData();
+    expect(res._getStatusCode()).toEqual(StatusCodes.OK);
+    expect(data).toEqual(v2DocumentListWrapperNoResults);
   });
+
 
   it('should return internal server error', async () => {
     const req = httpMocks.createRequest({

--- a/packages/applications-service-api/__tests__/unit/controllers/documents.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/documents.test.js
@@ -556,8 +556,7 @@ describe('getV2Documents', () => {
     expect(res._getStatusCode()).toEqual(StatusCodes.OK);
     expect(data).toEqual(v2DocumentListWrapperNoResults);
   });
-
-
+  
   it('should return internal server error', async () => {
     const req = httpMocks.createRequest({
       query: {

--- a/packages/applications-service-api/src/controllers/documents.js
+++ b/packages/applications-service-api/src/controllers/documents.js
@@ -84,10 +84,6 @@ module.exports = {
         stage && !(stage instanceof Array) ? [stage] : stage,
         typeFilters
       );
-      console.log(documents.rows.length);
-      if (!documents.rows.length) {
-        throw ApiError.noDocumentsFound();
-      }
 
       const { itemsPerPage, documentsHost } = config;
       const totalItems = documents.count;
@@ -100,7 +96,7 @@ module.exports = {
         documents: rows,
         totalItems,
         itemsPerPage,
-        totalPages: Math.ceil(totalItems / itemsPerPage),
+        totalPages: Math.ceil(Math.max(1, totalItems) / itemsPerPage),
         currentPage: page,
         filters: {
           stageFilters: stageFiltersAvailable

--- a/packages/forms-web-app/__tests__/unit/controllers/projects/documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/projects/documents.test.js
@@ -66,7 +66,7 @@ describe('controllers/documents', () => {
     );
   });
 
-  describe('getAboutTheApplication', () => {
+  describe('getApplicationDocuments', () => {
     it('should call the correct template', async () => {
       await aboutTheApplicationController.getApplicationDocuments(req, res);
       expect(res.render).toHaveBeenCalledWith(VIEW.PROJECTS.DOCUMENTS, {
@@ -89,16 +89,41 @@ describe('controllers/documents', () => {
       });
     });
 
-    it('should call the correct template if received 404', async () => {
+    it('should handle an empty result list', async () => {
       searchDocumentListV2.mockImplementation(() =>
         Promise.resolve({
-          resp_code: 404,
+          resp_code: 200,
+          data: {
+            documents: [],
+            filters: {
+              stageFilters: [],
+              typeFilters: [],
+            },
+            totalItems: 1,
+            itemsPerPage: 20,
+            totalPages: 1,
+            currentPage: 1,
+          },
         })
       );
       await aboutTheApplicationController.getApplicationDocuments(req, res);
       expect(res.render).toHaveBeenCalledWith(VIEW.PROJECTS.DOCUMENTS, {
         projectName: 'St James Barton Giant Wind Turbine',
         caseRef: 'ABCD1234',
+        documents: [],
+        queryUrl: '',
+        searchTerm: undefined,
+        modifiedStageFilters: [],
+        top5TypeFilters: [],
+        pageOptions: [1],
+        paginationData: {
+          currentPage: 1,
+          fromRange: 1,
+          itemsPerPage: 20,
+          toRange: 1,
+          totalItems: 1,
+          totalPages: 1,
+        },
       });
     });
   });

--- a/packages/forms-web-app/src/controllers/projects/documents.js
+++ b/packages/forms-web-app/src/controllers/projects/documents.js
@@ -15,93 +15,87 @@ function renderData(
   stageList = [],
   typeList = []
 ) {
-  if (response.resp_code === 404) {
-    res.render(VIEW.PROJECTS.DOCUMENTS, {
-      projectName,
-      caseRef: params.caseRef,
-      searchTerm: params.searchTerm,
+  let queryUrl = '';
+  if (params.searchTerm) {
+    queryUrl = `&searchTerm=${params.searchTerm}`;
+  }
+  if (params.stage) {
+    const stageQueryParams = params.type instanceof Array ? [...params.stage] : [params.stage];
+    queryUrl = `${queryUrl}&stage=${stageQueryParams.join('&stage=')}`;
+  }
+  if (params.type) {
+    const typeQueryParams = params.type instanceof Array ? [...params.type] : [params.type];
+    queryUrl = `${queryUrl}&type=${typeQueryParams.join('&type=')}`;
+  }
+  const respData = response.data;
+  const { documents, filters } = respData;
+  const { stageFilters, typeFilters } = filters;
+  logger.debug(`Document data received:  ${JSON.stringify(documents)} `);
+  const paginationData = getPaginationData(respData);
+  const pageOptions = calculatePageOptions(paginationData);
+  const modifiedStageFilters = [];
+  const top5TypeFilters = [];
+
+  stageFilters.forEach(function (stage) {
+    modifiedStageFilters.push({
+      text: `${projectStageNames[stage.name]} (${stage.count})`,
+      value: stage.name,
+      checked: stageList.includes(stage.name),
     });
-  } else {
-    let queryUrl = '';
-    if (params.searchTerm) {
-      queryUrl = `&searchTerm=${params.searchTerm}`;
-    }
-    if (params.stage) {
-      const stageQueryParams = params.type instanceof Array ? [...params.stage] : [params.stage];
-      queryUrl = `${queryUrl}&stage=${stageQueryParams.join('&stage=')}`;
-    }
-    if (params.type) {
-      const typeQueryParams = params.type instanceof Array ? [...params.type] : [params.type];
-      queryUrl = `${queryUrl}&type=${typeQueryParams.join('&type=')}`;
-    }
-    const respData = response.data;
-    const { documents, filters } = respData;
-    const { stageFilters, typeFilters } = filters;
-    logger.debug(`Document data received:  ${JSON.stringify(documents)} `);
-    const paginationData = getPaginationData(respData);
-    const pageOptions = calculatePageOptions(paginationData);
-    const modifiedStageFilters = [];
-    const top5TypeFilters = [];
+  }, Object.create(null));
 
-    stageFilters.forEach(function (stage) {
-      modifiedStageFilters.push({
-        text: `${projectStageNames[stage.name]} (${stage.count})`,
-        value: stage.name,
-        checked: stageList.includes(stage.name),
-      });
-    }, Object.create(null));
+  let otherTypeFiltersCount = 0;
+  typeFilters.slice(-(typeFilters.length - 5)).forEach(function (type) {
+    otherTypeFiltersCount += type.count;
+  }, Object.create(null));
 
-    let otherTypeFiltersCount = 0;
-    typeFilters.slice(-(typeFilters.length - 5)).forEach(function (type) {
-      otherTypeFiltersCount += type.count;
-    }, Object.create(null));
-
-    typeFilters
-      .slice(0, 5)
-      .sort(function (a, b) {
-        if (a.name < b.name) {
-          return -1;
-        }
-        return 0;
-      })
-      .forEach(function (type) {
-        top5TypeFilters.push({
-          text: `${type.name} (${type.count})`,
-          value: type.name,
-          checked: typeList.includes(type.name),
-        });
-      }, Object.create(null));
-    if (typeFilters.length > 5) {
+  typeFilters
+    .slice(0, 5)
+    .sort(function (a, b) {
+      if (a.name < b.name) {
+        return -1;
+      }
+      return 0;
+    })
+    .forEach(function (type) {
       top5TypeFilters.push({
-        text: `Everything else (${otherTypeFiltersCount})`,
-        value: 'everything_else',
-        checked: typeList.includes('everything_else'),
+        text: `${type.name} (${type.count})`,
+        value: type.name,
+        checked: typeList.includes(type.name),
       });
-    }
-    res.render(VIEW.PROJECTS.DOCUMENTS, {
-      documents,
-      projectName,
-      caseRef: params.caseRef,
-      paginationData,
-      pageOptions,
-      searchTerm: params.searchTerm,
-      queryUrl,
-      modifiedStageFilters,
-      top5TypeFilters,
+    }, Object.create(null));
+  if (typeFilters.length > 5) {
+    top5TypeFilters.push({
+      text: `Everything else (${otherTypeFiltersCount})`,
+      value: 'everything_else',
+      checked: typeList.includes('everything_else'),
     });
   }
+  res.render(VIEW.PROJECTS.DOCUMENTS, {
+    documents,
+    projectName,
+    caseRef: params.caseRef,
+    paginationData,
+    pageOptions,
+    searchTerm: params.searchTerm,
+    queryUrl,
+    modifiedStageFilters,
+    top5TypeFilters,
+  });
 }
 
 exports.getApplicationDocuments = async (req, res) => {
   const applicationResponse = await getAppData(req.params.case_ref);
-  const projectName = applicationResponse.data.ProjectName;
-  const params = {
-    caseRef: req.params.case_ref,
-    classification: 'application',
-    page: '1',
-    ...req.query,
-  };
-  const { searchTerm, stage, type } = req.query;
-  const response = await searchDocumentsV2(params);
-  renderData(req, res, searchTerm, params, response, projectName, stage, type);
+  if (applicationResponse.resp_code === 200) {
+    const projectName = applicationResponse.data.ProjectName;
+    const params = {
+      caseRef: req.params.case_ref,
+      classification: 'application',
+      page: '1',
+      ...req.query,
+    };
+    const { searchTerm, stage, type } = req.query;
+    const response = await searchDocumentsV2(params);
+    renderData(req, res, searchTerm, params, response, projectName, stage, type);
+  }
 };

--- a/packages/forms-web-app/src/views/projects/documents.njk
+++ b/packages/forms-web-app/src/views/projects/documents.njk
@@ -4,18 +4,21 @@
 {% set activeProjectLink = 'about-the-application' %}
 
 {% block contentHeader %}
-    <h2 class="govuk-heading-l">Project application documents</h2>
+  <h2 class="govuk-heading-l">Project application documents</h2>
+  {% if documents.length != 0 or queryUrl != '' %}
     <p>
       <input class="govuk-input govuk-!-width-one-half" id="search" name="searchTerm" type="text" value="{{ searchTerm }}">
       <button class="govuk-button" data-cy="search-button">Search</button>
     </p>
+  {% endif %}
 {% endblock %}
 
 {% block columnTwo %}
   <div class="govuk-grid-row">
-    {% if documents %}
-    <p class="hmcts-pagination__results">Showing <b>{{ paginationData.fromRange }}</b> to <b>{{ paginationData.toRange }}</b> of <b>{{ paginationData.totalItems }}</b> documents, newest first.</p>
-      <strong></p>
+    {% if documents.length > 0 %}
+      <p class="hmcts-pagination__results">
+        Showing <b>{{ paginationData.fromRange }}</b> to <b>{{ paginationData.toRange }}</b> of <b>{{ paginationData.totalItems }}</b> documents, newest first.
+      </p>
 
       <ul class="pins-govuk-result-list">
         {% for document in documents %}
@@ -44,16 +47,24 @@
           </li>
         {% endfor %}
       </ul>
-    {% else %}
+   {% elseif documents.length == 0 and queryUrl != '' %}
       <p style="govuk-body" data-cy="no-docs-text">
-        No documents were found matching your search terms.
+        No documents were found matching your search term and filters.
       </p>
       <p style="govuk-body">
-        Would you like to clear your search and view all documents instead? <a style="govuk-link" href="/projects/{{ caseRef }}/application-documents" data-cy="clear-search">Clear search</a>
+        Would you like to clear your search and filters to view all available documents instead?
+      </p>
+      <p>
+        <a style="govuk-link" href="/projects/{{ caseRef }}/application-documents" data-cy="clear-search">Clear search and filters</a>
+      </p>
+    {% elseif documents.length == 0 %}
+      <p class="govuk-body">There are no project application documents available to display at the moment.</p>
+      <p class="govuk-body">
+        <a href="/projects/{{ caseRef }}" class="govuk-link">Return to the project overview</a>
       </p>
     {% endif %}
 
-    {% if documents %}
+    {% if documents.length > 0 %}
         {% set pageLinkTemplate -%}
           /projects/{{ caseRef }}/application-documents?page=:page{{ queryUrl | safe }}
         {%- endset %}
@@ -64,43 +75,45 @@
 
 
 {% block columnThree %}
-  <div class="govuk-grid-row govuk-!-margin-left-3 govuk-!-margin-right-3">
-        {% set projectStageFilter %}
-          {{ govukCheckboxes({ classes: "govuk-checkboxes--small", idPrefix: "stage",
-          name: "stage", items: modifiedStageFilters }) }}
-        {% endset %}
-        {% set top5ProjectTypeFilter %}
-          {{ govukCheckboxes({ classes: "govuk-checkboxes--small", idPrefix: "top5Type",
-          name: "type", items: top5TypeFilters }) }}
-        {% endset %}
-      <div style="background-color: #f3f2f1; padding: 10px;">
-      <h2 class="govuk-heading-m">Filter by</h2>
+  {% if documents.length != 0 or queryUrl != '' %}
+    <div class="govuk-grid-row govuk-!-margin-left-3 govuk-!-margin-right-3">
+          {% set projectStageFilter %}
+            {{ govukCheckboxes({ classes: "govuk-checkboxes--small", idPrefix: "stage",
+            name: "stage", items: modifiedStageFilters }) }}
+          {% endset %}
+          {% set top5ProjectTypeFilter %}
+            {{ govukCheckboxes({ classes: "govuk-checkboxes--small", idPrefix: "top5Type",
+            name: "type", items: top5TypeFilters }) }}
+          {% endset %}
+        <div style="background-color: #f3f2f1; padding: 10px;">
+        <h2 class="govuk-heading-m">Filter by</h2>
 
-      {{ govukAccordion({
-          id: "accordion-default",
-          classes: "filter-accordion",
-          headingLevel: 3,
-          items: [
-              {
-                  heading: {
-                      html: '<span class="filter-heading">Document stage</span>'
-                  },
-                  content: {
-                      html: projectStageFilter
-                  }
-              },
-              {
-                  heading: {
-                      html: '<span class="filter-heading">Project type</span>'
-                  },
-                  content: {
-                      html: top5ProjectTypeFilter
-                  }
-              }
-          ]
-          })
-      }}
+        {{ govukAccordion({
+            id: "accordion-default",
+            classes: "filter-accordion",
+            headingLevel: 3,
+            items: [
+                {
+                    heading: {
+                        html: '<span class="filter-heading">Document stage</span>'
+                    },
+                    content: {
+                        html: projectStageFilter
+                    }
+                },
+                {
+                    heading: {
+                        html: '<span class="filter-heading">Project type</span>'
+                    },
+                    content: {
+                        html: top5ProjectTypeFilter
+                    }
+                }
+            ]
+            })
+        }}
 
-      <button class="govuk-button">Apply Filters</button>
-  </div>
+        <button class="govuk-button">Apply Filters</button>
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Changed v2 documents endpoint to longer return 404 but instead an empty list when no documents are found. Changed frontend to handle an empty list of documents with no search and filters differently than when there is an empty list of documents due to search and/or filtering