### PR TITLE
fix(docker): permissions relating to uploads directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,4 +117,4 @@ junit.xml
 .DS_Store
 
 packages/forms-web-app/src/public/stylesheets/main.css
-packages/applications-service-api/uploads
+uploads/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   applications-service-api:
     image: node:16-alpine
+    user: node
     container_name: applications-service-api
     environment:
       APP_APPLICATIONS_BASE_URL: http://forms-web-app:9004
@@ -23,6 +24,7 @@ services:
       DOCUMENTS_PER_PAGE: 20
       DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       ENCRYPTION_SECRET_KEY: x!A%C*F-JaNdRgUkXp2s5v8y/B?E(G+K
+      FILE_UPLOADS_PATH: /opt/app/uploads
       HAVING_YOUR_SAY_URL: https://applications-service-web-app.azurewebsites.net/
       LOGGER_LEVEL: debug
       MAGIC_LINK_DOMAIN: http://localhost:9004/
@@ -48,10 +50,12 @@ services:
       - ./package.json:/opt/app/package.json
       - ./node_modules:/opt/app/node_modules
       - ./packages/applications-service-api:/opt/app/packages/applications-service-api
+      - ./uploads:/opt/app/uploads
     command: npm run start:dev --workspace=packages/applications-service-api
 
   applications-web-app:
     image: node:16-alpine
+    user: node
     container_name: applications-web-app
     environment:
       APPLICATIONS_SERVICE_API_URL: http://applications-service-api:3000

--- a/packages/applications-service-api/Dockerfile
+++ b/packages/applications-service-api/Dockerfile
@@ -17,6 +17,9 @@ COPY packages/applications-service-api/src ./packages/applications-service-api/s
 COPY packages/applications-service-api/package.json ./packages/applications-service-api/package.json
 COPY packages/applications-service-api/.sequelizerc ./packages/applications-service-api/.sequelizerc
 
+RUN mkdir uploads && \
+    chown node:node uploads
+
 RUN npm ci
 
 # Stage 2/2: Run app

--- a/packages/applications-service-api/src/lib/config.js
+++ b/packages/applications-service-api/src/lib/config.js
@@ -20,7 +20,7 @@ module.exports = {
 		redact: ['config.services.notify.apiKey']
 	},
 	uploads: {
-		path: path.join(__dirname, '..', '..', 'uploads')
+		path: process.env.FILE_UPLOADS_PATH || path.join(__dirname, '..', '..', '..', '..', 'uploads')
 	},
 	server: {
 		port: Number(process.env.SERVER_PORT || 3000),


### PR DESCRIPTION
- Moves `uploads` directory to project root
- Amend Dockerfile to ensure `node` owners owns the `uploads` directory
- Provide a volume mount between local filesystem and Docker container for when running locally via Docker Compose