### PR TITLE
chore(api): update fetch timetable query to order by dateOfEvent ASC

### DIFF
--- a/packages/applications-service-api/__tests__/unit/services/timetable.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/timetable.service.test.js
@@ -18,7 +18,7 @@ describe('timetable service', () => {
 				case_reference: 'SOMECASE'
 			},
 			limit: 100,
-			order: [['date_of_event', 'DESC']]
+			order: [['date_of_event', 'ASC']]
 		});
 	});
 });

--- a/packages/applications-service-api/src/services/timetable.service.js
+++ b/packages/applications-service-api/src/services/timetable.service.js
@@ -7,7 +7,7 @@ const getTimetables = async (caseRef) => {
 			case_reference: caseRef
 		},
 		limit: config.timetableItemsPerPage,
-		order: [['date_of_event', 'DESC']]
+		order: [['date_of_event', 'ASC']]
 	});
 };
 


### PR DESCRIPTION
Change default sort order for `/timetables/{caseRef}` to `dateOfEvent` `ASC`