### PR TITLE
feat('other documents' to be part of 'everything else' filter): add Other Documents' to everything else filter

### DIFF
--- a/packages/applications-service-api/src/controllers/documents.js
+++ b/packages/applications-service-api/src/controllers/documents.js
@@ -69,6 +69,7 @@ module.exports = {
 					const everythingElseFilterValues = typeFiltersAvailable.slice(5).map(function (t) {
 						return t.filter_1;
 					});
+					everythingElseFilterValues.push('Other Documents');
 					typeFilters = typeFilters.filter((e) => e !== 'everything_else');
 					typeFilters.push(everythingElseFilterValues);
 				}

--- a/packages/forms-web-app/__tests__/unit/utils/replace-controller-param-type.test.js
+++ b/packages/forms-web-app/__tests__/unit/utils/replace-controller-param-type.test.js
@@ -1,0 +1,79 @@
+const { replaceControllerParamType } = require('../../../src/utils/replace-controller-param-type');
+
+describe('All test cases', () => {
+	const inputValues = {
+		unexpected: {
+			input1: undefined,
+			input2: null,
+			input3: '',
+			input4: false,
+			input5: {},
+			input6: [],
+			input7: 0
+		},
+		expected: {
+			input1: 'Other Documents',
+			input2: ['Other Documents'],
+			input3: ['Other Documents', 'everything_else']
+		}
+	};
+
+	const expectedValues = {
+		expectedInputsReturn: {
+			output1: 'everything_else',
+			output2: ['everything_else']
+		}
+	};
+
+	const { input1: expectedInput1 } = inputValues.expected;
+	const { output1: expectedInputsReturnInput1 } = expectedValues.expectedInputsReturn;
+
+	Object.entries(inputValues.unexpected).forEach(([inputName, inputValue]) => {
+		it(`Check function return with unexpected ${inputName} in expectedParam field`, () => {
+			const result = replaceControllerParamType(
+				expectedInput1,
+				inputValue,
+				expectedInputsReturnInput1
+			);
+			expect(result).toBe(undefined);
+		});
+	});
+
+	Object.entries(inputValues.unexpected).forEach(([inputName, inputValue]) => {
+		it(`Check function return with unexpected ${inputName} in paramsType field`, () => {
+			const result = replaceControllerParamType(
+				inputValue,
+				expectedInput1,
+				expectedInputsReturnInput1
+			);
+			expect(result).toBe(undefined);
+		});
+	});
+
+	Object.entries(inputValues.unexpected).forEach(([inputName, inputValue]) => {
+		it(`Check function return with unexpected ${inputName} in both paramsType and expectedParam fields`, () => {
+			const result = replaceControllerParamType(inputValue, inputValue, expectedInputsReturnInput1);
+			expect(result).toBe(undefined);
+		});
+	});
+
+	// Correct Input/Output Values
+	Object.entries(inputValues.expected).forEach(([inputName], index) => {
+		const expectedInput = inputValues.expected[inputName];
+		const expectedResult = expectedValues.expectedInputsReturn['output2'];
+		it(`Check function return with expected ${inputName} in both paramsType and expectedParam fields`, () => {
+			const result = replaceControllerParamType(
+				expectedInput, // paramsType
+				expectedInput1, // expectedParam
+				expectedInputsReturnInput1 // newParamType
+			);
+
+			if (index === 0) {
+				expect(result).toBe(expectedInputsReturnInput1);
+				return;
+			}
+
+			expect(result).toStrictEqual(expectedResult);
+		});
+	});
+});

--- a/packages/forms-web-app/src/controllers/projects/documents.js
+++ b/packages/forms-web-app/src/controllers/projects/documents.js
@@ -6,6 +6,7 @@ const { VIEW } = require('../../lib/views');
 const { getAppData } = require('../../services/application.service');
 const { searchDocumentsV2 } = require('../../services/document.service');
 const { featureHideLink } = require('../../config');
+const { replaceControllerParamType } = require('../../utils/replace-controller-param-type');
 
 const {
 	hideProjectInformationLink,
@@ -124,20 +125,14 @@ exports.getApplicationDocuments = async (req, res) => {
 			...req.query
 		};
 
-		if (typeof params?.type === 'string' && params?.type === 'Other Documents') {
-			params.type = 'everything_else';
-		}
+		const newParamsType = replaceControllerParamType(
+			params?.type,
+			'Other Documents',
+			'everything_else'
+		);
 
-		if (Array.isArray(params?.type) && params?.type.includes('Other Documents')) {
-			const removeOtherDocuments = params?.type.filter((t) => t !== 'Other Documents');
-
-			if (params.type.includes('everything_else')) {
-				params.type = removeOtherDocuments;
-			}
-
-			removeOtherDocuments.push('everything_else');
-
-			params.type = removeOtherDocuments;
+		if (newParamsType) {
+			params.type = newParamsType;
 		}
 
 		const { searchTerm, stage, type } = req.query;

--- a/packages/forms-web-app/src/utils/replace-controller-param-type.js
+++ b/packages/forms-web-app/src/utils/replace-controller-param-type.js
@@ -1,0 +1,21 @@
+const replaceControllerParamType = (paramsType, expectedParam, newParamType) => {
+	if (!paramsType || !expectedParam || !newParamType) return;
+
+	if (typeof paramsType === 'string' && paramsType === expectedParam) {
+		return newParamType;
+	}
+
+	if (Array.isArray(paramsType) && paramsType.includes(expectedParam)) {
+		const removedParamTypeList = paramsType.filter((t) => t !== expectedParam);
+
+		if (paramsType.includes(newParamType)) {
+			return removedParamTypeList;
+		}
+
+		removedParamTypeList.push(newParamType);
+
+		return removedParamTypeList;
+	}
+};
+
+module.exports = { replaceControllerParamType };


### PR DESCRIPTION
add Other Documents' to everything else filter

'Other Documents' to be part of 'Everything else' filter

BREAKING CHANGE: Now other documents filter is part of the everything else filter which changes how
the filters behaviour