### PR TITLE
fix(personal information): clear personal information on NO selection

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/examination/personal-information/controller.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/personal-information/controller.test.js
@@ -14,7 +14,16 @@ let {
 let {
 	addKeyValueToActiveSubmissionItem
 } = require('../../../../../src/controllers/examination/session/submission-items-session');
+const {
+	clearAllPersonalInformationFlags
+} = require('../../../../../src/controllers/examination/personal-information-which/utils/savePersonalInformationFlags');
 
+jest.mock(
+	'../../../../../src/controllers/examination/personal-information-which/utils/savePersonalInformationFlags',
+	() => ({
+		clearAllPersonalInformationFlags: jest.fn()
+	})
+);
 jest.mock(
 	'../../../../../src/controllers/examination/personal-information/utils/page-data',
 	() => ({
@@ -101,6 +110,7 @@ describe('controllers/examination/personal-information/controller', () => {
 					};
 					getPageData.mockReturnValue(mockPageDataValue);
 					getRedirectUrl.mockReturnValue(mockRedirectUrl);
+					clearAllPersonalInformationFlags.mockReturnValue();
 					postPersonalInformation(req, res);
 				});
 				it('should call the functions', () => {
@@ -115,6 +125,25 @@ describe('controllers/examination/personal-information/controller', () => {
 						mockPageDataValue.id,
 						mockPageDataIdValue
 					);
+				});
+				it('should redirect to the next page', () => {
+					expect(res.redirect).toHaveBeenCalledWith(mockRedirectUrl);
+				});
+			});
+			describe('and the response is NO', () => {
+				const mockPageDataIdValue = 'no';
+				const mockRedirectUrl = 'redirect url';
+				beforeEach(() => {
+					req.body = {
+						[mockPageDataValue.id]: mockPageDataIdValue
+					};
+					getPageData.mockReturnValue(mockPageDataValue);
+					getRedirectUrl.mockReturnValue(mockRedirectUrl);
+					clearAllPersonalInformationFlags.mockReturnValue();
+					postPersonalInformation(req, res);
+				});
+				it('should clear all the personal information stored', () => {
+					expect(clearAllPersonalInformationFlags).toHaveBeenCalledWith(mockSession);
 				});
 				it('should redirect to the next page', () => {
 					expect(res.redirect).toHaveBeenCalledWith(mockRedirectUrl);

--- a/packages/forms-web-app/src/controllers/examination/personal-information/controller.js
+++ b/packages/forms-web-app/src/controllers/examination/personal-information/controller.js
@@ -11,6 +11,9 @@ const {
 } = require('../../../routes/config');
 
 const { getRedirectUrl } = require('./utils/get-redirect-url');
+const {
+	clearAllPersonalInformationFlags
+} = require('../personal-information-which/utils/savePersonalInformationFlags');
 
 const getPersonalInformation = (req, res) => {
 	try {
@@ -39,6 +42,8 @@ const postPersonalInformation = (req, res) => {
 		const personalInformationValue = body[setPageData.id];
 
 		addKeyValueToActiveSubmissionItem(session, 'personalInformation', personalInformationValue);
+
+		if (personalInformationValue === 'no') clearAllPersonalInformationFlags(session);
 
 		const redirectUrl = getRedirectUrl(session, setPageData.id, personalInformationValue);
 		return res.redirect(redirectUrl);


### PR DESCRIPTION
Fixes a bug when marking a file/comment as containing personal information. 