### PR TITLE
fix(documents.njk): fix for the document library paging bug

### DIFF
--- a/packages/forms-web-app/src/views/projects/documents.njk
+++ b/packages/forms-web-app/src/views/projects/documents.njk
@@ -67,7 +67,7 @@
 
     {% if documents.length > 0 %}
         {% set pageLinkTemplate -%}
-          /projects/${case_ref}/application-documents?page=:page{{ queryUrl | safe }}
+          /projects/{{ caseRef }}/application-documents?page=:page{{ queryUrl | safe }}
         {%- endset %}
         {{ paginationBar(pageOptions, paginationData, pageLinkTemplate) }}
     {% endif %}


### PR DESCRIPTION
This is a fix to a regression where the paging in the document library no longer works.  Select a page number in document library resulted in data unable to be fetched as the caseRef was not sent on the request to API.
