### PR TITLE
feat(submission-complete): create new submission complete page

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/examination/process-submission/controller.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/process-submission/controller.test.js
@@ -8,12 +8,19 @@ const {
 const {
 	handleProcessSubmission
 } = require('../../../../../src/controllers/examination/process-submission/utils/process');
+const {
+	deleteExaminationSession
+} = require('../../../../../src/controllers/examination/session/delete-examination-session');
 
 jest.mock('../../../../../src/controllers/examination/session/examination-session', () => ({
 	setExaminationUploadingState: jest.fn()
 }));
 jest.mock('../../../../../src/controllers/examination/process-submission/utils/process', () => ({
 	handleProcessSubmission: jest.fn()
+}));
+
+jest.mock('../../../../../src/controllers/examination/session/delete-examination-session', () => ({
+	deleteExaminationSession: jest.fn()
 }));
 describe('examination/process-submission/controller', () => {
 	describe('#getProcessSubmission', () => {
@@ -70,6 +77,9 @@ describe('examination/process-submission/controller', () => {
 				});
 				it('should handle the submission', () => {
 					expect(handleProcessSubmission).toHaveBeenCalledWith(req.session);
+				});
+				it('should delete the examination journey from session', () => {
+					expect(deleteExaminationSession).toHaveBeenCalledWith(req.session);
 				});
 				it('should redirect', () => {
 					expect(res.redirect).toHaveBeenCalledWith('/examination/submission-complete');

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/process-submission/utils/process.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/process-submission/utils/process.test.js
@@ -60,17 +60,17 @@ describe('#process', () => {
 				expectFormDataToBeUndefined(form, 4);
 			});
 
-			it('should submit the second submission item without a submission id', () => {
+			it('should submit the second submission item with a submission id', () => {
 				expect(postSubmission).toHaveBeenNthCalledWith(2, expectedUrl, form2);
 				expectFormDataKeyValue(form2, 'submissionId', '1234', 3);
 			});
 
-			it('should submit the third submission item without a submission id', () => {
+			it('should submit the third submission item with a submission id', () => {
 				expect(postSubmission).toHaveBeenNthCalledWith(3, expectedUrl, form3);
 				expectFormDataKeyValue(form3, 'submissionId', '1234', 3);
 			});
 
-			it('should submit the forth submission item without a submission id', () => {
+			it('should submit the forth submission item with a submission id', () => {
 				expect(postSubmission).toHaveBeenNthCalledWith(4, expectedUrl, form4);
 				expectFormDataKeyValue(form4, 'submissionId', '1234', 3);
 			});

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/session/delete-examination-session.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/session/delete-examination-session.test.js
@@ -1,0 +1,42 @@
+const {
+	deleteExaminationSession
+} = require('../../../../../src/controllers/examination/session/delete-examination-session');
+const {
+	getExaminationSession
+} = require('../../../../../src/controllers/examination/session/examination-session');
+
+jest.mock('../../../../../src/controllers/examination/session/examination-session', () => ({
+	getExaminationSession: jest.fn()
+}));
+
+describe('#deleteExaminationSession', () => {
+	describe('when deleting the examination session ', () => {
+		describe('and there are keys required to be kept', () => {
+			const mockSession = {
+				save: jest.fn()
+			};
+			const mockExam = {
+				submissionId: '1234',
+				submissionComplete: true,
+				extra: 'i should be ignored'
+			};
+
+			beforeEach(() => {
+				getExaminationSession.mockReturnValue(mockExam);
+				deleteExaminationSession(mockSession);
+			});
+			it('should save the session', () => {
+				expect(mockSession.save).toHaveBeenCalled();
+			});
+			it('should only keep the required examination session key values', () => {
+				expect(mockSession).toEqual({
+					examination: {
+						submissionId: '1234',
+						submissionComplete: true
+					},
+					save: mockSession.save
+				});
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/session/examination-session.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/session/examination-session.test.js
@@ -4,7 +4,8 @@ const {
 	setExaminationSubmissionComplete,
 	setExaminationSubmissionId,
 	getExaminationUploadingState,
-	getExaminationSubmissionComplete
+	getExaminationSubmissionComplete,
+	getExaminationSubmissionId
 } = require('../../../../../src/controllers/examination/session/examination-session');
 describe('controllers/examination/session/examination-session', () => {
 	describe('#getExaminationSession', () => {
@@ -129,6 +130,15 @@ describe('controllers/examination/session/examination-session', () => {
 				it('should set submission complete to true', () => {
 					expect(mockSession.examination.submissionId).toEqual('1234');
 				});
+			});
+		});
+	});
+	describe('#getExaminationSubmissionId', () => {
+		describe('When getting the submission id', () => {
+			const mockSession = { examination: { submissionId: '1234' } };
+			const result = getExaminationSubmissionId(mockSession);
+			it('should return the value of submission id', () => {
+				expect(result).toEqual('1234');
 			});
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/session/examination-session.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/session/examination-session.test.js
@@ -2,6 +2,7 @@ const {
 	getExaminationSession,
 	setExaminationUploadingState,
 	setExaminationSubmissionComplete,
+	setExaminationSubmissionId,
 	getExaminationUploadingState,
 	getExaminationSubmissionComplete
 } = require('../../../../../src/controllers/examination/session/examination-session');
@@ -113,6 +114,20 @@ describe('controllers/examination/session/examination-session', () => {
 					expect(() => setExaminationSubmissionComplete(mockSession)).toThrow(
 						'Examination submission complete state is not a boolean'
 					);
+				});
+			});
+		});
+	});
+	describe('#setExaminationSubmissionId', () => {
+		describe('When setting the submission Id', () => {
+			describe('and the submission Id 1234', () => {
+				const mockSession = { examination: {} };
+				beforeEach(() => {
+					mockSession.save = jest.fn();
+					setExaminationSubmissionId(mockSession, '1234');
+				});
+				it('should set submission complete to true', () => {
+					expect(mockSession.examination.submissionId).toEqual('1234');
 				});
 			});
 		});

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/submission-complete/controller.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/submission-complete/controller.test.js
@@ -3,32 +3,34 @@ const {
 } = require('../../../../../src/controllers/examination/submission-complete/controller');
 
 const {
-	getExaminationSession
+	getExaminationSubmissionId
 } = require('../../../../../src/controllers/examination/session/examination-session');
+const {
+	getProjectEmailAddress
+} = require('../../../../../src/controllers/session/app-data-session');
 
 jest.mock('../../../../../src/controllers/examination/session/examination-session', () => ({
-	getExaminationSession: jest.fn()
+	getExaminationSubmissionId: jest.fn()
+}));
+
+jest.mock('../../../../../src/controllers/session/app-data-session', () => ({
+	getProjectEmailAddress: jest.fn()
 }));
 
 describe('examination/submission-complete/controller', () => {
 	describe('#getSubmissionComplete', () => {
-		const session = {
-			appData: {
-				ProjectEmailAddress: 'dummy.email@testing.gov.uk'
-			},
-			examination: {
-				submissionId: '1234'
-			}
-		};
+		const session = {};
 		const req = { session };
 		const res = {
 			redirect: jest.fn(),
 			render: jest.fn(),
 			status: jest.fn(() => res)
 		};
+		const mockProjectEmail = 'dummy.email@testing.gov.uk';
 		describe('When getting the submission complete page', () => {
 			beforeEach(() => {
-				getExaminationSession.mockReturnValue(session.examination);
+				getExaminationSubmissionId.mockReturnValue('1234');
+				getProjectEmailAddress.mockReturnValue(mockProjectEmail);
 			});
 			describe('and the page is rendered with submissionId and project email', () => {
 				beforeEach(() => {

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/submission-complete/controller.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/submission-complete/controller.test.js
@@ -27,7 +27,7 @@ describe('examination/submission-complete/controller', () => {
 			status: jest.fn(() => res)
 		};
 		describe('When getting the submission complete page', () => {
-			beforeEach(async () => {
+			beforeEach(() => {
 				getExaminationSession.mockReturnValue(session.examination);
 			});
 			describe('and the page is rendered with submissionId and project email', () => {

--- a/packages/forms-web-app/__tests__/unit/controllers/examination/submission-complete/controller.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/examination/submission-complete/controller.test.js
@@ -1,0 +1,58 @@
+const {
+	getSubmissionComplete
+} = require('../../../../../src/controllers/examination/submission-complete/controller');
+
+const {
+	getExaminationSession
+} = require('../../../../../src/controllers/examination/session/examination-session');
+
+jest.mock('../../../../../src/controllers/examination/session/examination-session', () => ({
+	getExaminationSession: jest.fn()
+}));
+
+describe('examination/submission-complete/controller', () => {
+	describe('#getSubmissionComplete', () => {
+		const session = {
+			appData: {
+				ProjectEmailAddress: 'dummy.email@testing.gov.uk'
+			},
+			examination: {
+				submissionId: '1234'
+			}
+		};
+		const req = { session };
+		const res = {
+			redirect: jest.fn(),
+			render: jest.fn(),
+			status: jest.fn(() => res)
+		};
+		describe('When getting the submission complete page', () => {
+			beforeEach(async () => {
+				getExaminationSession.mockReturnValue(session.examination);
+			});
+			describe('and the page is rendered with submissionId and project email', () => {
+				beforeEach(() => {
+					getSubmissionComplete(req, res);
+				});
+				it('should render the page', () => {
+					expect(res.render).toHaveBeenCalledWith('pages/examination/submission-complete', {
+						submissionId: '1234',
+						projectEmail: 'dummy.email@testing.gov.uk'
+					});
+				});
+			});
+			describe('and there is an error', () => {
+				beforeEach(() => {
+					res.render.mockImplementationOnce(() => {
+						throw new Error('an error');
+					});
+					getSubmissionComplete(req, res);
+				});
+				it('should render the error page', () => {
+					expect(res.status).toHaveBeenCalledWith(500);
+					expect(res.render).toHaveBeenCalledWith('error/unhandled-exception');
+				});
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/controllers/session/app-data-session.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/session/app-data-session.test.js
@@ -1,0 +1,43 @@
+const {
+	getAppDataSession,
+	getProjectEmailAddress
+} = require('../../../../src/controllers/session/app-data-session');
+
+describe('session/app-data-session', () => {
+	describe('#getAppDataSession', () => {
+		describe('When getting the current session app data', () => {
+			describe('and the current app data is available', () => {
+				const mockSession = { appData: 'mock app data' };
+				const result = getAppDataSession(mockSession);
+				it('should return the current view', () => {
+					expect(result).toEqual('mock app data');
+				});
+			});
+			describe('and the app data is NOT available', () => {
+				it('should throw an error', () => {
+					expect(() => getAppDataSession({})).toThrow('No app data in session');
+				});
+			});
+		});
+	});
+
+	describe('#getProjectEmailAddress', () => {
+		describe('When getting the project email address from app data', () => {
+			describe('and the project email address  is available', () => {
+				const mockSession = { appData: { ProjectEmailAddress: 'mock project email' } };
+				const result = getProjectEmailAddress(mockSession);
+				it('should return the current view', () => {
+					expect(result).toEqual('mock project email');
+				});
+			});
+			describe('and the project email address  is NOT available', () => {
+				const mockSession = { appData: {} };
+				it('should throw an error', () => {
+					expect(() => getProjectEmailAddress(mockSession)).toThrow(
+						'No project email address in app data session'
+					);
+				});
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/services/submission.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/submission.service.test.js
@@ -1,41 +1,91 @@
 const fetch = require('node-fetch');
-const { postSubmission } = require('../../../src/services/submission.service');
+const {
+	postSubmission,
+	postSubmissionComplete
+} = require('../../../src/services/submission.service');
 jest.mock('node-fetch', () => jest.fn());
 
-describe('#postSubmission', () => {
-	describe('When submitting a form for a submission', () => {
-		const caseRef = '1234';
-		const body = 'mock body';
-		describe('the post is successful', () => {
-			let response;
-			beforeEach(async () => {
-				fetch.mockResolvedValue({ json: () => ({ mockData: 'mock data' }), ok: true, status: 200 });
-				response = await postSubmission(caseRef, body);
-			});
-			it('should call fecth ', () => {
-				expect(fetch).toHaveBeenCalledWith(
-					'http://applications-service-api:3000/api/v1/submissions/1234',
-					{
-						body: 'mock body',
-						headers: {
-							'X-Correlation-ID': expect.any(String)
-						},
-						method: 'POST'
-					}
-				);
-			});
-			it('should return a body', () => {
-				expect(response).toEqual({ data: { mockData: 'mock data' }, resp_code: 200 });
-			});
-		});
-		describe('there is an error', () => {
-			beforeEach(async () => {
-				fetch.mockImplementation(() => {
-					throw new Error('an error');
+describe('services/submission.service', () => {
+	describe('#postSubmission', () => {
+		describe('When submitting a form for a submission', () => {
+			const caseRef = '1234';
+			const body = 'mock body';
+			describe('the post is successful', () => {
+				let response;
+				beforeEach(async () => {
+					fetch.mockResolvedValue({
+						json: () => ({ mockData: 'mock data' }),
+						ok: true,
+						status: 200
+					});
+					response = await postSubmission(caseRef, body);
+				});
+				it('should call fecth ', () => {
+					expect(fetch).toHaveBeenCalledWith(
+						'http://applications-service-api:3000/api/v1/submissions/1234',
+						{
+							body: 'mock body',
+							headers: {
+								'X-Correlation-ID': expect.any(String)
+							},
+							method: 'POST'
+						}
+					);
+				});
+				it('should return a body', () => {
+					expect(response).toEqual({ data: { mockData: 'mock data' }, resp_code: 200 });
 				});
 			});
-			it('should throw an error', async () => {
-				await expect(postSubmission()).rejects.toThrow('an error');
+			describe('there is an error', () => {
+				beforeEach(async () => {
+					fetch.mockImplementation(() => {
+						throw new Error('an error');
+					});
+				});
+				it('should throw an error', async () => {
+					await expect(postSubmission()).rejects.toThrow('an error');
+				});
+			});
+		});
+	});
+	describe('#postSubmissionComplete', () => {
+		describe('When submitting to submission compete', () => {
+			const submissionsId = '1234';
+			describe('the post is successful', () => {
+				let response;
+				beforeEach(async () => {
+					fetch.mockResolvedValue({
+						ok: true,
+						status: 204
+					});
+					response = await postSubmissionComplete(submissionsId);
+				});
+				it('should call fecth ', () => {
+					expect(fetch).toHaveBeenCalledWith(
+						'http://applications-service-api:3000/api/v1/submissions/1234/complete',
+						{
+							headers: {
+								'X-Correlation-ID': expect.any(String)
+							},
+							method: 'POST'
+						}
+					);
+				});
+				it('should return a body', () => {
+					expect(response).toEqual({ resp_code: 204 });
+				});
+			});
+			describe('there is an error', () => {
+				beforeEach(async () => {
+					fetch.mockImplementation(() => {
+						throw new Error('an error');
+					});
+				});
+				it('should throw an error', async () => {
+					await expect(postSubmissionComplete()).rejects.toThrow(
+						'Submission Complete request failed'
+					);
+				});
 			});
 		});
 	});

--- a/packages/forms-web-app/src/controllers/examination/process-submission/controller.js
+++ b/packages/forms-web-app/src/controllers/examination/process-submission/controller.js
@@ -10,6 +10,7 @@ const {
 } = require('../../../routes/config');
 const { handleProcessSubmission } = require('./utils/process');
 const { setExaminationUploadingState } = require('../session/examination-session');
+const { deleteExaminationSession } = require('../session/delete-examination-session');
 
 const getProcessSubmission = (req, res) => {
 	try {
@@ -30,6 +31,7 @@ const postProcessSubmission = async (req, res) => {
 		const { session } = req;
 		setExaminationUploadingState(session, true);
 		await handleProcessSubmission(session);
+		deleteExaminationSession(session);
 		return res.redirect(`${directory}${submissionComplete.route}`);
 	} catch (error) {
 		logger.error(error);

--- a/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
+++ b/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
@@ -27,7 +27,6 @@ const handleProcessSubmission = async (session) => {
 		logger.info('Processing files complete');
 		setExaminationSubmissionComplete(session, true);
 		setExaminationSubmissionId(session, submissionId);
-
 		await postSubmissionComplete(submissionId);
 	} catch (error) {
 		logger.error(error);

--- a/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
+++ b/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
@@ -28,19 +28,10 @@ const handleProcessSubmission = async (session) => {
 		setExaminationSubmissionComplete(session, true);
 		setExaminationSubmissionId(session, submissionId);
 
-		await submissionComplete(submissionId);
-	} catch (error) {
-		logger.error(error);
-		throw new Error('Process Submission failed');
-	}
-};
-
-const submissionComplete = async (submissionId) => {
-	try {
 		await postSubmissionComplete(submissionId);
 	} catch (error) {
 		logger.error(error);
-		throw new Error('Submission Complete request failed');
+		throw new Error('Process Submission failed');
 	}
 };
 

--- a/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
+++ b/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
@@ -20,6 +20,8 @@ const handleProcessSubmission = async (session) => {
 			}
 		}
 		logger.info('Processing files complete');
+		examinationSession.submissionId = submissionId;
+
 		setExaminationSubmissionComplete(session, true);
 	} catch (error) {
 		logger.error(error);

--- a/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
+++ b/packages/forms-web-app/src/controllers/examination/process-submission/utils/process.js
@@ -1,8 +1,13 @@
 const logger = require('../../../../lib/logger');
-const { postSubmission } = require('../../../../services/submission.service');
+const {
+	postSubmission,
+	postSubmissionComplete
+} = require('../../../../services/submission.service');
+
 const { getListOfFormData } = require('./fromDataMappers');
 const {
 	setExaminationSubmissionComplete,
+	setExaminationSubmissionId,
 	getExaminationSession
 } = require('../../session/examination-session');
 
@@ -20,12 +25,22 @@ const handleProcessSubmission = async (session) => {
 			}
 		}
 		logger.info('Processing files complete');
-		examinationSession.submissionId = submissionId;
-
 		setExaminationSubmissionComplete(session, true);
+		setExaminationSubmissionId(session, submissionId);
+
+		await submissionComplete(submissionId);
 	} catch (error) {
 		logger.error(error);
 		throw new Error('Process Submission failed');
+	}
+};
+
+const submissionComplete = async (submissionId) => {
+	try {
+		await postSubmissionComplete(submissionId);
+	} catch (error) {
+		logger.error(error);
+		throw new Error('Submission Complete request failed');
 	}
 };
 

--- a/packages/forms-web-app/src/controllers/examination/session/delete-examination-session.js
+++ b/packages/forms-web-app/src/controllers/examination/session/delete-examination-session.js
@@ -1,0 +1,23 @@
+const logger = require('../../../lib/logger');
+const { getExaminationSession } = require('./examination-session');
+
+const examinationKey = 'examination';
+
+const deleteExaminationSession = (session) => {
+	const { submissionId, submissionComplete } = getExaminationSession(session);
+	const keep = {
+		submissionId,
+		submissionComplete
+	};
+
+	delete session[examinationKey];
+	session[examinationKey] = keep;
+
+	session.save(function (err) {
+		if (err) logger.error(err);
+	});
+};
+
+module.exports = {
+	deleteExaminationSession
+};

--- a/packages/forms-web-app/src/controllers/examination/session/examination-session.js
+++ b/packages/forms-web-app/src/controllers/examination/session/examination-session.js
@@ -32,6 +32,12 @@ const setExaminationSubmissionComplete = (session, state) => {
 	});
 };
 
+const setExaminationSubmissionId = (session, submissionId) => {
+	const examinationSession = getExaminationSession(session);
+
+	examinationSession.submissionId = submissionId;
+};
+
 const getExaminationSubmissionComplete = (session) => {
 	const examinationSession = getExaminationSession(session);
 	return examinationSession.submissionComplete;
@@ -41,6 +47,7 @@ module.exports = {
 	getExaminationSession,
 	setExaminationUploadingState,
 	setExaminationSubmissionComplete,
+	setExaminationSubmissionId,
 	getExaminationSubmissionComplete,
 	getExaminationUploadingState
 };

--- a/packages/forms-web-app/src/controllers/examination/session/examination-session.js
+++ b/packages/forms-web-app/src/controllers/examination/session/examination-session.js
@@ -43,11 +43,17 @@ const getExaminationSubmissionComplete = (session) => {
 	return examinationSession.submissionComplete;
 };
 
+const getExaminationSubmissionId = (session) => {
+	const examinationSession = getExaminationSession(session);
+	return examinationSession.submissionId;
+};
+
 module.exports = {
 	getExaminationSession,
 	setExaminationUploadingState,
 	setExaminationSubmissionComplete,
 	setExaminationSubmissionId,
 	getExaminationSubmissionComplete,
-	getExaminationUploadingState
+	getExaminationUploadingState,
+	getExaminationSubmissionId
 };

--- a/packages/forms-web-app/src/controllers/examination/submission-complete/controller.js
+++ b/packages/forms-web-app/src/controllers/examination/submission-complete/controller.js
@@ -1,4 +1,4 @@
-const { getExaminationSession } = require('../session/examination-session');
+const { getExaminationSubmissionId } = require('../session/examination-session');
 
 const {
 	routesConfig: {
@@ -8,15 +8,15 @@ const {
 	}
 } = require('../../../routes/config');
 const logger = require('../../../lib/logger');
+const { getProjectEmailAddress } = require('../../session/app-data-session');
 
 const getSubmissionComplete = (req, res) => {
 	try {
 		const { session } = req;
-		const examinationSession = getExaminationSession(session);
 
 		const pageData = {
-			submissionId: examinationSession.submissionId,
-			projectEmail: session.appData.ProjectEmailAddress
+			submissionId: getExaminationSubmissionId(session),
+			projectEmail: getProjectEmailAddress(session)
 		};
 
 		return res.render(submissionComplete.view, pageData);

--- a/packages/forms-web-app/src/controllers/examination/submission-complete/controller.js
+++ b/packages/forms-web-app/src/controllers/examination/submission-complete/controller.js
@@ -1,3 +1,5 @@
+const { getExaminationSession } = require('../session/examination-session');
+
 const {
 	routesConfig: {
 		examination: {
@@ -5,9 +7,23 @@ const {
 		}
 	}
 } = require('../../../routes/config');
+const logger = require('../../../lib/logger');
 
 const getSubmissionComplete = (req, res) => {
-	return res.render(submissionComplete.view);
+	try {
+		const { session } = req;
+		const examinationSession = getExaminationSession(session);
+
+		const pageData = {
+			submissionId: examinationSession.submissionId,
+			projectEmail: session.appData.ProjectEmailAddress
+		};
+
+		return res.render(submissionComplete.view, pageData);
+	} catch (error) {
+		logger.error(error);
+		return res.status(500).render('error/unhandled-exception');
+	}
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/controllers/session/app-data-session.js
+++ b/packages/forms-web-app/src/controllers/session/app-data-session.js
@@ -1,0 +1,17 @@
+const getAppDataSession = (session) => {
+	const appData = session?.appData;
+	if (!appData) throw new Error('No app data in session');
+	return appData;
+};
+
+const getProjectEmailAddress = (session) => {
+	const appDataSession = getAppDataSession(session);
+	if (!appDataSession.ProjectEmailAddress)
+		throw new Error('No project email address in app data session');
+	return appDataSession.ProjectEmailAddress;
+};
+
+module.exports = {
+	getAppDataSession,
+	getProjectEmailAddress
+};

--- a/packages/forms-web-app/src/lib/application-api-wrapper.js
+++ b/packages/forms-web-app/src/lib/application-api-wrapper.js
@@ -61,6 +61,10 @@ async function handler(callingMethod, path, method = 'GET', opts = {}, headers =
 				if (callingMethod === 'putComments') {
 					return apiResponse;
 				}
+
+				if (apiResponse.status === 204) {
+					return { resp_code: apiResponse.status };
+				}
 				const data = await apiResponse.json();
 				logger.debug(`Response received: ${JSON.stringify(data)}`);
 				const wrappedResp = { data, resp_code: apiResponse.status };
@@ -152,4 +156,10 @@ exports.wrappedPostSubmission = async (caseRef, body) => {
 	return handler('postSubmission', URL, method, {
 		body
 	});
+};
+
+exports.wrappedPostSubmissionComplete = async (submissionId) => {
+	const URL = `/api/v1/submissions/${submissionId}/complete`;
+	const method = 'POST';
+	return handler('postSubmissionComplete', URL, method, {});
 };

--- a/packages/forms-web-app/src/services/submission.service.js
+++ b/packages/forms-web-app/src/services/submission.service.js
@@ -1,7 +1,14 @@
-const { wrappedPostSubmission } = require('../lib/application-api-wrapper');
+const {
+	wrappedPostSubmission,
+	wrappedPostSubmissionComplete
+} = require('../lib/application-api-wrapper');
 
 const postSubmission = async (caseRef, body) => wrappedPostSubmission(caseRef, body);
 
+const postSubmissionComplete = async (submissionsId) =>
+	wrappedPostSubmissionComplete(submissionsId);
+
 module.exports = {
-	postSubmission
+	postSubmission,
+	postSubmissionComplete
 };

--- a/packages/forms-web-app/src/services/submission.service.js
+++ b/packages/forms-web-app/src/services/submission.service.js
@@ -2,11 +2,18 @@ const {
 	wrappedPostSubmission,
 	wrappedPostSubmissionComplete
 } = require('../lib/application-api-wrapper');
+const logger = require('../lib/logger');
 
 const postSubmission = async (caseRef, body) => wrappedPostSubmission(caseRef, body);
 
-const postSubmissionComplete = async (submissionsId) =>
-	wrappedPostSubmissionComplete(submissionsId);
+const postSubmissionComplete = async (submissionsId) => {
+	try {
+		return await wrappedPostSubmissionComplete(submissionsId);
+	} catch (error) {
+		logger.error(error);
+		throw new Error('Submission Complete request failed');
+	}
+};
 
 module.exports = {
 	postSubmission,

--- a/packages/forms-web-app/src/views/pages/examination/submission-complete.njk
+++ b/packages/forms-web-app/src/views/pages/examination/submission-complete.njk
@@ -1,1 +1,53 @@
-<h1> You made it</h1>
+{% extends "layouts/default.njk" %}
+
+{% block pageTitle %}
+	Submission Complete
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">Submission Complete</h1>
+        <div class="govuk-panel__body">
+          Your reference number<br>
+          <strong>{{ submissionId }}</strong>
+        </div>
+      </div>
+
+      <p class="govuk-body">We've sent a confirmation email to confirm we have received your submission.</p>
+
+			<h3 class="govuk-heading-m">Contact us</h3>
+      <h4 class="govuk-heading-s">Telephone </h4>
+      <p>If you have an interested party number, have it with you when you call.</p>
+
+			<p class="govuk-body">Telephone: 0303 444 5000
+				<br>
+				Monday to Friday, 9am to 12pm (except public holidays)
+			</p>
+
+			<h4 class="govuk-heading-s">Email </h4>
+			<p class="govuk-body">
+				<a id="project-email-link" href="{{ projectEmail }}" class="govuk-link"> {{ projectEmail }} </a>
+			</p>
+			<p class="govuk-body">
+				When you're writing an email, quote the name of the project in the subject line.
+			</p>
+			<p class="govuk-body">
+				We aim to respond within 10 working days.
+			</p>
+
+			<h4 class="govuk-heading-s">Alternative formats </h4>
+			<p class="govuk-body">
+				Call or email to ask for project documents in alternative formats such as PDF, large print, easy read, audio recording or braille.
+			</p>
+			<p class="govuk-body">
+				<a href="{{ serviceFeedbackUrl }}" class="govuk-link">What did you think of this service?</a> (takes 3 seconds)
+			</p>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
Added new page for submission complete.

- The submissionId has been added to the examinationSession data
- There is an assumption that project email and submissionId will be available.  Page will still be rendered without them as we don't want to fail the process at this stage.