### PR TITLE
refactor(forms-web-app): tidying up async routes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
 	},
 	extends: ['eslint:recommended', 'prettier'],
 	ignorePatterns: ['node_modules/**', 'dist/**', 'webpack.**', '*.script.js'],
+	rules: {
+		'require-await': 'error'
+	},
 	parserOptions: {
 		ecmaVersion: 2020,
 		sourceType: 'module'

--- a/packages/applications-service-api/__tests__/unit/lib/crypto.test.js
+++ b/packages/applications-service-api/__tests__/unit/lib/crypto.test.js
@@ -1,14 +1,14 @@
 const { encrypt, decrypt } = require('../../../src/lib/crypto');
 
 describe('encrypt', () => {
-	it('should encrypt a value', async () => {
+	it('should encrypt a value', () => {
 		const encrypted = encrypt('30000120');
 		expect(encrypted).toHaveLength(48);
 	});
 });
 
 describe('decrypt', () => {
-	it('should decrypt a value', async () => {
+	it('should decrypt a value', () => {
 		const decrypted = decrypt('3e2895fd6c43c5b24626168d6366c07da167af7dd0b337a3');
 		expect(decrypted).toEqual('30000120');
 	});

--- a/packages/applications-service-api/__tests__/unit/middleware/validator/submission.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/validator/submission.test.js
@@ -16,7 +16,7 @@ describe('submission request validator', () => {
 			query: {}
 		};
 
-		it('returns error if request does not contain required properties', async () => {
+		it('returns error if request does not contain required properties', () => {
 			expect(() => validateRequest(request)).toThrowError(
 				expect.objectContaining({
 					code: 400,
@@ -33,7 +33,7 @@ describe('submission request validator', () => {
 			);
 		});
 
-		it('returns error if request does not representation or file', async () => {
+		it('returns error if request does not representation or file', () => {
 			expect(() =>
 				validateRequest({
 					...request,
@@ -55,7 +55,7 @@ describe('submission request validator', () => {
 			);
 		});
 
-		it('returns error if request has both representation and file', async () => {
+		it('returns error if request has both representation and file', () => {
 			expect(() =>
 				validateRequest({
 					...request,
@@ -79,7 +79,7 @@ describe('submission request validator', () => {
 			);
 		});
 
-		it('returns error if request contains file of unsupported type', async () => {
+		it('returns error if request contains file of unsupported type', () => {
 			expect(() =>
 				validateRequest({
 					...request,
@@ -105,7 +105,7 @@ describe('submission request validator', () => {
 			);
 		});
 
-		it('returns error if request contains representation larger than max limit', async () => {
+		it('returns error if request contains representation larger than max limit', () => {
 			const generateLongRepresentation = () => [...Array(65235)].map(() => 'a').join('');
 			expect(() =>
 				validateRequest({

--- a/packages/applications-service-api/src/main.js
+++ b/packages/applications-service-api/src/main.js
@@ -3,7 +3,8 @@
 const logger = require('./lib/logger');
 const server = require('./server');
 
-function main() {
+// eslint-disable-next-line require-await
+async function main() {
 	server();
 }
 

--- a/packages/applications-service-api/src/main.js
+++ b/packages/applications-service-api/src/main.js
@@ -3,7 +3,7 @@
 const logger = require('./lib/logger');
 const server = require('./server');
 
-async function main() {
+function main() {
 	server();
 }
 

--- a/packages/applications-service-api/src/server.js
+++ b/packages/applications-service-api/src/server.js
@@ -17,4 +17,6 @@ module.exports = () => {
 	server.listen(config.server.port, () => {
 		logger.info({ config }, 'Listening');
 	});
+
+	return server;
 };

--- a/packages/applications-service-api/src/services/ni.file.service.js
+++ b/packages/applications-service-api/src/services/ni.file.service.js
@@ -4,7 +4,7 @@ const { updateSubmission } = require('./submission.service');
 const { md5 } = require('../utils/md5');
 const { textToPdf } = require('../utils/pdf');
 
-const submitUserUploadedFile = async (submission, file) => {
+const submitUserUploadedFile = (submission, file) => {
 	const fileName = buildFileName(file.originalName, submission);
 	const fileData = {
 		name: fileName,
@@ -14,7 +14,7 @@ const submitUserUploadedFile = async (submission, file) => {
 	return submitFile(submission, fileData);
 };
 
-const submitRepresentationFile = async (submission) => {
+const submitRepresentationFile = (submission) => {
 	const fileName = buildRepresentationFileName(submission);
 	const fileData = generateRepresentationPDF(submission.submissionId, submission.representation, fileName);
 

--- a/packages/applications-service-api/src/services/representation.service.js
+++ b/packages/applications-service-api/src/services/representation.service.js
@@ -47,7 +47,7 @@ const getRepresentationsForApplication = async (applicationId, page, searchTerm,
 	return representations;
 };
 
-const getRepresentationById = async (ID) => {
+const getRepresentationById = (ID) => {
 	return db.Representation.findOne({ where: { ID } });
 };
 

--- a/packages/applications-service-api/src/services/timetable.service.js
+++ b/packages/applications-service-api/src/services/timetable.service.js
@@ -1,7 +1,7 @@
 const config = require('../lib/config');
 const db = require('../models');
 
-const getTimetables = async (caseRef) => {
+const getTimetables = (caseRef) => {
 	return db.Timetable.findAndCountAll({
 		where: {
 			case_reference: caseRef

--- a/packages/common/src/health.spec.js
+++ b/packages/common/src/health.spec.js
@@ -75,7 +75,7 @@ describe('health check configuration', () => {
 			const tasks = [
 				{
 					name: 'passing test',
-					test: async () => true
+					test: () => true
 				}
 			];
 
@@ -95,11 +95,11 @@ describe('health check configuration', () => {
 			const tasks = [
 				{
 					name: 'passing test',
-					test: async () => true
+					test: () => true
 				},
 				{
 					name: 'failing test',
-					test: async () => false
+					test: () => false
 				}
 			];
 
@@ -126,11 +126,11 @@ describe('health check configuration', () => {
 			const tasks = [
 				{
 					name: 'passing test',
-					test: async () => true
+					test: () => true
 				},
 				{
 					name: 'thrown test',
-					test: async () => {
+					test: () => {
 						throw new Error('some-error');
 					}
 				}
@@ -160,7 +160,7 @@ describe('health check configuration', () => {
 			const tasks = [
 				{
 					name: 'passing test',
-					test: async () => true
+					test: () => true
 				},
 				{
 					name: 'timedout test',

--- a/packages/common/src/utils.spec.js
+++ b/packages/common/src/utils.spec.js
@@ -6,7 +6,7 @@ describe('Utils test', () => {
 			const response = 'yay';
 			const timeout = 10;
 
-			const promise = async () => response;
+			const promise = () => Promise.resolve(response);
 
 			await expect(util.promiseTimeout(timeout, promise())).resolves.toEqual(response);
 		});
@@ -15,6 +15,7 @@ describe('Utils test', () => {
 			const err = new Error('some-error');
 			const timeout = 10;
 
+			// eslint-disable-next-line require-await
 			const promise = async () => {
 				throw err;
 			};

--- a/packages/forms-web-app/__tests__/unit/controllers/register/type-of-party.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/register/type-of-party.test.js
@@ -31,25 +31,25 @@ describe('controllers/register/type-of-party', () => {
 	});
 
 	describe('forwardPage', () => {
-		it(`should return '/${VIEW.REGISTER.MYSELF.FULL_NAME}' if 1st option selected`, async () => {
+		it(`should return '/${VIEW.REGISTER.MYSELF.FULL_NAME}' if 1st option selected`, () => {
 			const pageRedirect = typeOfPartyController.forwardPage('myself');
 
 			expect(pageRedirect).toEqual(VIEW.REGISTER.MYSELF.FULL_NAME);
 		});
 
-		it(`should return '/${VIEW.REGISTER.ORGANISATION.FULL_NAME}' if 2nd option selected`, async () => {
+		it(`should return '/${VIEW.REGISTER.ORGANISATION.FULL_NAME}' if 2nd option selected`, () => {
 			const pageRedirect = typeOfPartyController.forwardPage('organisation');
 
 			expect(pageRedirect).toEqual(VIEW.REGISTER.ORGANISATION.FULL_NAME);
 		});
 
-		it(`should return '/${VIEW.REGISTER.AGENT.FULL_NAME}' if 3rd option selected`, async () => {
+		it(`should return '/${VIEW.REGISTER.AGENT.FULL_NAME}' if 3rd option selected`, () => {
 			const pageRedirect = typeOfPartyController.forwardPage('behalf');
 
 			expect(pageRedirect).toEqual(VIEW.REGISTER.AGENT.FULL_NAME);
 		});
 
-		it(`should return '/${VIEW.REGISTER.TYPE_OF_PARTY}' if it is 'default'`, async () => {
+		it(`should return '/${VIEW.REGISTER.TYPE_OF_PARTY}' if it is 'default'`, () => {
 			const pageRedirect = typeOfPartyController.forwardPage('default');
 
 			expect(pageRedirect).toEqual(VIEW.REGISTER.TYPE_OF_PARTY);

--- a/packages/forms-web-app/__tests__/unit/scripts/sanitise-form.test.js
+++ b/packages/forms-web-app/__tests__/unit/scripts/sanitise-form.test.js
@@ -75,7 +75,7 @@ describe('scripts/sanitise-form', () => {
 		fetch(fetchConfig.valid);
 		formOne.submit();
 
-		test('redirect url', async () => {
+		test('redirect url', () => {
 			expect(window.location.href).toEqual(fetchConfig.valid.url);
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/utils/async-route.test.js
+++ b/packages/forms-web-app/__tests__/unit/utils/async-route.test.js
@@ -1,15 +1,16 @@
 const { asyncRoute } = require('../../../src/utils/async-route');
 
 describe('async-route helper', () => {
-	it('should throw error if route throws error', () => {
+	it('should throw error if route throws error', async () => {
 		const error = new Error('some error');
 
 		// eslint-disable-next-line no-unused-vars
 		const route = async (req, res) => {
+			await Promise.resolve(); // some example async function
 			throw error;
 		};
 
-		expect(asyncRoute(route)).rejects.toThrowError(error);
+		await expect(asyncRoute(route)).rejects.toThrowError(error);
 	});
 
 	it('should throw error if route returns rejected promise', () => {

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -42,7 +42,7 @@ module.exports = {
 		useRedisSessionStore: process.env.FEATURE_REDIS_SESSION_STORE === 'true',
 		allowSaveAndExitOption: process.env.FEATURE_SAVE_AND_EXIT_OPTION === 'true',
 		showAffectedAreaSection: process.env.FEATURE_SHOW_AFFECTED_AREA_SECTION === 'true',
-		hideProjectTimelineLink: process.env.FEATURE_PROJECT_TIMELINE_LINK === 'true',
+		showProjectTimelineLink: process.env.FEATURE_PROJECT_TIMELINE_LINK === 'true',
 		allowDocumentLibrary: process.env.FEATURE_ALLOW_DOCUMENT_LIBRARY === 'true',
 		allowRepresentation: process.env.FEATURE_ALLOW_REPRESENTATION === 'true'
 	},

--- a/packages/forms-web-app/src/controllers/examination/email.js
+++ b/packages/forms-web-app/src/controllers/examination/email.js
@@ -22,7 +22,7 @@ const pageData = {
 	hint: "We'll use your email address to confirm we've received your submission. We will not publish your email address."
 };
 
-const getEmail = async (req, res) => {
+const getEmail = (req, res) => {
 	const requestSession = req.session;
 	const examinationStorage = requestSession?.[examinationSessionStorageName];
 	const currentView = requestSession?.currentView;
@@ -37,7 +37,7 @@ const getEmail = async (req, res) => {
 	res.render(email.view, pageData);
 };
 
-const postEmail = async (req, res) => {
+const postEmail = (req, res) => {
 	const { body = {} } = req;
 	const { errors = {}, errorSummary = [] } = body;
 	const requestSession = req?.session;

--- a/packages/forms-web-app/src/controllers/examination/enter-comment/controller.js
+++ b/packages/forms-web-app/src/controllers/examination/enter-comment/controller.js
@@ -23,7 +23,7 @@ const pageData = {
 	title: enterComment.name
 };
 
-const getEnterComment = async (req, res) => {
+const getEnterComment = (req, res) => {
 	try {
 		const { session } = req;
 		const setPageData = { ...pageData };
@@ -39,7 +39,7 @@ const getEnterComment = async (req, res) => {
 	}
 };
 
-const postEnterComment = async (req, res) => {
+const postEnterComment = (req, res) => {
 	try {
 		const { body, session } = req;
 		const { errors = {}, errorSummary = [] } = body;

--- a/packages/forms-web-app/src/controllers/examination/evidence-or-comment/controller.js
+++ b/packages/forms-web-app/src/controllers/examination/evidence-or-comment/controller.js
@@ -26,7 +26,7 @@ const pageData = {
 	title: evidenceOrComment.title
 };
 
-const getEvidenceOrComment = async (req, res) => {
+const getEvidenceOrComment = (req, res) => {
 	try {
 		const setPageData = { ...pageData };
 
@@ -47,7 +47,7 @@ const getEvidenceOrComment = async (req, res) => {
 	}
 };
 
-const postEvidenceOrComment = async (req, res) => {
+const postEvidenceOrComment = (req, res) => {
 	try {
 		const { body, session } = req;
 

--- a/packages/forms-web-app/src/controllers/examination/have-your-say.js
+++ b/packages/forms-web-app/src/controllers/examination/have-your-say.js
@@ -14,7 +14,7 @@ const {
 	routesConfig: { project }
 } = require('../../routes/config');
 
-const getHaveYourSay = async (req, res) => {
+const getHaveYourSay = (req, res) => {
 	const { session = { examination: { caseRef: null, name: null } } } = req;
 	const reqExaminationSession = session[examinationSession.name] ?? { caseRef: null };
 

--- a/packages/forms-web-app/src/controllers/examination/name.js
+++ b/packages/forms-web-app/src/controllers/examination/name.js
@@ -20,7 +20,7 @@ const pageData = {
 	values: { backLinkUrl: `${examinationDirectory + submittingFor.route}` }
 };
 
-const getName = async (req, res) => {
+const getName = (req, res) => {
 	const examinationSession = req?.session?.[examinationSessionStorageName];
 
 	const sessionCurrentView = req.session?.currentView;
@@ -39,7 +39,7 @@ const getName = async (req, res) => {
 	res.render(view, pageData.values);
 };
 
-const postName = async (req, res) => {
+const postName = (req, res) => {
 	const { body = {}, session } = req;
 	const { errors = {}, errorSummary = [] } = body;
 	const examinationSession = session?.[examinationSessionStorageName];

--- a/packages/forms-web-app/src/controllers/projects/all-examination-documents.js
+++ b/packages/forms-web-app/src/controllers/projects/all-examination-documents.js
@@ -1,6 +1,6 @@
 const { VIEW } = require('../../lib/views');
 
-exports.getAllExaminationDocuments = async (req, res) => {
+exports.getAllExaminationDocuments = (req, res) => {
 	res.render(VIEW.PROJECTS.ALL_EXAMINATION_DOCUMENTS, {
 		caseRef: req.session.caseRef,
 		projectName: req.session.projectName

--- a/packages/forms-web-app/src/controllers/projects/project-timeline.js
+++ b/packages/forms-web-app/src/controllers/projects/project-timeline.js
@@ -1,6 +1,6 @@
 const { VIEW } = require('../../lib/views');
 
-exports.getProjectTimeLine = async (req, res) => {
+exports.getProjectTimeLine = (req, res) => {
 	res.render(VIEW.PROJECTS.PROJECT_TIMELINE, {
 		caseRef: req.session.caseRef,
 		projectName: req.session.projectName

--- a/packages/forms-web-app/src/controllers/projects/recommendations.js
+++ b/packages/forms-web-app/src/controllers/projects/recommendations.js
@@ -1,6 +1,6 @@
 const { VIEW } = require('../../lib/views');
 
-exports.getRecommendations = async (req, res) => {
+exports.getRecommendations = (req, res) => {
 	res.render(VIEW.PROJECTS.RECOMMENDATIONS, {
 		projectName: req.session.projectName,
 		caseRef: req.session.caseRef

--- a/packages/forms-web-app/src/lib/application-api-wrapper.js
+++ b/packages/forms-web-app/src/lib/application-api-wrapper.js
@@ -76,15 +76,15 @@ async function handler(callingMethod, path, method = 'GET', opts = {}, headers =
 	}
 }
 
-exports.getProjectData = async (case_ref) => {
+exports.getProjectData = (case_ref) => {
 	return handler('getProjectData', `/api/v1/applications/${case_ref}`);
 };
 
-exports.getAllProjectList = async () => {
+exports.getAllProjectList = () => {
 	return handler('getAllProjectList', '/api/v1/applications');
 };
 
-exports.searchDocumentList = async (case_ref, search_data) => {
+exports.searchDocumentList = (case_ref, search_data) => {
 	const documentServiceApiUrl = `/api/v1/documents/${case_ref}`;
 	const method = 'POST';
 	return handler('searchDocumentList', documentServiceApiUrl, method, {
@@ -92,7 +92,7 @@ exports.searchDocumentList = async (case_ref, search_data) => {
 	});
 };
 
-exports.searchRepresentations = async (params) => {
+exports.searchRepresentations = (params) => {
 	const queryString = Object.keys(params)
 		.map((key) => `${key}=${params[key]}`)
 		.join('&');
@@ -101,7 +101,7 @@ exports.searchRepresentations = async (params) => {
 	return handler('searchRepresentations', representationServiceApiUrl, method);
 };
 
-exports.searchDocumentListV2 = async (params) => {
+exports.searchDocumentListV2 = (params) => {
 	const queryString = queryStringBuilder(params, [
 		'caseRef',
 		'classification',
@@ -116,7 +116,7 @@ exports.searchDocumentListV2 = async (params) => {
 	return handler('searchDocumentListV2', documentServiceApiUrl, method);
 };
 
-exports.postRegistration = async (registeration_data) => {
+exports.postRegistration = (registeration_data) => {
 	const registrationServiceApiUrl = '/api/v1/interested-party';
 	const method = 'POST';
 	return handler('postRegistration', registrationServiceApiUrl, method, {
@@ -124,7 +124,7 @@ exports.postRegistration = async (registeration_data) => {
 	});
 };
 
-exports.putComments = async (ipRefNo, comments_data) => {
+exports.putComments = (ipRefNo, comments_data) => {
 	const commentsServiceApiUrl = `/api/v1/interested-party/${ipRefNo}/comments`;
 	const method = 'PUT';
 	return handler('putComments', commentsServiceApiUrl, method, {
@@ -132,7 +132,7 @@ exports.putComments = async (ipRefNo, comments_data) => {
 	});
 };
 
-exports.authenticateToken = async (token, email) => {
+exports.authenticateToken = (token, email) => {
 	const authTokenServiceApiUrl = `/api/v1/interested-party/${token}`;
 	const method = 'POST';
 	return handler('authenticateToken', authTokenServiceApiUrl, method, {
@@ -140,9 +140,8 @@ exports.authenticateToken = async (token, email) => {
 	});
 };
 
-exports.getRepresentationById = async (id) => {
+exports.getRepresentationById = (id) => {
 	return handler('getRepresentationById', `/api/v1/representations/${id}`);
 };
 
-exports.getTimetables = async (caseRef) =>
-	handler('getTimetables', `/api/v1/timetables/${caseRef}`);
+exports.getTimetables = (caseRef) => handler('getTimetables', `/api/v1/timetables/${caseRef}`);

--- a/packages/forms-web-app/src/routes/project-search.js
+++ b/packages/forms-web-app/src/routes/project-search.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const projectSearchController = require('../controllers/project-search');
+const { asyncRoute } = require('../utils/async-route');
 
 const router = express.Router();
 
-router.get('/', projectSearchController.getProjectList);
+router.get('/', asyncRoute(projectSearchController.getProjectList));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/projects/index.js
+++ b/packages/forms-web-app/src/routes/projects/index.js
@@ -13,7 +13,7 @@ const {
 
 const {
 	featureFlag: {
-		hideProjectTimelineLink,
+		showProjectTimelineLink,
 		allowDocumentLibrary,
 		allowRepresentation,
 		usePrivateBetaV1RoutesOnly
@@ -45,7 +45,7 @@ if (!usePrivateBetaV1RoutesOnly) {
 	router.get('/:case_ref', asyncRoute(projectsController.getExamination));
 }
 
-if (hideProjectTimelineLink) {
+if (showProjectTimelineLink) {
 	router.get('/project-timeline', projectTimeLineController.getProjectTimeLine);
 }
 

--- a/packages/forms-web-app/src/routes/projects/index.js
+++ b/packages/forms-web-app/src/routes/projects/index.js
@@ -31,18 +31,18 @@ const projectsController = require('../../controllers/projects/examination');
 const aboutTheApplicationController = require('../../controllers/projects/documents');
 
 if (!usePrivateBetaV1RoutesOnly) {
-	router.get('/', projectSearchController.getProjectList);
+	router.get('/', asyncRoute(projectSearchController.getProjectList));
 	router.get('/all-examination-documents', allExaminationDocsController.getAllExaminationDocuments);
 	router.get('/recommendations', recommendationsController.getRecommendations);
 	router.get(
 		subDirectory + pages.examinationTimetable.route,
-		examinationTimetable.getExaminationTimetable
+		asyncRoute(examinationTimetable.getExaminationTimetable)
 	);
 	router.post(
 		subDirectory + pages.examinationTimetable.route,
 		examinationTimetable.postExaminationTimetable
 	);
-	router.get('/:case_ref', projectsController.getExamination);
+	router.get('/:case_ref', asyncRoute(projectsController.getExamination));
 }
 
 if (hideProjectTimelineLink) {
@@ -52,7 +52,7 @@ if (hideProjectTimelineLink) {
 if (allowDocumentLibrary) {
 	router.get(
 		'/:case_ref/application-documents',
-		aboutTheApplicationController.getApplicationDocuments
+		asyncRoute(aboutTheApplicationController.getApplicationDocuments)
 	);
 }
 

--- a/packages/forms-web-app/src/services/document.service.js
+++ b/packages/forms-web-app/src/services/document.service.js
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 const { searchDocumentList, searchDocumentListV2 } = require('../lib/application-api-wrapper');
 
-const searchDocument = async (case_ref, search_data) => {
+const searchDocument = (case_ref, search_data) => {
 	return searchDocumentList(case_ref, search_data);
 };
 
-const searchDocumentsV2 = async (params) => {
+const searchDocumentsV2 = (params) => {
 	return searchDocumentListV2(params);
 };
 

--- a/packages/forms-web-app/src/services/representation.service.js
+++ b/packages/forms-web-app/src/services/representation.service.js
@@ -1,7 +1,7 @@
 const { getRepresentationById } = require('../lib/application-api-wrapper');
 
 // eslint-disable-next-line camelcase
-const getRepresentation = async (id) => {
+const getRepresentation = (id) => {
 	return getRepresentationById(id);
 };
 

--- a/packages/forms-web-app/src/services/timetable.service.js
+++ b/packages/forms-web-app/src/services/timetable.service.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 const { getTimetables: getTimetablesByCaseRef } = require('../lib/application-api-wrapper');
 
-const getTimetables = async (case_ref) => {
+const getTimetables = (case_ref) => {
 	return getTimetablesByCaseRef(case_ref);
 };
 

--- a/packages/forms-web-app/src/views/layouts/vertical-tabs.njk
+++ b/packages/forms-web-app/src/views/layouts/vertical-tabs.njk
@@ -9,7 +9,7 @@
 				{% endif %}
 			</li>
 		{% endif %}
-		{% if featureFlag.hideProjectTimelineLink %}
+		{% if featureFlag.showProjectTimelineLink %}
 		<li class="style-vertical-tabs__tab govuk-body-s {% if 'project-timeline' == activeProjectLink %} style-vertical-tabs__tab--active {% endif %}">
       {% if 'project-timeline' != activeProjectLink %}
         <a href="/projects/project-timeline">Project timeline</a>


### PR DESCRIPTION
A little bit of refactoring around `async` routes. We fixed a couple of instances of this issue in #493 and #475 already but there are others so I am fixing them in bulk here.

The changes are:
- (41161cad) Removing the `async` keyword from route/controller functions that _don't_ need to be asynchronous 
- (015d624c) Applying the `asyncRoute` wrapper function to routes that _do_ need to be `async` (usually because they call the API). This wrapper function catches unhanded exception and passes them to the Express error handler. If an exception isn't caught, it crashes the web server.
- (d15a96de) adding an eslint rule which disallows labelling a function as `async` unless it contains an `await`. This should stop us accidentally defining routes as `async` which do not need to be, I hope.
- (e9bdacdd) minor tweak: renaming of a feature flag that had a confusing name.

--------------------

Going forward, if a new route is added and needs to be `async`, then it should be defined in one of two ways:

1. Using `asyncRoute` wrapper:

```
const myControllerFunction = async (req, res) => { ... }
route.get('/some-route', asyncRoute(myControllerFunction)) => { ... }
```

2. Controller function should catch any unhandled exceptions (try/catch)
```
const myControllerFunction = async (req, res) => {
    try {
        await someFunction();
        // or, anything that might throw an exception
    } catch (e) {
        // render an error page
    }
}

route.get('/some-route', myControllerFunction) => { ... }
```

I prefer (1), and is what I have used in my refactoring here so am establishing a pattern of sorts but it does have its shortcomings and the try/catch approach is perfectly valid is some scenarios as an alternative. 