### PR TITLE
fix(applications-service-api): add secondary sort column for document v3 lookup

### DIFF
--- a/packages/applications-service-api/__tests__/unit/services/document.v3.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/document.v3.service.test.js
@@ -18,6 +18,12 @@ describe('documentV3 service', () => {
 	beforeEach(() => jest.resetAllMocks());
 
 	describe('fetchDocuments', () => {
+		const expectedQuery = {
+			limit: 20,
+			offset: 0,
+			order: [['date_published', 'DESC'], ['id']]
+		};
+
 		beforeEach(() => {
 			mockFindAndCountAll.mockResolvedValueOnce({
 				count: 4,
@@ -32,9 +38,7 @@ describe('documentV3 service', () => {
 			});
 
 			expect(mockFindAndCountAll).toBeCalledWith({
-				limit: 20,
-				offset: 0,
-				order: [['date_published', 'DESC']],
+				...expectedQuery,
 				where: {
 					[Op.and]: [{ case_reference: 'EN010085' }]
 				}
@@ -65,9 +69,7 @@ describe('documentV3 service', () => {
 			});
 
 			expect(mockFindAndCountAll).toBeCalledWith({
-				limit: 20,
-				offset: 0,
-				order: [['date_published', 'DESC']],
+				...expectedQuery,
 				where: {
 					[Op.and]: [
 						{ case_reference: 'EN010085' },
@@ -90,9 +92,7 @@ describe('documentV3 service', () => {
 			});
 
 			expect(mockFindAndCountAll).toBeCalledWith({
-				limit: 20,
-				offset: 0,
-				order: [['date_published', 'DESC']],
+				...expectedQuery,
 				where: {
 					[Op.and]: [
 						{ case_reference: 'EN010085' },
@@ -124,9 +124,7 @@ describe('documentV3 service', () => {
 			});
 
 			expect(mockFindAndCountAll).toBeCalledWith({
-				limit: 20,
-				offset: 0,
-				order: [['date_published', 'DESC']],
+				...expectedQuery,
 				where: {
 					[Op.and]: [
 						{ case_reference: 'EN010085' },
@@ -159,9 +157,7 @@ describe('documentV3 service', () => {
 			});
 
 			expect(mockFindAndCountAll).toBeCalledWith({
-				limit: 20,
-				offset: 0,
-				order: [['date_published', 'DESC']],
+				...expectedQuery,
 				where: {
 					[Op.and]: [
 						{ case_reference: 'EN010085' },

--- a/packages/applications-service-api/src/services/document.v3.service.js
+++ b/packages/applications-service-api/src/services/document.v3.service.js
@@ -9,7 +9,7 @@ const fetchDocuments = async (requestQuery) => {
 
 	const dbQuery = {
 		where,
-		order: [['date_published', 'DESC']],
+		order: [['date_published', 'DESC'], ['id']],
 		offset,
 		limit: config.itemsPerPage
 	};


### PR DESCRIPTION
- adds `id` as a secondary sort column on the SELECT query which retrieves documents from the database
- this fixes an issue where results were inconsistent between queries due to documents having the same published date