### PR TITLE
Update release pipelines to use App Service slots

### DIFF
--- a/packages/applications-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/applications-service-api/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/applications-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/applications-service-api/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.2.1
+      ref: refs/tags/release/2.5.1
   pipelines:
     - pipeline: applications-service-api-ci
       source: applications-service-api CI
@@ -30,14 +30,23 @@ extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
-      - name: Deploy
+      - name: Stage
         deploymentSteps:
-          - template: ../steps/azure_web_app_slot_swap_deploy.yml
+          - template: ../steps/azure_web_app_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)
+              appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_slot_swap.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              appStagingSlotName: staging
+              appTargetSlotName: production
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/applications-service-api/pipelines/azure-pipelines-variables.yml@self 

--- a/packages/applications-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/applications-service-api/pipelines/azure-pipelines-release.yml
@@ -40,6 +40,8 @@ extends:
               azurecrName: $(azurecrName)
               repository: $(repository)
       - name: Deploy
+        dependsOn:
+          - Stage
         deploymentSteps:
           - template: ../steps/azure_web_app_slot_swap.yml
             parameters:

--- a/packages/applications-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/applications-service-api/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.2.1
   pipelines:
     - pipeline: applications-service-api-ci
       source: applications-service-api CI
@@ -32,7 +32,7 @@ extends:
     deploymentStages:
       - name: Deploy
         deploymentSteps:
-          - template: ../steps/azure_web_app_deploy.yml
+          - template: ../steps/azure_web_app_slot_swap_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)

--- a/packages/common/pipelines/azure-pipelines-build.yml
+++ b/packages/common/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/forms-web-app/pipelines/azure-pipelines-build.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-build.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.2.1
+      ref: refs/tags/release/2.5.1
   pipelines:
     - pipeline: forms-web-app-ci
       source: forms-web-app CI
@@ -30,14 +30,23 @@ extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
-      - name: Deploy
+      - name: Stage
         deploymentSteps:
-          - template: ../steps/azure_web_app_slot_swap_deploy.yml
+          - template: ../steps/azure_web_app_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)
+              appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_slot_swap.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              appStagingSlotName: staging
+              appTargetSlotName: production
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/forms-web-app/pipelines/azure-pipelines-variables.yml@self

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.2.1
   pipelines:
     - pipeline: forms-web-app-ci
       source: forms-web-app CI
@@ -32,7 +32,7 @@ extends:
     deploymentStages:
       - name: Deploy
         deploymentSteps:
-          - template: ../steps/azure_web_app_deploy.yml
+          - template: ../steps/azure_web_app_slot_swap_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -40,6 +40,8 @@ extends:
               azurecrName: $(azurecrName)
               repository: $(repository)
       - name: Deploy
+        dependsOn:
+          - Stage
         deploymentSteps:
           - template: ../steps/azure_web_app_slot_swap.yml
             parameters:


### PR DESCRIPTION
Updated release pipelines for web and API apps to utilize [App Service slots](https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots) for deployments. Containers are first deployed to a staging slot, then the staging slot is swapped with the current production slot.

This method of deployment decreases downtime from the end-user perspective during deployments and allows developers to swap back to the previous deployment by swapping the deployment slots, rather than needing to redeploy an old version of the app.

Both release pipelines were manually run against this branch prior to merge to confirm that both apps were successfully deployed to their respective App Service staging slot, then those slots swapped into production.
