### PR TITLE
fix(add another deadline item): bug with empty submission item would not be able to find

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/examination/session/deadlineItems-session.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/session/deadlineItems-session.test.js
@@ -117,6 +117,43 @@ describe('controllers/examination/session/deadlineItems-session', () => {
 					expect(result).toEqual([]);
 				});
 			});
+			describe('and submission items is empty', () => {
+				const mockSession = 'mock session';
+				const deadlineItems = [
+					{ text: 'should be removed' },
+					{ text: 'should be removed as well' }
+				];
+				const mockExaminationSession = {
+					deadlineItems,
+					submissionItems: []
+				};
+				let result;
+				beforeEach(() => {
+					getExaminationSession.mockReturnValue(mockExaminationSession);
+					result = getDeadlineItemStillToSubmit(mockSession);
+				});
+				it('should return the deadline items', () => {
+					expect(result).toEqual(deadlineItems);
+				});
+			});
+			describe('and there are No submission items', () => {
+				const mockSession = 'mock session';
+				const deadlineItems = [
+					{ text: 'should be removed' },
+					{ text: 'should be removed as well' }
+				];
+				const mockExaminationSession = {
+					deadlineItems
+				};
+				let result;
+				beforeEach(() => {
+					getExaminationSession.mockReturnValue(mockExaminationSession);
+					result = getDeadlineItemStillToSubmit(mockSession);
+				});
+				it('should return the deadline items', () => {
+					expect(result).toEqual(deadlineItems);
+				});
+			});
 		});
 	});
 });

--- a/packages/forms-web-app/src/controllers/examination/session/deadlineItems-session.js
+++ b/packages/forms-web-app/src/controllers/examination/session/deadlineItems-session.js
@@ -20,12 +20,12 @@ const getDeadlineItems = (session) => {
 const getDeadlineItemStillToSubmit = (session) => {
 	const examinationSession = getExaminationSession(session);
 	const deadlineItemsStillToSubmit = [];
-	examinationSession.deadlineItems.forEach((item) => {
-		if (
-			!examinationSession.submissionItems.find((subItem) => subItem.submissionItem === item.text)
-		) {
+	const localDeadlineItems = [...examinationSession.deadlineItems];
+	const localSubmissionItems = examinationSession.submissionItems || [];
+
+	localDeadlineItems.forEach((item) => {
+		if (!localSubmissionItems.find((subItem) => subItem.submissionItem === item.text))
 			deadlineItemsStillToSubmit.push(item);
-		}
 	});
 	return deadlineItemsStillToSubmit;
 };


### PR DESCRIPTION
Replicate - have an empty session, go to through the emanation journey to the select a deadline item page and the page should render. 

The issues was no setting a default array if the submission items did not exists. 