### PR TITLE
ci: fix build steps not running on main branch pipeline runs

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -14,7 +14,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.0.1
+      ref: refs/tags/release/3.0.3
 
 extends:
   template: stages/wrapper_ci.yml@templates
@@ -62,9 +62,13 @@ extends:
                 eq(variables['Build.Reason'], 'Manual'),
                 eq(${{ parameters.buildAPI }}, 'true')
               ),
-              or(
-                eq(dependencies.Run_Linting_And_Tests.outputs['check_files.api'], 'true'),
-                eq(dependencies.Run_Linting_And_Tests.outputs['check_files.common'], 'true')
+              and(
+                ne(variables['Build.Reason'], 'Manual'),
+                or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
+                  eq(dependencies.run_linting_and_tests.outputs['check_files.api'], 'true'),
+                  eq(dependencies.run_linting_and_tests.outputs['check_files.common'], 'true')
+                )
               )
             )
           )
@@ -85,9 +89,13 @@ extends:
                 eq(variables['Build.Reason'], 'Manual'),
                 eq(${{ parameters.buildWeb }}, 'true')
               ),
-              or(
-                eq(dependencies.Run_Linting_And_Tests.outputs['check_files.common'], 'true'),
-                eq(dependencies.Run_Linting_And_Tests.outputs['check_files.web'], 'true')
+              and(
+                ne(variables['Build.Reason'], 'Manual'),
+                or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
+                  eq(dependencies.run_linting_and_tests.outputs['check_files.common'], 'true'),
+                  eq(dependencies.run_linting_and_tests.outputs['check_files.web'], 'true')
+                )
               )
             )
           )

--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -24,7 +24,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.0.1
+      ref: refs/tags/release/3.0.3
   pipelines:
     - pipeline: build
       source: Applications Service Build

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -16,7 +16,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.0.1
+      ref: refs/tags/release/3.0.3
 
 extends:
   template: stages/wrapper_cd.yml@templates


### PR DESCRIPTION
When the pipeline runs after a merge to `main`, the build steps were being skipped. Since it's quite difficult in ADO to get variables from another pipeline, it's better to just run all steps when merging to `main` I think.