### PR TITLE
feat(applications-service-api): add filter label to document v3 response

### DIFF
--- a/packages/applications-service-api/__tests__/__data__/documents.js
+++ b/packages/applications-service-api/__tests__/__data__/documents.js
@@ -3,7 +3,7 @@ const DB_DOCUMENTS = [
 		id: 1052,
 		dataID: 'EN010085-002134',
 		case_reference: 'EN010085',
-		Stage: 7,
+		stage: 7,
 		type: 'Correction Order',
 		filter_1: 'Plans',
 		filter_2: 'Correction Order',
@@ -29,7 +29,7 @@ const DB_DOCUMENTS = [
 		id: 1053,
 		dataID: 'EN010085-002133',
 		case_reference: 'EN010085',
-		Stage: 7,
+		stage: 7,
 		type: 'Correction Notice',
 		filter_1: 'Decided',
 		filter_2: 'Correction Notice',
@@ -55,7 +55,7 @@ const DB_DOCUMENTS = [
 		id: 365,
 		dataID: 'EN010085-000925',
 		case_reference: 'EN010085',
-		Stage: 4,
+		stage: 4,
 		type: 'Recording of hearing',
 		filter_1: 'Recording of hearing',
 		filter_2: null,
@@ -80,7 +80,7 @@ const DB_DOCUMENTS = [
 		id: 329,
 		dataID: 'EN010085-001882',
 		case_reference: 'EN010085',
-		Stage: 0,
+		stage: 1,
 		type: 'Application Form',
 		filter_1: null,
 		filter_2: null,
@@ -185,7 +185,7 @@ const RESPONSE_DOCUMENTS = [
 		id: 329,
 		dataId: 'EN010085-001882',
 		caseReference: 'EN010085',
-		stage: 0,
+		stage: 1,
 		type: 'Application Form',
 		filter1: null,
 		filter2: null,
@@ -209,7 +209,7 @@ const RESPONSE_DOCUMENTS = [
 ];
 
 const DB_FILTERS = [
-	{ stage: 0, filter_1: 'Application Form', category: "Developer's Application", count: 1 },
+	{ stage: 1, filter_1: 'Application Form', category: "Developer's Application", count: 1 },
 	{ stage: 4, filter_1: 'Recording of hearing', category: null, count: 1 },
 	{ stage: 7, filter_1: 'Plans', category: null, count: 1 },
 	{ stage: 7, filter_1: 'Decided', category: null, count: 1 }
@@ -218,9 +218,9 @@ const DB_FILTERS = [
 const RESPONSE_FILTERS = [
 	{
 		name: 'stage',
-		value: 0,
+		value: 1,
 		count: 1,
-		label: undefined,
+		label: 'Pre-application',
 		type: [{ value: 'Application Form', count: 1 }]
 	},
 	{

--- a/packages/applications-service-api/__tests__/__data__/documents.js
+++ b/packages/applications-service-api/__tests__/__data__/documents.js
@@ -220,18 +220,21 @@ const RESPONSE_FILTERS = [
 		name: 'stage',
 		value: 0,
 		count: 1,
+		label: undefined,
 		type: [{ value: 'Application Form', count: 1 }]
 	},
 	{
 		name: 'stage',
 		value: 4,
 		count: 1,
+		label: 'Examination',
 		type: [{ value: 'Recording of hearing', count: 1 }]
 	},
 	{
 		name: 'stage',
 		value: 7,
 		count: 2,
+		label: 'Post-decision',
 		type: [
 			{ value: 'Plans', count: 1 },
 			{ value: 'Decided', count: 1 }
@@ -240,6 +243,7 @@ const RESPONSE_FILTERS = [
 	{
 		name: 'category',
 		value: "Developer's Application",
+		label: "Developer's Application",
 		count: 1,
 		type: [{ value: 'Application Form', count: 1 }]
 	}

--- a/packages/applications-service-api/__tests__/unit/services/document.v3.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/document.v3.service.test.js
@@ -146,6 +146,33 @@ describe('documentV3 service', () => {
 			});
 		});
 
+		it('calls query api without filter_1 if filter does not include type', async () => {
+			await fetchDocuments({
+				caseReference: 'EN010085',
+				page: 1,
+				filters: [
+					{
+						name: 'stage',
+						value: 1
+					}
+				]
+			});
+
+			expect(mockFindAndCountAll).toBeCalledWith({
+				limit: 20,
+				offset: 0,
+				order: [['date_published', 'DESC']],
+				where: {
+					[Op.and]: [
+						{ case_reference: 'EN010085' },
+						{
+							[Op.or]: [{ stage: 1 }]
+						}
+					]
+				}
+			});
+		});
+
 		it('sets correct offset when page number >1 is requested', async () => {
 			await fetchDocuments({
 				caseReference: 'EN010085',

--- a/packages/applications-service-api/__tests__/unit/services/document.v3.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/document.v3.service.test.js
@@ -193,8 +193,15 @@ describe('documentV3 service', () => {
 
 			const result = await getAvailableFilters('EN010085');
 
-			const mockFindAllCall = mockFindAll.mock.calls[0][0];
-			expect(mockFindAllCall.where[Op.and][0].case_reference).toEqual('EN010085');
+			const mockInvocation = mockFindAll.mock.calls[0][0];
+
+			expect(mockInvocation.where).toEqual({
+				[Op.and]: [
+					{ case_reference: 'EN010085' },
+					{ stage: { [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: 0 }] } },
+					{ filter_1: { [Op.ne]: null } }
+				]
+			});
 
 			expect(result).toEqual(DB_FILTERS);
 		});

--- a/packages/applications-service-api/__tests__/unit/utils/documentFilterLabelMapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/documentFilterLabelMapper.test.js
@@ -1,0 +1,21 @@
+const { mapDocumentFilterLabel } = require('../../../src/utils/documentFilterLabelMapper');
+
+describe('mapDocumentFilterLabel', () => {
+	it.each([
+		['stage', 1, 'Pre-application'],
+		['stage', 2, 'Acceptance'],
+		['stage', 3, 'Pre-examination'],
+		['stage', 4, 'Examination'],
+		['stage', 5, 'Recommendation'],
+		['stage', 6, 'Decision'],
+		['stage', 7, 'Post-decision'],
+		['category', "Developer's Application", "Developer's Application"],
+		['non-existent-filter', 'someValue', 'someValue'],
+		['stage', 99999, undefined]
+	])(
+		'given filter name %s and value %s, returns label %s',
+		(filterName, filterValue, expectedLabel) => {
+			expect(mapDocumentFilterLabel(filterName, filterValue)).toEqual(expectedLabel);
+		}
+	);
+});

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -840,6 +840,9 @@ components:
           items:
             $ref: '#/components/schemas/DocumentV3RequestFilter'
     DocumentV3RequestFilter:
+      required:
+        - name
+        - value
       properties:
         name:
           type: string

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -895,6 +895,10 @@ components:
           type: string
           example: 1
           description: Value of property to filter by
+        label:
+          type: string
+          example: Pre-application
+          description: Display name for the filter value
         count:
           type: number
           example: 5

--- a/packages/applications-service-api/src/controllers/documents.v3.js
+++ b/packages/applications-service-api/src/controllers/documents.v3.js
@@ -1,6 +1,7 @@
 const { fetchDocuments, getAvailableFilters } = require('../services/document.v3.service');
 const config = require('../lib/config');
 const toCamelCase = require('lodash.camelcase');
+const { mapDocumentFilterLabel } = require('../utils/documentFilterLabelMapper');
 
 const getDocuments = async (req, res) => {
 	const requestFilters = {
@@ -46,6 +47,7 @@ const mapFilters = (input) => {
 			filterGroup[filterValue] = {
 				name: filterName,
 				value: filterValue,
+				label: mapDocumentFilterLabel(filterName, filterValue),
 				count: 0,
 				type: []
 			};
@@ -69,18 +71,8 @@ const mapFilters = (input) => {
 		{ stages: {}, categories: {} }
 	);
 
-	const formatFiltersForResponse = (filters, filterName) =>
-		Object.values(filters).map((filter) => {
-			return {
-				name: filterName,
-				value: filter.value,
-				count: filter.count,
-				type: filter.type
-			};
-		});
-
-	const stageFilters = formatFiltersForResponse(groupedFilters.stages, 'stage');
-	const categoryFilters = formatFiltersForResponse(groupedFilters.categories, 'category');
+	const stageFilters = Object.values(groupedFilters.stages);
+	const categoryFilters = Object.values(groupedFilters.categories);
 
 	return stageFilters.concat(categoryFilters);
 };

--- a/packages/applications-service-api/src/services/document.v3.service.js
+++ b/packages/applications-service-api/src/services/document.v3.service.js
@@ -33,7 +33,7 @@ const getAvailableFilters = async (caseReference) => {
 		where: {
 			[Op.and]: [
 				{ case_reference: caseReference },
-				{ stage: { [Op.ne]: null } },
+				{ stage: { [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: 0 }] } },
 				{ filter_1: { [Op.ne]: null } }
 			]
 		},

--- a/packages/applications-service-api/src/services/document.v3.service.js
+++ b/packages/applications-service-api/src/services/document.v3.service.js
@@ -69,7 +69,8 @@ const mapFiltersToQuery = (filters) => {
 	if (filters) {
 		const filtersQuery = filters.map((filter) => {
 			let filterStatement = { [filter.name]: filter.value };
-			if (filter.type) filterStatement['filter_1'] = filter.type.map((type) => type.value);
+			if (filter.type && filter.type.length > 0)
+				filterStatement['filter_1'] = filter.type.map((type) => type.value);
 			return filterStatement;
 		});
 		if (filtersQuery.length > 0) return { [Op.or]: filtersQuery };

--- a/packages/applications-service-api/src/utils/documentFilterLabelMapper.js
+++ b/packages/applications-service-api/src/utils/documentFilterLabelMapper.js
@@ -1,0 +1,24 @@
+const mapDocumentFilterLabel = (filterName, filterValue) => {
+	try {
+		return {
+			stage: {
+				1: 'Pre-application',
+				2: 'Acceptance',
+				3: 'Pre-examination',
+				4: 'Examination',
+				5: 'Recommendation',
+				6: 'Decision',
+				7: 'Post-decision'
+			},
+			category: {
+				"Developer's Application": "Developer's Application"
+			}
+		}[filterName][filterValue];
+	} catch (e) {
+		return filterValue;
+	}
+};
+
+module.exports = {
+	mapDocumentFilterLabel
+};


### PR DESCRIPTION
- exclude stage 0 from filters
- add label to document v3 filter response
- fix error when document filter type is empty array
- (openapi) make value and name required for /v3/documents request filter