### PR TITLE
ci: fix install dependencies step in release pipeline

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -94,7 +94,7 @@ extends:
               - template: ../steps/node_script.yml
                 parameters:
                   nodeVersion: 14
-                  script: npm ci
+                  script: make install
               - template: ../steps/node_script.yml
                 parameters:
                   nodeVersion: 14


### PR DESCRIPTION
- `make install` instead of `npm ci`