### PR TITLE
Fix: Prevent email copy from rendering if email address is not present

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/projects/examination.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/projects/examination.test.js
@@ -45,7 +45,6 @@ describe('controllers/projects/examination', () => {
 				appData: { DateOfRelevantRepresentationClose: '2020-02-02' },
 				caseRef: undefined,
 				dateOfClosure: 'Sunday 02 February 2020',
-				hasContactSupport: undefined,
 				periodOpen: false,
 				projectAcceptsComments: false,
 				projectName: undefined,

--- a/packages/forms-web-app/src/controllers/projects/examination.js
+++ b/packages/forms-web-app/src/controllers/projects/examination.js
@@ -20,7 +20,6 @@ exports.getExamination = async (req, res) => {
 		const stagePosition = appData.Stage;
 		const stageTotal = Object.keys(Status).length;
 		const projectAcceptsComments = !periodOpen && appData.Stage < 5;
-		const hasContactSupport = appData.ProjectEmailAddress;
 
 		req.session.appData = appData;
 		req.session.caseRef = caseRef;
@@ -31,7 +30,6 @@ exports.getExamination = async (req, res) => {
 			appData,
 			caseRef,
 			dateOfClosure,
-			hasContactSupport,
 			projectAcceptsComments,
 			projectName,
 			periodOpen,

--- a/packages/forms-web-app/src/views/projects/index.njk
+++ b/packages/forms-web-app/src/views/projects/index.njk
@@ -64,18 +64,26 @@
 {% elif projectAcceptsComments %}
   {% set contentStage = contentStage + '
     <p>
-       We have now published all registration comments.
-        </p>
-        <p>
-        You can
-        <a href="/projects/' + caseRef + '/representations">
-          view comments from other people who registered</a>.
-        </p>
-        <p>
-          <a href="/having-your-say-guide/have-your-say-examination">Find out more about getting involved during the Examination of the application</a>
-      </p>
-    '%}
-  {% endif %}
+      The registration period to have your say about this project has closed.
+      You can still get involved and comment on the project during the Examination stage.
+      If you are not registered and you submit information during the Examination stage, this may not be included.
+    </p>
+    <p> ' +
+      textLink(
+        "#project-section-contact-support",
+        "Go to the Contact us for support section.",
+        "Contact the project case team"
+      ) + ' to find out more about how to get involved if you are not registered.
+    </p>
+    <p> ' +
+      textLink(
+        "/decision-making-process-guide/examination-of-the-application",
+        "Find out more about getting involved during the Examination of the application.",
+        "Find out more about getting involved during the Examination of the application"
+      ) + '
+    </p>
+  '%}
+{% endif %}
 
 {% set contentAboutProject = '
   <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
@@ -156,16 +164,23 @@
   </div>
 '%}
 
-{% set contentSupport = '
-  <p>
-    <strong>
-      Project case team email:
-    </strong>
-    <br>
-    <a href="mailto:' + appData.ProjectEmailAddress + '">
-      ' + appData.ProjectEmailAddress + '
-    </a>
-  </p>
+{% set contentSupport = '' %}
+
+{% if appData.ProjectEmailAddress %}
+  {% set contentSupport =  contentSupport + '
+    <p>
+      <strong>
+        Project case team email:
+      </strong>
+      <br>
+      <a href="mailto:' + appData.ProjectEmailAddress + '">
+        ' + appData.ProjectEmailAddress + '
+      </a>
+    </p>
+  '%}
+{% endif %}
+
+{% set contentSupport =  contentSupport + '
   <p>
     <strong>
       General enquiries telephone:


### PR DESCRIPTION
Fix to prevent 'Contact us for support' section rendering email paragraph when ProjectEmailAddress is returned as null.

Example of the issue can be seen at: https://applications-service-test.planninginspectorate.gov.uk/projects/EN010074

![Screenshot 2022-07-12 at 14 06 55](https://user-images.githubusercontent.com/102227020/178497445-fce188d2-988c-4613-8202-7d82be632fb5.png)
