### PR TITLE
ASB-288: Change handling of no representations found

### DIFF
--- a/packages/applications-service-api/__tests__/unit/controllers/representations.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/representations.test.js
@@ -83,7 +83,7 @@ jest.mock('../../../src/models', () => {
       return mockData;
     }
     if (queryOptions[0].where.CaseReference === 'EN000000') {
-      return { rows: [] };
+      return { rows: [], count: 0 };
     }
     const symbolKey = Reflect.ownKeys(queryOptions[0].where).find(
       (key) => key.toString() === 'Symbol(and)'
@@ -122,7 +122,7 @@ describe('getRepresentationsForApplication', () => {
     expect(data).toEqual(returnData);
   });
 
-  it('should return representations not found', async () => {
+  it('should return an empty list if no representations found', async () => {
     const req = httpMocks.createRequest({
       query: {
         applicationId: 'EN000000',
@@ -131,10 +131,13 @@ describe('getRepresentationsForApplication', () => {
 
     const res = httpMocks.createResponse();
     await getRepresentationsForApplication(req, res);
-    expect(res._getStatusCode()).toEqual(StatusCodes.NOT_FOUND);
+    expect(res._getStatusCode()).toEqual(StatusCodes.OK);
     expect(res._getData()).toEqual({
-      code: StatusCodes.NOT_FOUND,
-      errors: ['No representations found'],
+      representations: [],
+      totalItems: 0,
+      itemsPerPage: 3,
+      totalPages: 1,
+      currentPage: 1,
     });
   });
 

--- a/packages/applications-service-api/src/controllers/representations.js
+++ b/packages/applications-service-api/src/controllers/representations.js
@@ -10,17 +10,14 @@ const ApiError = require('../error/apiError');
 module.exports = {
   async getRepresentationsForApplication(req, res) {
     const { applicationId, page, searchTerm } = req.query;
+    const selectedPage = page || 1;
     logger.debug(`Retrieving representations for application ref ${applicationId}`);
     try {
       const representations = await getRepresentationsForApplication(
         applicationId,
-        page || 1,
+        selectedPage,
         searchTerm
       );
-
-      if (!representations.rows.length) {
-        throw ApiError.noRepresentationsFound();
-      }
 
       const { itemsPerPage } = config;
       const totalItems = representations.count;
@@ -29,8 +26,8 @@ module.exports = {
         representations: representations.rows,
         totalItems,
         itemsPerPage,
-        totalPages: Math.ceil(totalItems / itemsPerPage),
-        currentPage: page,
+        totalPages: Math.ceil(Math.max(totalItems, 1) / itemsPerPage),
+        currentPage: selectedPage,
       };
 
       res.status(StatusCodes.OK).send(wrapper);

--- a/packages/forms-web-app/src/views/projects/representations.njk
+++ b/packages/forms-web-app/src/views/projects/representations.njk
@@ -4,23 +4,14 @@
 {% set activeProjectLink = 'representations' %}
 
 {% block contentHeader %}
-  <div class="govuk-grid-row">
-    <h2 class="govuk-heading-l">Registration Comments</h2>
-      <p class="results">
-          {% if representations %}
-            <p class="hmcts-pagination__results">Showing <b>{{ paginationData.fromRange }}</b> to <b>{{ paginationData.toRange }}</b> of <b>{{ paginationData.totalItems }}</b> comments, newest first.</p>
-          {% else %}
-            <p class="govuk-body">There are no registration comments to display. Registration comments will be published after the registration period has closed.</p>
-            <p class="govuk-body">
-              <a href="/projects/{{ caseRef }}" class="govuk-link">Return to the project overview</a>
-            </p>
-          {% endif %}
-      </p>
-  </div>
+  <h2 class="govuk-heading-l">Registration Comments</h2>
 {% endblock %}
 
 {% block columnTwo %}
-      {% if representations %}
+  <div class="govuk-grid-row">
+      {% if representations.length > 0 %}
+        <p class="hmcts-pagination__results">Showing <b>{{ paginationData.fromRange }}</b> to <b>{{ paginationData.toRange }}</b> of <b>{{ paginationData.totalItems }}</b> comments, newest first.</p>
+
         <ul class="pins-govuk-result-list">
           {% for representation in representations %}
             <li class="pins-govuk-result-list__item">
@@ -44,11 +35,17 @@
             </li>
           {% endfor %}
         </ul>
+
+        {% set pageLinkTemplate -%}
+          /projects/{{ caseRef }}/representations?page=:page
+        {%- endset %}
+        {{ paginationBar(pageOptions, paginationData, pageLinkTemplate) }}
+
+      {% else %}
+        <p class="govuk-body">There are no registration comments to display. Registration comments will be published after the registration period has closed.</p>
+        <p class="govuk-body">
+          <a href="/projects/{{ caseRef }}" class="govuk-link">Return to the project overview</a>
+        </p>
       {% endif %}
-      {% if representations %}
-          {% set pageLinkTemplate -%}
-            /projects/{{ caseRef }}/representations?page=:page
-          {%- endset %}
-          {{ paginationBar(pageOptions, paginationData, pageLinkTemplate) }}
-      {% endif %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
Changed representations endpoint to longer return 404 but instead an empty list when no representations found.   Changed frontend to handle an empty list of representations