### PR TITLE
chore(pipelines): update to pipelines version 2.5.3

### DIFF
--- a/packages/applications-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/applications-service-api/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.3
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/applications-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/applications-service-api/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.3
   pipelines:
     - pipeline: applications-service-api-ci
       source: applications-service-api CI
@@ -30,14 +30,25 @@ extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
-      - name: Deploy
+      - name: Stage
         deploymentSteps:
           - template: ../steps/azure_web_app_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)
+              appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+      - name: Deploy
+        dependsOn:
+          - Stage
+        deploymentSteps:
+          - template: ../steps/azure_web_app_slot_swap.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              appStagingSlotName: staging
+              appTargetSlotName: production
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/applications-service-api/pipelines/azure-pipelines-variables.yml@self 

--- a/packages/common/pipelines/azure-pipelines-build.yml
+++ b/packages/common/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.3
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/forms-web-app/pipelines/azure-pipelines-build.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-build.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.3
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.5.3
   pipelines:
     - pipeline: forms-web-app-ci
       source: forms-web-app CI
@@ -30,14 +30,25 @@ extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
-      - name: Deploy
+      - name: Stage
         deploymentSteps:
           - template: ../steps/azure_web_app_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)
+              appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+      - name: Deploy
+        dependsOn:
+          - Stage
+        deploymentSteps:
+          - template: ../steps/azure_web_app_slot_swap.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              appStagingSlotName: staging
+              appTargetSlotName: production
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/forms-web-app/pipelines/azure-pipelines-variables.yml@self


### PR DESCRIPTION
Updates pipelines to version 2.5.3.

The pipeline now works in 2 stages. First, it will deploy the changes to the Azure App Service Slot called "staging". Then it will swap the "production" and "staging" slots. Since there is an approval step in between, this gives the possibility to run some smoke tests against the staging slot.

The deployment is now done via a webhook from the pipeline (instead of previously from the container registry) so this fixes the issue where the webook was being sent over the internet instead of via the Virtual Network.