### PR TITLE
fix(fix form max character length validation): fix form max character validation

### DIFF
--- a/packages/forms-web-app/src/public/javascripts/modules/sanitise-form.js
+++ b/packages/forms-web-app/src/public/javascripts/modules/sanitise-form.js
@@ -19,10 +19,12 @@ window.App.Modules = window.App.Modules || {};
 						formData.append(field.name, sanitiseString(field.value));
 					});
 
-					const response = await fetch(window.location.href, {
-						method: 'POST',
-						body: formData
-					});
+					const response = await (
+						await fetch(window.location.href, {
+							method: 'POST',
+							body: formData
+						})
+					).json();
 
 					if (!response.url) {
 						form.submit();

--- a/packages/forms-web-app/src/validators/register/tell-us-about-project.js
+++ b/packages/forms-web-app/src/validators/register/tell-us-about-project.js
@@ -3,11 +3,11 @@ const { body } = require('express-validator');
 const validate = () => {
 	return [
 		body('comment')
-			.notEmpty()
-			.withMessage('Enter what you want to tell us about this proposed project'),
-		body('comment')
 			.isLength({ min: 1, max: 65234 })
-			.withMessage('What you want to tell us must be 65234 characters or less')
+			.withMessage('What you want to tell us must be 65234 characters or less'),
+		body('comment')
+			.notEmpty()
+			.withMessage('Enter what you want to tell us about this proposed project')
 	];
 };
 

--- a/packages/forms-web-app/src/validators/register/tell-us-about-project.js
+++ b/packages/forms-web-app/src/validators/register/tell-us-about-project.js
@@ -3,7 +3,7 @@ const { body } = require('express-validator');
 const validate = () => {
 	return [
 		body('comment')
-			.isLength({ min: 1, max: 65234 })
+			.isLength({ max: 65234 })
 			.withMessage('What you want to tell us must be 65234 characters or less'),
 		body('comment')
 			.notEmpty()

--- a/packages/forms-web-app/src/views/projects/documents.njk
+++ b/packages/forms-web-app/src/views/projects/documents.njk
@@ -67,7 +67,7 @@
 
     {% if documents.length > 0 %}
         {% set pageLinkTemplate -%}
-          /projects/${case_ref}/application-documents?page=:page{{ queryUrl | safe }}
+          /projects/{{ caseRef }}/application-documents?page=:page{{ queryUrl | safe }}
         {%- endset %}
         {{ paginationBar(pageOptions, paginationData, pageLinkTemplate) }}
     {% endif %}

--- a/packages/forms-web-app/src/views/register/agent/tell-us-about-project.njk
+++ b/packages/forms-web-app/src/views/register/agent/tell-us-about-project.njk
@@ -85,11 +85,10 @@
             classes: "govuk-label--s",
             isPageHeading: true
           },
-          maxwords: 200,
           id: "comment",
           name: "comment",
           value: comment or errors['comment'].value,
-          attributes: {"data-cy": "comment"},
+          attributes: {"data-cy": "comment", maxLength: "65234"},
           errorMessage: errors['comment'] and {
               text: errors['comment'].msg
           }

--- a/packages/forms-web-app/src/views/register/myself/tell-us-about-project.njk
+++ b/packages/forms-web-app/src/views/register/myself/tell-us-about-project.njk
@@ -85,11 +85,10 @@
             classes: "govuk-label--s",
             isPageHeading: true
           },
-          maxwords: 200,
           id: "comment",
           name: "comment",
           value: comment or errors['comment'].value,
-          attributes: {"data-cy": "comment"},
+          attributes: {"data-cy": "comment", maxLength: "65234"},
           errorMessage: errors['comment'] and {
               text: errors['comment'].msg
           }

--- a/packages/forms-web-app/src/views/register/organisation/tell-us-about-project.njk
+++ b/packages/forms-web-app/src/views/register/organisation/tell-us-about-project.njk
@@ -80,7 +80,6 @@
         </p>
 
         {{ govukTextarea({
-          maxwords: 200,
           id: "comment",
           label: {
             text: "Registration comments",
@@ -89,7 +88,7 @@
           },
           name: "comment",
           value: comment or errors['comment'].value,
-          attributes: {"data-cy": "comment"},
+          attributes: {"data-cy": "comment", maxLength: "65234"},
           errorMessage: errors['comment'] and {
               text: errors['comment'].msg
           }


### PR DESCRIPTION
Fix form max character length validation 
Add maxLength attribute to html text area tag

Jira Ticket: https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-448

You can use a character count website like: https://wordcounter.net/

Local Project URL: http://localhost:9004/register/myself/check-answers

I would like to have someone pulling it and checking if it works for you as well.

Caveat: you won't see any errors if you input more than 65234 characters in the text area because its maxLength attribute is set to 65234.

To see the error and bypass it you need to inspect the element and manually increase it.