### PR TITLE
fix(start.js): remove code to delete myself session data

### DIFF
--- a/packages/forms-web-app/src/controllers/register/start.js
+++ b/packages/forms-web-app/src/controllers/register/start.js
@@ -6,7 +6,6 @@ const logger = require('../../lib/logger');
 
 exports.getStart = async (req, res) => {
 	delete req.session.comment;
-	delete req.session.mySelfRegdata;
 	delete req.session.typeOfParty;
 
 	const response = await getAppData(req.params.case_ref);


### PR DESCRIPTION
Do not delete the myself session data at the start of the relevant reps submission journey.  This data will be initialised in the type-of-party.js controller.  By not deleting it we will reduce the number of null data issues.

In production we are seeing the same session Id completing multiple journeys which is causing the initial journey with deleted myself session data to throw errors.
 