### PR TITLE
feat(applications-service-api): complete submission endpoint

### DIFF
--- a/packages/applications-service-api/__tests__/__data__/submission.js
+++ b/packages/applications-service-api/__tests__/__data__/submission.js
@@ -1,0 +1,21 @@
+const SUBMISSION_CREATE_REQUEST = {
+	headers: {
+		'content-type':
+			'multipart/form-data; boundary=--------------------------002628336047044988377296',
+		'content-length': '1010'
+	},
+	body: {},
+	params: {
+		caseReference: 'EN010009'
+	},
+	query: {},
+	baseUrl: '/api/v1/submissions',
+	route: {
+		path: '/:caseReference'
+	},
+	method: 'POST'
+};
+
+module.exports = {
+	SUBMISSION_CREATE_REQUEST
+};

--- a/packages/applications-service-api/__tests__/unit/controllers/submissions.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/submissions.test.js
@@ -1,13 +1,15 @@
 const httpMocks = require('node-mocks-http');
 
 const { ORIGINAL_REQUEST_FILE_DATA, SUBMISSION_DATA, FILE_DATA } = require('../../__data__/file');
-const { createSubmission } = require('../../../src/controllers/submissions');
+const { createSubmission, completeSubmission } = require('../../../src/controllers/submissions');
 
 jest.mock('../../../src/services/submission.service');
 jest.mock('../../../src/services/ni.file.service');
 
 const createSubmissionService =
 	require('../../../src/services/submission.service').createSubmission;
+const completeSubmissionService =
+	require('../../../src/services/submission.service').completeSubmission;
 const submitUserUploadedFileService =
 	require('../../../src/services/ni.file.service').submitUserUploadedFile;
 const submitRepresentationFileService =
@@ -90,6 +92,29 @@ describe('submissions controller', () => {
 
 			expect(res._getStatusCode()).toEqual(201);
 			expect(res._getData()).toEqual(submissionDataWithRepresentation);
+		});
+	});
+
+	describe('completeSubmission', () => {
+		const req = {
+			params: {
+				submissionId: 1
+			}
+		};
+		const res = httpMocks.createResponse();
+
+		it('returns successful response when service completes without throwing', async () => {
+			completeSubmissionService.mockResolvedValueOnce();
+
+			await completeSubmission(req, res);
+
+			expect(res._getStatusCode()).toEqual(204);
+		});
+
+		it('throws if service throws', async () => {
+			completeSubmissionService.mockRejectedValueOnce('some error');
+
+			await expect(completeSubmission(req, res)).rejects.toEqual('some error');
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/middleware/parseFormDataProperties.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/parseFormDataProperties.test.js
@@ -1,6 +1,9 @@
-const { parseFormDataProperties } = require('../../../src/middleware/parseFormDataProperties');
+const { parseFormDataProperties, parseIntegerParam} = require('../../../src/middleware/parseFormDataProperties');
 
 describe('request middleware', () => {
+	const res = jest.fn();
+	const next = jest.fn();
+
 	describe('parseFormDataProperties', () => {
 		it('should parse string representations of numbers and booleans in the request body', () => {
 			const req = {
@@ -10,13 +13,25 @@ describe('request middleware', () => {
 					numberOfThings: '1'
 				}
 			};
-			const res = jest.fn();
-			const next = jest.fn();
 
 			parseFormDataProperties(['isActive'], ['numberOfThings'])(req, res, next);
 
 			expect(req.body.isActive).toEqual(true);
 			expect(req.body.numberOfThings).toEqual(1);
+		});
+	});
+
+	describe('parseIntegerParam', () => {
+		it('should parse integer property within request params', () => {
+			const req = {
+				params: {
+					foo: '1'
+				}
+			};
+
+			parseIntegerParam('foo')(req, res, next);
+
+			expect(req.params.foo).toEqual(1);
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/middleware/validator/openapi.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/validator/openapi.test.js
@@ -1,0 +1,42 @@
+const { validateRequestWithOpenAPI } = require('../../../../src/middleware/validator/openapi');
+const ApiError = require('../../../../src/error/apiError');
+const { SUBMISSION_CREATE_REQUEST } = require('../../../__data__/submission');
+
+describe('openapi validator', () => {
+	describe('validateRequestWithOpenAPI', () => {
+		const req = {
+			...SUBMISSION_CREATE_REQUEST
+		};
+		const res = jest.fn();
+		const next = jest.fn();
+
+		it('given request with data not conforming to openapi spec, throws apierror with error messages', () => {
+			const generateLongRepresentation = () => [...Array(65235)].map(() => 'a').join('');
+
+			const requestWithTooLongCaseReference = {
+				...req,
+				params: {
+					caseReference: '1234567890987654321'
+				},
+				body: {
+					representation: generateLongRepresentation()
+				}
+			};
+
+			const expectedError = new ApiError(400, {
+				errors: [
+					"'representation' must not have more than 65234 characters",
+					"must have required property 'name'",
+					"must have required property 'email'",
+					"must have required property 'interestedParty'",
+					"must have required property 'deadline'",
+					"must have required property 'submissionType'"
+				]
+			});
+
+			expect(() =>
+				validateRequestWithOpenAPI(requestWithTooLongCaseReference, res, next)
+			).toThrowError(expect.objectContaining(expectedError));
+		});
+	});
+});

--- a/packages/applications-service-api/__tests__/unit/routes/submissions.test.js
+++ b/packages/applications-service-api/__tests__/unit/routes/submissions.test.js
@@ -2,8 +2,9 @@ const { post } = require('./router-mock');
 const fileUpload = require('express-fileupload');
 const submissionsController = require('../../../src/controllers/submissions');
 const config = require('../../../src/lib/config');
-const { validateRequest } = require('../../../src/middleware/validator/submission');
+const { validateCreateSubmissionRequest } = require('../../../src/middleware/validator/submission');
 const { normaliseRequestFileData } = require('../../../src/middleware/normaliseRequestFileData');
+const {validateRequestWithOpenAPI} = require("../../../src/middleware/validator/openapi");
 
 jest.mock('express-fileupload');
 jest.mock('../../../src/middleware/fileUploadLimitHandler');
@@ -17,9 +18,13 @@ const parseFormDataPropertiesMock =
 	require('../../../src/middleware/parseFormDataProperties').parseFormDataProperties;
 const parseFormDataPropertiesMockValue = jest.fn();
 
+const parseIntegerParamMock = require('../../../src/middleware/parseFormDataProperties').parseIntegerParam;
+const parseIntegerParamMockValue = jest.fn();
+
 describe('routes/submissions', () => {
 	fileUpload.mockImplementation(() => fileUploadMockValue);
 	parseFormDataPropertiesMock.mockImplementation(() => parseFormDataPropertiesMockValue);
+	parseIntegerParamMock.mockImplementation(() => parseIntegerParamMockValue);
 
 	beforeEach(() => {
 		// eslint-disable-next-line global-require
@@ -47,8 +52,17 @@ describe('routes/submissions', () => {
 			fileUploadMockValue,
 			normaliseRequestFileData,
 			parseFormDataPropertiesMockValue,
-			validateRequest,
+			validateCreateSubmissionRequest,
 			submissionsController.createSubmission
+		);
+
+		expect(parseIntegerParamMock).toBeCalledWith('submissionId');
+
+		expect(post).toHaveBeenCalledWith(
+			'/:submissionId/complete',
+			parseIntegerParamMockValue,
+			validateRequestWithOpenAPI,
+			submissionsController.completeSubmission
 		);
 	});
 });

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -362,18 +362,20 @@ paths:
                 $ref: '#/components/schemas/Representation'
         '404':
           description: Representation not found
-  '/api/v1/timetables/{caseRef}':
+  '/api/v1/timetables/{caseReference}':
     get:
       summary: Returns timetable data for a case
       tags:
         - Timetables
       parameters:
         - in: path
-          name: caseRef
+          name: caseReference
           example: EN020021
           required: true
           schema:
             type: string
+            minLength: 2
+            maxLength: 12
           description: Case / Project unique identifier
       responses:
         '200':
@@ -394,13 +396,7 @@ paths:
       tags:
         - Submissions
       parameters:
-        - in: path
-          name: caseReference
-          example: EN020021
-          required: true
-          schema:
-            type: string
-          description: Case / Project unique identifier
+        - $ref: '#/components/parameters/caseReference'
       requestBody:
         content:
           multipart/form-data:
@@ -419,6 +415,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationError'
+        '500':
+          description: Internal server error
+  '/api/v1/submissions/{submissionId}/complete':
+    post:
+      summary: Mark a submission as complete
+      tags:
+        - Submissions
+      parameters:
+        - in: path
+          name: submissionId
+          example: 1234
+          required: true
+          schema:
+            type: number
+      responses:
+        '204':
+          description: Request was successful
+        '400':
+          description: Request body validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Submission with given ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
         '500':
           description: Internal server error
   '/test':
@@ -1140,3 +1165,14 @@ components:
           items:
             type: string
             example: Missing property 'x'
+    NotFoundError:
+      type: object
+      properties:
+        code:
+          type: integer
+          example: 404
+        errors:
+          type: array
+          items:
+            type: string
+            example: Submission not found

--- a/packages/applications-service-api/src/controllers/submissions.js
+++ b/packages/applications-service-api/src/controllers/submissions.js
@@ -1,24 +1,27 @@
 const { StatusCodes } = require('http-status-codes');
-const { createSubmission } = require('../services/submission.service');
+const { createSubmission, completeSubmission} = require('../services/submission.service');
 const { submitUserUploadedFile, submitRepresentationFile } = require('../services/ni.file.service');
 
-module.exports = {
-	async createSubmission(req, res) {
-		const { caseReference } = req.params;
+const createSubmissionController = async (req, res) => {
+	const { caseReference } = req.params;
 
-		const submissionRequestData = buildSubmissionData(req.body, caseReference);
-		let submission = await createSubmission(submissionRequestData);
+	const submissionRequestData = buildSubmissionData(req.body, caseReference);
+	let submission = await createSubmission(submissionRequestData);
 
-		if (req.file) {
-			submission = await submitUserUploadedFile(submission, req.file);
-		}
-
-		if (submission.representation) {
-			await submitRepresentationFile(submission);
-		}
-
-		return res.status(StatusCodes.CREATED).send(submission);
+	if (req.file) {
+		submission = await submitUserUploadedFile(submission, req.file);
 	}
+
+	if (submission.representation) {
+		await submitRepresentationFile(submission);
+	}
+
+	return res.status(StatusCodes.CREATED).send(submission);
+};
+
+const completeSubmissionController = async (req, res) => {
+	await completeSubmission(req.params.submissionId);
+	return res.sendStatus(StatusCodes.NO_CONTENT);
 };
 
 const buildSubmissionData = (requestBody, caseReference) => {
@@ -36,4 +39,9 @@ const buildSubmissionData = (requestBody, caseReference) => {
 		caseReference: caseReference,
 		dateSubmitted: new Date()
 	};
+};
+
+module.exports = {
+	createSubmission: createSubmissionController,
+	completeSubmission: completeSubmissionController
 };

--- a/packages/applications-service-api/src/error/apiError.js
+++ b/packages/applications-service-api/src/error/apiError.js
@@ -10,8 +10,12 @@ class ApiError {
 		return new ApiError(StatusCodes.BAD_REQUEST, { errors: messages.flat() });
 	}
 
+	static notFound(message) {
+		return new ApiError(StatusCodes.NOT_FOUND, { errors: [message] });
+	}
+
 	static applicationNotFound(id) {
-		return new ApiError(StatusCodes.NOT_FOUND, { errors: [`Application ${id} was not found`] });
+		return this.notFound(`Application ${id} was not found`);
 	}
 
 	static applicationNotAcceptable(id) {
@@ -21,39 +25,27 @@ class ApiError {
 	}
 
 	static noApplicationsFound() {
-		return new ApiError(StatusCodes.NOT_FOUND, { errors: [`No applications found`] });
+		return this.notFound('No applications found');
 	}
 
 	static interestedPartyNotFound(caseRef) {
-		return new ApiError(StatusCodes.NOT_FOUND, {
-			errors: [`Interested party for project ${caseRef} not found`]
-		});
+		return this.notFound(`Interested party for project ${caseRef} not found`);
 	}
 
 	static noDocumentsFound() {
-		return new ApiError(404, { errors: [`No documents found`] });
+		return this.notFound('No documents found');
 	}
 
-	static commentsForPartyWithIDNotUpdated(ID) {
-		return new ApiError(StatusCodes.BAD_REQUEST, {
-			errors: [`Failed to update comments for party with ID ${ID}`]
-		});
-	}
-
-	static interestedPartyNotFoundByID(ID) {
-		return new ApiError(StatusCodes.NOT_FOUND, {
-			errors: [`Interested party ${ID} not found`]
-		});
+	static interestedPartyNotFoundByID(id) {
+		return this.notFound(`Interested party ${id} not found`);
 	}
 
 	static noRepresentationsFound() {
-		return new ApiError(StatusCodes.NOT_FOUND, { errors: [`No representations found`] });
+		return this.notFound('No representations found');
 	}
 
 	static representationNotFound(id) {
-		return new ApiError(StatusCodes.NOT_FOUND, {
-			errors: [`Representation with ID ${id} not found`]
-		});
+		return this.notFound(`Representation with ID ${id} not found`);
 	}
 }
 

--- a/packages/applications-service-api/src/lib/notify.js
+++ b/packages/applications-service-api/src/lib/notify.js
@@ -61,7 +61,13 @@ async function sendMagicLinkToIP(details) {
 	}
 }
 
+const sendSubmissionNotification = (data) => {
+	// TODO in ASB-901
+	console.log(data);
+}
+
 module.exports = {
 	sendIPRegistrationConfirmationEmailToIP,
-	sendMagicLinkToIP
+	sendMagicLinkToIP,
+	sendSubmissionNotification
 };

--- a/packages/applications-service-api/src/middleware/parseFormDataProperties.js
+++ b/packages/applications-service-api/src/middleware/parseFormDataProperties.js
@@ -15,6 +15,17 @@ const parseFormDataProperties = (booleanProperties, integerProperties) => {
 	};
 };
 
+const parseIntegerParam = (property) => {
+	return (req, res, next) => {
+		if (req.params && req.params[property]) {
+			req.params[property] = parseInteger(req.params[property]);
+		}
+
+		next();
+	};
+}
+
 module.exports = {
-	parseFormDataProperties
+	parseFormDataProperties,
+	parseIntegerParam
 };

--- a/packages/applications-service-api/src/middleware/validator/openapi.js
+++ b/packages/applications-service-api/src/middleware/validator/openapi.js
@@ -1,0 +1,25 @@
+const { createRequestValidator } = require('../../utils/openapi');
+const ApiError = require('../../error/apiError');
+
+const validateRequestWithOpenAPI = (req, res, next) => {
+	const validator = createRequestValidator(req.method, `${req.baseUrl}${req.route.path}`);
+
+	const errors = validator.validateRequest(req);
+
+	if (errors) {
+		throw ApiError.badRequest(
+			errors.errors.map((e) => {
+				if (e.errorCode.match(/maxLength|minLength/)) {
+					return `'${e.path}' ${e.message.toLowerCase()}`;
+				}
+				return e.message;
+			})
+		);
+	}
+
+	next();
+};
+
+module.exports = {
+	validateRequestWithOpenAPI
+};

--- a/packages/applications-service-api/src/middleware/validator/submission.js
+++ b/packages/applications-service-api/src/middleware/validator/submission.js
@@ -1,22 +1,9 @@
 const config = require('../../lib/config');
 const ApiError = require('../../error/apiError');
-const { createRequestValidator } = require('../../utils/openapi');
+const { validateRequestWithOpenAPI } = require('./openapi');
 
-const validator = createRequestValidator('POST', '/api/v1/submissions/{caseReference}');
-
-const validateRequest = (req, res, next) => {
-	const errors = validator.validateRequest(req);
-
-	if (errors) {
-		throw ApiError.badRequest(
-			errors.errors.map((e) => {
-				if (e.errorCode.includes('maxLength')) {
-					return `'${e.path}' ${e.message.toLowerCase()}`;
-				}
-				return e.message;
-			})
-		);
-	}
+const validateCreateSubmissionRequest = (req, res, next) => {
+	validateRequestWithOpenAPI(req, res, next);
 
 	if (!req.body.representation && !req.file) {
 		throw ApiError.badRequest("must have required property 'representation' or 'file'");
@@ -38,5 +25,5 @@ const validateRequest = (req, res, next) => {
 };
 
 module.exports = {
-	validateRequest
+	validateCreateSubmissionRequest
 };

--- a/packages/applications-service-api/src/routes/index.js
+++ b/packages/applications-service-api/src/routes/index.js
@@ -21,6 +21,6 @@ router.use('/api/v1/documents', documentRouter);
 router.use('/api/v2/documents', documentRouter);
 router.use('/api/v1/representations', representationsRouter);
 router.use('/api/v1/timetables', timetablesRouter);
-router.use('/api/v1/submission', submissionRouter);
+router.use('/api/v1/submissions', submissionRouter);
 
 module.exports = router;

--- a/packages/applications-service-api/src/routes/submissions.js
+++ b/packages/applications-service-api/src/routes/submissions.js
@@ -3,10 +3,14 @@ const fileUpload = require('express-fileupload');
 
 const submissionsController = require('../controllers/submissions');
 const config = require('../lib/config');
-const { parseFormDataProperties } = require('../middleware/parseFormDataProperties');
+const {
+	parseFormDataProperties,
+	parseIntegerParam
+} = require('../middleware/parseFormDataProperties');
 const { fileUploadLimitHandler } = require('../middleware/fileUploadLimitHandler');
-const { validateRequest } = require('../middleware/validator/submission');
+const { validateCreateSubmissionRequest } = require('../middleware/validator/submission');
 const { normaliseRequestFileData } = require('../middleware/normaliseRequestFileData');
+const { validateRequestWithOpenAPI } = require('../middleware/validator/openapi');
 
 const router = express.Router();
 
@@ -19,8 +23,15 @@ router.post(
 	}),
 	normaliseRequestFileData,
 	parseFormDataProperties(['interestedParty', 'sensitiveData', 'lateSubmission'], ['submissionId']),
-	validateRequest,
+	validateCreateSubmissionRequest,
 	submissionsController.createSubmission
+);
+
+router.post(
+	'/:submissionId/complete',
+	parseIntegerParam('submissionId'),
+	validateRequestWithOpenAPI,
+	submissionsController.completeSubmission
 );
 
 module.exports = router;

--- a/packages/applications-service-api/src/services/submission.service.js
+++ b/packages/applications-service-api/src/services/submission.service.js
@@ -1,5 +1,6 @@
 const db = require('../models');
 const ApiError = require('../error/apiError');
+const { sendSubmissionNotification } = require('../lib/notify');
 
 const PLACEHOLDER_SUBMISSION_ID = 0;
 
@@ -66,7 +67,22 @@ const updateSubmission = async (submission) => {
 	});
 };
 
+const getSubmission = (submissionId) => db.Submission.findOne({ where: { id: submissionId } });
+
+const completeSubmission = async (submissionId) => {
+	const submission = await getSubmission(submissionId);
+
+	if (!submission) {
+		throw ApiError.notFound(`Submission with ID ${submissionId} not found`);
+	}
+
+	console.log(`Found submission with ID ${submission.id}, email: ${submission.email}`);
+
+	sendSubmissionNotification(submission);
+};
+
 module.exports = {
 	createSubmission,
-	updateSubmission
+	updateSubmission,
+	completeSubmission
 };

--- a/packages/applications-service-api/src/services/submission.service.js
+++ b/packages/applications-service-api/src/services/submission.service.js
@@ -76,8 +76,6 @@ const completeSubmission = async (submissionId) => {
 		throw ApiError.notFound(`Submission with ID ${submissionId} not found`);
 	}
 
-	console.log(`Found submission with ID ${submission.id}, email: ${submission.email}`);
-
 	sendSubmissionNotification(submission);
 };
 

--- a/packages/applications-service-api/src/utils/openapi.js
+++ b/packages/applications-service-api/src/utils/openapi.js
@@ -22,7 +22,7 @@ const loadOpenAPISpec = memoizeWith(Object, _ => {
 const createRequestValidator = (verb, path) => {
     try {
         const openAPISpec = loadOpenAPISpec();
-        const requestSpec = openAPISpec.paths[path][verb.toLowerCase()];
+        const requestSpec = openAPISpec.paths[path.replace(/(:(\w+))/g, "{$2}")][verb.toLowerCase()];
 
         return new OpenAPIRequestValidator({
             ...requestSpec,


### PR DESCRIPTION
- new `/submissions/{submissionId}/complete` endpoint
  - updated openapi spec
  - stub implementation
      - request validation
      - fetching submission from DB
      - does not call notify service yet, to be implemented in ASB-901
 - fix incorrect path of create submission endpoint. `/submission/:caseReference` -> `/submissions/:caseReference`