### PR TITLE
feat(applicatons-service-api): mock server for ni api calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       MYSQL_PORT: 3306
       MYSQL_DIALECT: mysql
       NODE_ENV: local
-      NI_API_HOST: ni-api-host.example.com
+      NI_API_HOST: api-mock-server:1080
       NI_OAUTH_CLIENT_ID: some-client-id
       NI_OAUTH_CLIENT_SECRET: some-client-secret
       NI_OAUTH_USERNAME: some-username
@@ -132,3 +132,14 @@ services:
     restart: always
     ports:
       - 9000:8080
+
+  api-mock-server:
+    image: mockserver/mockserver:5.14.0
+    container_name: api-mock-server
+    environment:
+      MOCKSERVER_WATCH_INITIALIZATION_JSON: "true"
+      MOCKSERVER_INITIALIZATION_JSON_PATH: /config/init.json
+    ports:
+      - 1080:1080
+    volumes:
+      - ./mock-server:/config

--- a/mock-server/init.json
+++ b/mock-server/init.json
@@ -1,0 +1,33 @@
+[
+	{
+		"httpRequest": {
+			"method": "POST",
+			"path": "/",
+			"queryStringParameters": {
+				"oauth": ["token"]
+			}
+		},
+		"httpResponse": {
+			"body": {
+				"access_token": "some-access-token",
+				"expires_in": 3600,
+				"token_type": "Bearer",
+				"scope": "basic",
+				"refresh_token": "some-refresh-token"
+			},
+			"statusCode": 200
+		}
+	},
+	{
+		"httpRequest": {
+			"method": "POST",
+			"path": "/api/v1/submissionsupload/file",
+			"queryStringParameters": {
+				"access_token": ["some-access-token"]
+			}
+		},
+		"httpResponse": {
+			"statusCode": 200
+		}
+	}
+]

--- a/packages/applications-service-api/__tests__/unit/middleware/validator/submission.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/validator/submission.test.js
@@ -2,17 +2,18 @@ const {
 	validateCreateSubmissionRequest
 } = require('../../../../src/middleware/validator/submission');
 const { REQUEST_FILE_DATA } = require('../../../__data__/file');
-const {SUBMISSION_CREATE_REQUEST} = require("../../../__data__/submission");
+const { SUBMISSION_CREATE_REQUEST } = require('../../../__data__/submission');
 
-jest.mock("../../../../src/middleware/validator/openapi");
-const validateRequestWithOpenAPIMock = require("../../../../src/middleware/validator/openapi").validateRequestWithOpenAPI;
+jest.mock('../../../../src/middleware/validator/openapi');
+const validateRequestWithOpenAPIMock =
+	require('../../../../src/middleware/validator/openapi').validateRequestWithOpenAPI;
 
 describe('submission request validator', () => {
 	describe('validateCreateSubmissionRequest', () => {
 		const res = jest.fn();
 		const next = jest.fn();
 
-		it('returns error if request does not contain required properties', async () => {
+		it('returns error if request has representation/file but not other required properties defined in openapi spec', async () => {
 			const openAPIValidationError = {
 				code: 400,
 				message: {
@@ -26,11 +27,20 @@ describe('submission request validator', () => {
 				}
 			};
 
-			validateRequestWithOpenAPIMock.mockImplementationOnce(() => { throw openAPIValidationError });
+			validateRequestWithOpenAPIMock.mockImplementationOnce(() => {
+				throw openAPIValidationError;
+			});
 
-			expect(() => validateCreateSubmissionRequest(SUBMISSION_CREATE_REQUEST, res, next)).toThrowError(
-				expect.objectContaining(openAPIValidationError)
-			);
+			expect(() =>
+				validateCreateSubmissionRequest(
+					{
+						...SUBMISSION_CREATE_REQUEST,
+						body: { representation: 'something' }
+					},
+					res,
+					next
+				)
+			).toThrowError(expect.objectContaining(openAPIValidationError));
 		});
 
 		it('returns error if request does not representation or file', async () => {

--- a/packages/applications-service-api/src/middleware/validator/submission.js
+++ b/packages/applications-service-api/src/middleware/validator/submission.js
@@ -3,8 +3,6 @@ const ApiError = require('../../error/apiError');
 const { validateRequestWithOpenAPI } = require('./openapi');
 
 const validateCreateSubmissionRequest = (req, res, next) => {
-	validateRequestWithOpenAPI(req, res, next);
-
 	if (!req.body.representation && !req.file) {
 		throw ApiError.badRequest("must have required property 'representation' or 'file'");
 	}
@@ -21,7 +19,7 @@ const validateCreateSubmissionRequest = (req, res, next) => {
 		}
 	}
 
-	next();
+	validateRequestWithOpenAPI(req, res, next);
 };
 
 module.exports = {


### PR DESCRIPTION
- basic mock server with static responses for the NI API calls (fetch token & post file)
- fix bug with POST `/submissions/:caseReference` where validation occurred after request had been completed (`ERR_HTTP_HEADERS_SENT` error, introduced by refactoring in #505 )