### PR TITLE
fix(declaration.js): ASB-620 handle internal exception when posting declaration

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/register/agent/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/agent/declaration.test.js
@@ -1,7 +1,7 @@
 const declarationController = require('../../../../../src/controllers/register/agent/declaration');
 const { postRegistration, putComments } = require('../../../../../src/lib/application-api-wrapper');
 const { VIEW } = require('../../../../../src/lib/views');
-const { mockReq, mockRes } = require('../../../mocks');
+const { mockReq, mockRes, mockResponse } = require('../../../mocks');
 
 jest.mock('../../../../../src/lib/application-api-wrapper');
 jest.mock('../../../../../src/lib/logger');
@@ -9,11 +9,26 @@ jest.mock('../../../../../src/lib/logger');
 describe('controllers/register/agent/declaration', () => {
 	let req;
 	let res;
+	let mockRequest;
 
 	beforeEach(() => {
 		req = mockReq();
 		res = mockRes();
 		jest.resetAllMocks();
+
+		mockRequest = {
+			...req,
+			session: {
+				behalfRegdata: {
+					email: 'anc@test.com',
+					ipRefNo: 'ABC123'
+				},
+				projectName: 'ABC',
+				caseRef: 'ABC123',
+				mode: 'final',
+				comment: 'comment'
+			}
+		};
 
 		postRegistration.mockImplementation(() =>
 			Promise.resolve({ resp_code: 200, data: '30020010' })
@@ -31,37 +46,21 @@ describe('controllers/register/agent/declaration', () => {
 
 	describe('postDeclaration', () => {
 		it(`'should post data and redirect to '/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}'`, async () => {
-			const mockRequest = {
-				...req,
-				session: {
-					behalfRegdata: {
-						email: 'anc@test.com',
-						ipRefNo: 'ABC123'
-					},
-					projectName: 'ABC',
-					caseRef: 'ABC123'
-				}
-			};
 			await declarationController.postDeclaration(mockRequest, res);
-
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}`);
 		});
 		it(`'should create session data and post, redirect to '/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}' if no ipRef exists in session`, async () => {
-			const mockRequest = {
-				...req,
-				session: {
-					behalfRegdata: {
-						email: 'anc@test.com'
-					},
-					projectName: 'ABC',
-					caseRef: 'ABC123',
-					mode: 'final',
-					comment: 'comment'
-				}
-			};
 			await declarationController.postDeclaration(mockRequest, res);
-
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}`);
+		});
+
+		it('handle exception thrown by API when writing representations', async () => {
+			res = mockResponse();
+			putComments.mockImplementation(() => {
+				throw new Error();
+			});
+			await declarationController.postDeclaration(mockRequest, res);
+			expect(res.render).toHaveBeenCalledWith('error/unhandled-exception');
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/register/agent/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/agent/declaration.test.js
@@ -9,26 +9,11 @@ jest.mock('../../../../../src/lib/logger');
 describe('controllers/register/agent/declaration', () => {
 	let req;
 	let res;
-	let mockRequest;
 
 	beforeEach(() => {
 		req = mockReq();
 		res = mockRes();
 		jest.resetAllMocks();
-
-		mockRequest = {
-			...req,
-			session: {
-				behalfRegdata: {
-					email: 'anc@test.com',
-					ipRefNo: 'ABC123'
-				},
-				projectName: 'ABC',
-				caseRef: 'ABC123',
-				mode: 'final',
-				comment: 'comment'
-			}
-		};
 
 		postRegistration.mockImplementation(() =>
 			Promise.resolve({ resp_code: 200, data: '30020010' })
@@ -46,16 +31,51 @@ describe('controllers/register/agent/declaration', () => {
 
 	describe('postDeclaration', () => {
 		it(`'should post data and redirect to '/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}'`, async () => {
+			const mockRequest = {
+				...req,
+				session: {
+					behalfRegdata: {
+						email: 'anc@test.com',
+						ipRefNo: 'ABC123'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123'
+				}
+			};
 			await declarationController.postDeclaration(mockRequest, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}`);
 		});
 		it(`'should create session data and post, redirect to '/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}' if no ipRef exists in session`, async () => {
+			const mockRequest = {
+				...req,
+				session: {
+					behalfRegdata: {
+						email: 'anc@test.com'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123',
+					mode: 'final',
+					comment: 'comment'
+				}
+			};
 			await declarationController.postDeclaration(mockRequest, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.AGENT.REGISTRATION_COMPLETE}`);
 		});
 
 		it('handle exception thrown by API when writing representations', async () => {
 			res = mockResponse();
+			const mockRequest = {
+				...req,
+				session: {
+					behalfRegdata: {
+						email: 'anc@test.com'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123',
+					mode: 'final',
+					comment: 'comment'
+				}
+			};
 			putComments.mockImplementation(() => {
 				throw new Error();
 			});

--- a/packages/forms-web-app/__tests__/unit/controllers/register/myself/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/myself/declaration.test.js
@@ -9,25 +9,11 @@ jest.mock('../../../../../src/lib/logger');
 describe('controllers/register/myself/declaration', () => {
 	let req;
 	let res;
-	let mockRequest;
 
 	beforeEach(() => {
 		req = mockReq();
 		res = mockRes();
 		jest.resetAllMocks();
-
-		mockRequest = {
-			...req,
-			session: {
-				mySelfRegdata: {
-					email: 'anc@test.com'
-				},
-				projectName: 'ABC',
-				caseRef: 'ABC123',
-				mode: 'final',
-				comment: 'comment'
-			}
-		};
 
 		postRegistration.mockImplementation(() =>
 			Promise.resolve({ resp_code: 200, data: '30020010' })
@@ -45,17 +31,52 @@ describe('controllers/register/myself/declaration', () => {
 
 	describe('postDeclaration', () => {
 		it(`'should post data and redirect to '/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}'`, async () => {
+			const mockRequest = {
+				...req,
+				session: {
+					mySelfRegdata: {
+						email: 'anc@test.com',
+						ipRefNo: 'ABC123'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123'
+				}
+			};
 			await declarationController.postDeclaration(mockRequest, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}`);
 		});
 
 		it(`'should create session data and post, redirect to '/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}' if no ipRef exists in session`, async () => {
+			const mockRequest = {
+				...req,
+				session: {
+					mySelfRegdata: {
+						email: 'anc@test.com'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123',
+					mode: 'final',
+					comment: 'comment'
+				}
+			};
 			await declarationController.postDeclaration(mockRequest, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}`);
 		});
 
 		it('handle exception thrown by API when writing representations', async () => {
 			res = mockResponse();
+			const mockRequest = {
+				...req,
+				session: {
+					mySelfRegdata: {
+						email: 'anc@test.com'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123',
+					mode: 'final',
+					comment: 'comment'
+				}
+			};
 			putComments.mockImplementation(() => {
 				throw new Error();
 			});

--- a/packages/forms-web-app/__tests__/unit/controllers/register/myself/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/myself/declaration.test.js
@@ -1,7 +1,7 @@
 const declarationController = require('../../../../../src/controllers/register/myself/declaration');
 const { postRegistration, putComments } = require('../../../../../src/lib/application-api-wrapper');
 const { VIEW } = require('../../../../../src/lib/views');
-const { mockReq, mockRes } = require('../../../mocks');
+const { mockReq, mockRes, mockResponse } = require('../../../mocks');
 
 jest.mock('../../../../../src/lib/application-api-wrapper');
 jest.mock('../../../../../src/lib/logger');
@@ -9,11 +9,25 @@ jest.mock('../../../../../src/lib/logger');
 describe('controllers/register/myself/declaration', () => {
 	let req;
 	let res;
+	let mockRequest;
 
 	beforeEach(() => {
 		req = mockReq();
 		res = mockRes();
 		jest.resetAllMocks();
+
+		mockRequest = {
+			...req,
+			session: {
+				mySelfRegdata: {
+					email: 'anc@test.com'
+				},
+				projectName: 'ABC',
+				caseRef: 'ABC123',
+				mode: 'final',
+				comment: 'comment'
+			}
+		};
 
 		postRegistration.mockImplementation(() =>
 			Promise.resolve({ resp_code: 200, data: '30020010' })
@@ -31,38 +45,22 @@ describe('controllers/register/myself/declaration', () => {
 
 	describe('postDeclaration', () => {
 		it(`'should post data and redirect to '/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}'`, async () => {
-			const mockRequest = {
-				...req,
-				session: {
-					mySelfRegdata: {
-						email: 'anc@test.com',
-						ipRefNo: 'ABC123'
-					},
-					projectName: 'ABC',
-					caseRef: 'ABC123'
-				}
-			};
 			await declarationController.postDeclaration(mockRequest, res);
-
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}`);
 		});
 
 		it(`'should create session data and post, redirect to '/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}' if no ipRef exists in session`, async () => {
-			const mockRequest = {
-				...req,
-				session: {
-					mySelfRegdata: {
-						email: 'anc@test.com'
-					},
-					projectName: 'ABC',
-					caseRef: 'ABC123',
-					mode: 'final',
-					comment: 'comment'
-				}
-			};
 			await declarationController.postDeclaration(mockRequest, res);
-
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}`);
+		});
+
+		it('handle exception thrown by API when writing representations', async () => {
+			res = mockResponse();
+			putComments.mockImplementation(() => {
+				throw new Error();
+			});
+			await declarationController.postDeclaration(mockRequest, res);
+			expect(res.render).toHaveBeenCalledWith('error/unhandled-exception');
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/register/organisation/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/organisation/declaration.test.js
@@ -1,7 +1,7 @@
 const declarationController = require('../../../../../src/controllers/register/organisation/declaration');
 const { postRegistration, putComments } = require('../../../../../src/lib/application-api-wrapper');
 const { VIEW } = require('../../../../../src/lib/views');
-const { mockReq, mockRes } = require('../../../mocks');
+const { mockReq, mockRes, mockResponse } = require('../../../mocks');
 
 jest.mock('../../../../../src/lib/application-api-wrapper');
 jest.mock('../../../../../src/lib/logger');
@@ -9,11 +9,25 @@ jest.mock('../../../../../src/lib/logger');
 describe('controllers/register/organisation/declaration', () => {
 	let req;
 	let res;
+	let mockRequest;
 
 	beforeEach(() => {
 		req = mockReq();
 		res = mockRes();
 		jest.resetAllMocks();
+
+		mockRequest = {
+			...req,
+			session: {
+				orgRegdata: {
+					email: 'anc@test.com'
+				},
+				projectName: 'ABC',
+				caseRef: 'ABC123',
+				mode: 'final',
+				comment: 'comment'
+			}
+		};
 
 		postRegistration.mockImplementation(() =>
 			Promise.resolve({ resp_code: 200, data: '30020010' })
@@ -31,38 +45,22 @@ describe('controllers/register/organisation/declaration', () => {
 
 	describe('postDeclaration', () => {
 		it(`'should post data and redirect to '/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}'`, async () => {
-			const mockRequest = {
-				...req,
-				session: {
-					orgRegdata: {
-						email: 'anc@test.com',
-						ipRefNo: 'ABC123'
-					},
-					projectName: 'ABC',
-					caseRef: 'ABC123'
-				}
-			};
 			await declarationController.postDeclaration(mockRequest, res);
-
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}`);
 		});
 
 		it(`'should create session data and post, redirect to '/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}' if no ipRef exists in session`, async () => {
-			const mockRequest = {
-				...req,
-				session: {
-					orgRegdata: {
-						email: 'anc@test.com'
-					},
-					projectName: 'ABC',
-					caseRef: 'ABC123',
-					mode: 'final',
-					comment: 'comment'
-				}
-			};
 			await declarationController.postDeclaration(mockRequest, res);
-
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}`);
+		});
+
+		it('handle exception thrown by API when writing representations', async () => {
+			res = mockResponse();
+			putComments.mockImplementation(() => {
+				throw new Error();
+			});
+			await declarationController.postDeclaration(mockRequest, res);
+			expect(res.render).toHaveBeenCalledWith('error/unhandled-exception');
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/register/organisation/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/organisation/declaration.test.js
@@ -9,25 +9,11 @@ jest.mock('../../../../../src/lib/logger');
 describe('controllers/register/organisation/declaration', () => {
 	let req;
 	let res;
-	let mockRequest;
 
 	beforeEach(() => {
 		req = mockReq();
 		res = mockRes();
 		jest.resetAllMocks();
-
-		mockRequest = {
-			...req,
-			session: {
-				orgRegdata: {
-					email: 'anc@test.com'
-				},
-				projectName: 'ABC',
-				caseRef: 'ABC123',
-				mode: 'final',
-				comment: 'comment'
-			}
-		};
 
 		postRegistration.mockImplementation(() =>
 			Promise.resolve({ resp_code: 200, data: '30020010' })
@@ -45,17 +31,52 @@ describe('controllers/register/organisation/declaration', () => {
 
 	describe('postDeclaration', () => {
 		it(`'should post data and redirect to '/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}'`, async () => {
+			const mockRequest = {
+				...req,
+				session: {
+					orgRegdata: {
+						email: 'anc@test.com',
+						ipRefNo: 'ABC123'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123'
+				}
+			};
 			await declarationController.postDeclaration(mockRequest, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}`);
 		});
 
 		it(`'should create session data and post, redirect to '/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}' if no ipRef exists in session`, async () => {
+			const mockRequest = {
+				...req,
+				session: {
+					orgRegdata: {
+						email: 'anc@test.com'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123',
+					mode: 'final',
+					comment: 'comment'
+				}
+			};
 			await declarationController.postDeclaration(mockRequest, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}`);
 		});
 
 		it('handle exception thrown by API when writing representations', async () => {
 			res = mockResponse();
+			const mockRequest = {
+				...req,
+				session: {
+					orgRegdata: {
+						email: 'anc@test.com'
+					},
+					projectName: 'ABC',
+					caseRef: 'ABC123',
+					mode: 'final',
+					comment: 'comment'
+				}
+			};
 			putComments.mockImplementation(() => {
 				throw new Error();
 			});

--- a/packages/forms-web-app/src/controllers/register/myself/declaration.js
+++ b/packages/forms-web-app/src/controllers/register/myself/declaration.js
@@ -10,19 +10,23 @@ exports.getDeclaration = async (req, res) => {
 
 exports.postDeclaration = async (req, res) => {
 	let { ipRefNo } = req.session.mySelfRegdata;
+	try {
+		if (!ipRefNo) {
+			req.session.mySelfRegdata.case_ref = req.session.caseRef;
+			req.session.mySelfRegdata.mode = req.session.mode;
+			const registrationData = JSON.stringify(req.session.mySelfRegdata);
+			const response = await postRegistrationData(registrationData);
+			ipRefNo = response.data;
+			req.session.mySelfRegdata.ipRefNo = ipRefNo;
+		}
 
-	if (!ipRefNo) {
-		req.session.mySelfRegdata.case_ref = req.session.caseRef;
-		req.session.mySelfRegdata.mode = req.session.mode;
-		const registrationData = JSON.stringify(req.session.mySelfRegdata);
-		const response = await postRegistrationData(registrationData);
-		ipRefNo = response.data;
-		req.session.mySelfRegdata.ipRefNo = ipRefNo;
-	}
-
-	const commentsData = JSON.stringify({ comments: req.session.comment, mode: req.session.mode });
-	if (commentsData && Object.keys(JSON.parse(commentsData)).length) {
-		await postCommentsData(ipRefNo, commentsData);
+		const commentsData = JSON.stringify({ comments: req.session.comment, mode: req.session.mode });
+		if (commentsData && Object.keys(JSON.parse(commentsData)).length) {
+			await postCommentsData(ipRefNo, commentsData);
+		}
+	} catch (e) {
+		req.log.error(e, 'Could not Post declaration, internal error occurred');
+		return res.status(500).render('error/unhandled-exception');
 	}
 
 	res.redirect(`/${VIEW.REGISTER.MYSELF.REGISTRATION_COMPLETE}`);

--- a/packages/forms-web-app/src/controllers/register/organisation/declaration.js
+++ b/packages/forms-web-app/src/controllers/register/organisation/declaration.js
@@ -11,18 +11,23 @@ exports.getDeclaration = async (req, res) => {
 exports.postDeclaration = async (req, res) => {
 	let { ipRefNo } = req.session.orgRegdata;
 
-	if (!ipRefNo) {
-		req.session.orgRegdata.case_ref = req.session.caseRef;
-		req.session.orgRegdata.mode = req.session.mode;
-		const registrationData = JSON.stringify(req.session.orgRegdata);
-		const response = await postRegistrationData(registrationData);
-		ipRefNo = response.data;
-		req.session.orgRegdata.ipRefNo = ipRefNo;
-	}
+	try {
+		if (!ipRefNo) {
+			req.session.orgRegdata.case_ref = req.session.caseRef;
+			req.session.orgRegdata.mode = req.session.mode;
+			const registrationData = JSON.stringify(req.session.orgRegdata);
+			const response = await postRegistrationData(registrationData);
+			ipRefNo = response.data;
+			req.session.orgRegdata.ipRefNo = ipRefNo;
+		}
 
-	const commentsData = JSON.stringify({ comments: req.session.comment, mode: req.session.mode });
-	if (commentsData && Object.keys(JSON.parse(commentsData)).length) {
-		await postCommentsData(ipRefNo, commentsData);
+		const commentsData = JSON.stringify({ comments: req.session.comment, mode: req.session.mode });
+		if (commentsData && Object.keys(JSON.parse(commentsData)).length) {
+			await postCommentsData(ipRefNo, commentsData);
+		}
+	} catch (e) {
+		req.log.error(e, 'Could not Post declaration, internal error occurred');
+		return res.status(500).render('error/unhandled-exception');
 	}
 
 	res.redirect(`/${VIEW.REGISTER.ORGANISATION.CONFIRMATION}`);


### PR DESCRIPTION
Add exception handling to relevant reps - POST to avoid uncaught exception forcing a web server re-start.

This is a generic catch all for now which will result in the same outcome on a 500 error from API - Page-not found.  The change here handles the exception which will avoid an uncaught exception and resulting web-app restart.

We may need to revisit this in future as error handling in this area requires some work.