### PR TITLE
Addressed a few styling issues

### DIFF
--- a/packages/forms-web-app/src/views/layouts/project-2-columns.njk
+++ b/packages/forms-web-app/src/views/layouts/project-2-columns.njk
@@ -2,7 +2,7 @@
 {% extends "layouts/project.njk" %}
 
 {% block content %}
-  <div class="govuk-grid-row govuk-!-margin-left-6 govuk-!-margin-right-6">
+  <div class="govuk-grid-row govuk-!-margin-left-0">
       <div class="govuk-grid-column-one-quarter">
         {% include "layouts/vertical-tabs.njk" %}
       </div>

--- a/packages/forms-web-app/src/views/layouts/project-3-columns.njk
+++ b/packages/forms-web-app/src/views/layouts/project-3-columns.njk
@@ -3,7 +3,7 @@
 
 {% block content %}
   <form action="/projects/{{ caseRef }}/{{ section }}" method="GET" novalidate>
-    <div class="govuk-grid-row govuk-!-margin-left-6 govuk-!-margin-right-6">
+    <div class="govuk-grid-row govuk-!-margin-left-0">
         <div class="govuk-grid-column-one-quarter">
           {% include "layouts/vertical-tabs.njk" %}
         </div>

--- a/packages/forms-web-app/src/views/layouts/project.njk
+++ b/packages/forms-web-app/src/views/layouts/project.njk
@@ -9,7 +9,7 @@
 
 {% block beforeContent %}
   <div class="project-header-section">
-    <div class="govuk-!-margin-left-6 govuk-!-margin-right-6">
+    <div>
       {{ govukPhaseBanner({
           tag: {
             text: "beta"
@@ -17,7 +17,7 @@
           html: 'This is a new service – your <a class="govuk-link " href="#">feedback</a> will help us to improve it.'
         })
       }}
-      <h1 class="govuk-heading-xl govuk-!-padding-top-9 govuk-!-padding-bottom-3 govuk-!-margin-bottom-3 govuk-!-margin-left-3" >{{ projectName }}</p>
+      <h1 class="govuk-heading-xl govuk-!-padding-top-9 govuk-!-padding-bottom-3 govuk-!-margin-bottom-3" >{{ projectName }}</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Fixed an issue with the alignment of the header, phase banner and main content by removing unnecessary margin classes.  Now, the PINS header, phase banner, project heading and project menu are properly aligned.

Before:

![image](https://user-images.githubusercontent.com/398961/169567971-b7d8a5dd-1342-4691-b11c-a55a8190319c.png)


After:

<img width="739" alt="Screenshot 2022-05-20 at 16 52 29" src="https://user-images.githubusercontent.com/398961/169567995-bfb0368f-8d55-4f51-901c-e66f9ea1f3f2.png">
