### PR TITLE
fix(application-api-wrapper.js): default the content header type 

### DIFF
--- a/packages/forms-web-app/__tests__/unit/services/submission.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/submission.service.test.js
@@ -20,7 +20,7 @@ describe('services/submission.service', () => {
 					});
 					response = await postSubmission(caseRef, body);
 				});
-				it('should call fecth ', () => {
+				it('should call fetch ', () => {
 					expect(fetch).toHaveBeenCalledWith(
 						'http://applications-service-api:3000/api/v1/submissions/1234',
 						{
@@ -65,6 +65,7 @@ describe('services/submission.service', () => {
 						'http://applications-service-api:3000/api/v1/submissions/1234/complete',
 						{
 							headers: {
+								'Content-Type': 'application/json',
 								'X-Correlation-ID': expect.any(String)
 							},
 							method: 'POST'

--- a/packages/forms-web-app/src/lib/application-api-wrapper.js
+++ b/packages/forms-web-app/src/lib/application-api-wrapper.js
@@ -7,7 +7,13 @@ const { queryStringBuilder } = require('../utils/query-string-builder');
 const config = require('../config');
 const parentLogger = require('./logger');
 
-async function handler(callingMethod, path, method = 'GET', opts = {}, headers = {}) {
+async function handler(
+	callingMethod,
+	path,
+	method = 'GET',
+	opts = {},
+	headers = { 'Content-Type': 'application/json' }
+) {
 	const correlationId = uuid.v4();
 	const url = `${config.applications.url}${path}`;
 
@@ -153,9 +159,15 @@ exports.getTimetables = async (caseRef) =>
 exports.wrappedPostSubmission = async (caseRef, body) => {
 	const URL = `/api/v1/submissions/${caseRef}`;
 	const method = 'POST';
-	return handler('postSubmission', URL, method, {
-		body
-	});
+	return handler(
+		'postSubmission',
+		URL,
+		method,
+		{
+			body
+		},
+		{}
+	);
 };
 
 exports.wrappedPostSubmissionComplete = async (submissionId) => {


### PR DESCRIPTION
The API handler had the content type removed as we were sending multi-part data for the new submission endpoint.
This broke the interested party endpoint as the string body was not being interpreted as JSON. 

This change defaults the content type to JSON and allows us to override with {} in the submission call in the wrapper.