### PR TITLE
fix(applications-service-api): make category label lookup case insensitive

### DIFF
--- a/packages/applications-service-api/__tests__/unit/utils/documentFilterLabelMapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/documentFilterLabelMapper.test.js
@@ -10,6 +10,10 @@ describe('mapDocumentFilterLabel', () => {
 		['stage', 6, 'Decision'],
 		['stage', 7, 'Post-decision'],
 		['category', "Developer's Application", "Developer's Application"],
+		['category', "Developer's application", "Developer's Application"],
+		['category', 'developers_application', "Developer's Application"],
+		['category', 'other', 'other'],
+		['category', 'None', 'None'],
 		['non-existent-filter', 'someValue', 'someValue'],
 		['stage', 99999, undefined]
 	])(

--- a/packages/applications-service-api/src/utils/documentFilterLabelMapper.js
+++ b/packages/applications-service-api/src/utils/documentFilterLabelMapper.js
@@ -1,19 +1,27 @@
 const mapDocumentFilterLabel = (filterName, filterValue) => {
+	const mapping = {
+		stage: {
+			1: 'Pre-application',
+			2: 'Acceptance',
+			3: 'Pre-examination',
+			4: 'Examination',
+			5: 'Recommendation',
+			6: 'Decision',
+			7: 'Post-decision'
+		},
+		category: {
+			developersapplication: "Developer's Application"
+		}
+	};
+
+	const normaliseKey = (key) => key.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
+
 	try {
-		return {
-			stage: {
-				1: 'Pre-application',
-				2: 'Acceptance',
-				3: 'Pre-examination',
-				4: 'Examination',
-				5: 'Recommendation',
-				6: 'Decision',
-				7: 'Post-decision'
-			},
-			category: {
-				"Developer's Application": "Developer's Application"
-			}
-		}[filterName][filterValue];
+		if (filterName === 'category') {
+			return mapping[filterName][normaliseKey(filterValue)] || filterValue;
+		}
+
+		return mapping[filterName][filterValue];
 	} catch (e) {
 		return filterValue;
 	}


### PR DESCRIPTION
the naming of "Developer's Application" in the DB is a bit inconsistent (at least on the test env DBs). This PR makes the label lookup code a bit more robust and dealing with such occurences

- looks up label name for `category` in a case insensitive way and provide a fallback value if no mapping found