### PR TITLE
feat(forms-web-app): redis cache config set up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
   redis:
     image: redis:6.2.5-alpine
     container_name: redis
+    command: redis-server --requirepass some_redis_password
     ports:
       - 6379:6379
 
@@ -83,7 +84,7 @@ services:
       HOST_URL: http://localhost:9004/
       PDF_SERVICE_API_URL: http://pdf-service-api:3000
       PRIVATE_BETA_V1_ROUTES_ONLY: 'false'
-      REDIS_URL: redis://redis:6379
+      REDIS_CONNECTION_STRING: redis:6379,password=some_redis_password,ssl=False,abortConnect=False
       SESSION_KEY: some_secure_key_goes_here
       # please override this locally if using not using localhost or ip address to browse the site in dev.
       SUBDOMAIN_OFFSET: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -3024,6 +3024,59 @@
 				"pino": "^6.7.0"
 			}
 		},
+		"node_modules/@redis/bloom": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.1.0.tgz",
+			"integrity": "sha512-9QovlxmpRtvxVbN0UBcv8WfdSMudNZZTFqCsnBszcQXqaZb/TVe30ScgGEO7u1EAIacTPAo7/oCYjYAxiHLanQ==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/client": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-1.4.2.tgz",
+			"integrity": "sha512-oUdEjE0I7JS5AyaAjkD3aOXn9NhO7XKyPyXEyrgFDu++VrVBHUPnV6dgEya9TcMuj5nIJRuCzCm8ZP+c9zCHPw==",
+			"dependencies": {
+				"cluster-key-slot": "1.1.1",
+				"generic-pool": "3.9.0",
+				"yallist": "4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@redis/graph": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+			"integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/json": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+			"integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
+		"node_modules/@redis/time-series": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+			"integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+			"peerDependencies": {
+				"@redis/client": "^1.0.0"
+			}
+		},
 		"node_modules/@semantic-release/commit-analyzer": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
@@ -5274,6 +5327,14 @@
 				"shimmer": "^1.1.0"
 			}
 		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+			"integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7426,6 +7487,14 @@
 			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
 			"dependencies": {
 				"is-property": "^1.0.2"
+			}
+		},
+		"node_modules/generic-pool": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+			"integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/gensync": {
@@ -17935,53 +18004,16 @@
 			}
 		},
 		"node_modules/redis": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-			"integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-4.5.1.tgz",
+			"integrity": "sha512-oxXSoIqMJCQVBTfxP6BNTCtDMyh9G6Vi5wjdPdV/sRKkufyZslDqCScSGcOr6XGR/reAWZefz7E4leM31RgdBA==",
 			"dependencies": {
-				"denque": "^1.5.0",
-				"redis-commands": "^1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-redis"
-			}
-		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis/node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"engines": {
-				"node": ">=0.10"
+				"@redis/bloom": "1.1.0",
+				"@redis/client": "1.4.2",
+				"@redis/graph": "1.1.0",
+				"@redis/json": "1.0.4",
+				"@redis/search": "1.1.0",
+				"@redis/time-series": "1.0.4"
 			}
 		},
 		"node_modules/regenerate": {
@@ -20896,7 +20928,7 @@
 				"nunjucks": "^3.2.3",
 				"nunjucks-date-filter": "^0.1.1",
 				"pino": "^6.13.2",
-				"redis": "3.1.2",
+				"redis": "^4.5.1",
 				"slugify": "^1.6.5",
 				"string-collapse-white-space": "^9.1.0",
 				"string-strip-html": "^8.3.0",
@@ -23533,7 +23565,7 @@
 				"nunjucks-date-filter": "^0.1.1",
 				"pino": "^6.13.2",
 				"pino-pretty": "^4.8.0",
-				"redis": "3.1.2",
+				"redis": "^4.5.1",
 				"sass": "^1.53.0",
 				"slugify": "^1.6.5",
 				"string-collapse-white-space": "^9.1.0",
@@ -23768,6 +23800,46 @@
 				"notifications-node-client": "^5.1.0",
 				"pino": "^6.7.0"
 			}
+		},
+		"@redis/bloom": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.1.0.tgz",
+			"integrity": "sha512-9QovlxmpRtvxVbN0UBcv8WfdSMudNZZTFqCsnBszcQXqaZb/TVe30ScgGEO7u1EAIacTPAo7/oCYjYAxiHLanQ==",
+			"requires": {}
+		},
+		"@redis/client": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@redis/client/-/client-1.4.2.tgz",
+			"integrity": "sha512-oUdEjE0I7JS5AyaAjkD3aOXn9NhO7XKyPyXEyrgFDu++VrVBHUPnV6dgEya9TcMuj5nIJRuCzCm8ZP+c9zCHPw==",
+			"requires": {
+				"cluster-key-slot": "1.1.1",
+				"generic-pool": "3.9.0",
+				"yallist": "4.0.0"
+			}
+		},
+		"@redis/graph": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.0.tgz",
+			"integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+			"requires": {}
+		},
+		"@redis/json": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.4.tgz",
+			"integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+			"requires": {}
+		},
+		"@redis/search": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.0.tgz",
+			"integrity": "sha512-NyFZEVnxIJEybpy+YskjgOJRNsfTYqaPbK/Buv6W2kmFNaRk85JiqjJZA5QkRmWvGbyQYwoO5QfDi2wHskKrQQ==",
+			"requires": {}
+		},
+		"@redis/time-series": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.4.tgz",
+			"integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+			"requires": {}
 		},
 		"@semantic-release/commit-analyzer": {
 			"version": "9.0.2",
@@ -25508,6 +25580,11 @@
 				"shimmer": "^1.1.0"
 			}
 		},
+		"cluster-key-slot": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+			"integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -27157,6 +27234,11 @@
 			"requires": {
 				"is-property": "^1.0.2"
 			}
+		},
+		"generic-pool": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+			"integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -34877,39 +34959,16 @@
 			}
 		},
 		"redis": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-			"integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/redis/-/redis-4.5.1.tgz",
+			"integrity": "sha512-oxXSoIqMJCQVBTfxP6BNTCtDMyh9G6Vi5wjdPdV/sRKkufyZslDqCScSGcOr6XGR/reAWZefz7E4leM31RgdBA==",
 			"requires": {
-				"denque": "^1.5.0",
-				"redis-commands": "^1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"denque": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-					"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
-				}
-			}
-		},
-		"redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-		},
-		"redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
-		},
-		"redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"requires": {
-				"redis-errors": "^1.0.0"
+				"@redis/bloom": "1.1.0",
+				"@redis/client": "1.4.2",
+				"@redis/graph": "1.1.0",
+				"@redis/json": "1.0.4",
+				"@redis/search": "1.1.0",
+				"@redis/time-series": "1.0.4"
 			}
 		},
 		"regenerate": {

--- a/packages/common/src/utils/redis.js
+++ b/packages/common/src/utils/redis.js
@@ -1,0 +1,33 @@
+const parseRedisConnectionString = (redisConnectionString) => {
+	if (!redisConnectionString) return {};
+
+	const components = redisConnectionString.split(',');
+
+	if (components.length !== 4) {
+		throw new Error(
+			"Redis connection string not in expected format (4 parts comma separated): 'some.example.org:6380,password=some_password,ssl=True,abortConnect=False'"
+		);
+	}
+
+	const hostComponents = components[0].split(':');
+
+	if (hostComponents.length !== 2) {
+		throw new Error(
+			"Hostname and port not in expected format (separated by colon): 'some.example.org:6380'"
+		);
+	}
+
+	const truePattern = new RegExp('True', 'i');
+
+	return {
+		host: hostComponents[0],
+		port: parseInt(hostComponents[1]),
+		password: components[1].replace(/^password=/, ''),
+		ssl: truePattern.test(components[2]),
+		abortConnect: truePattern.test(components[3])
+	};
+};
+
+module.exports = {
+	parseRedisConnectionString
+};

--- a/packages/common/src/utils/redis.test.js
+++ b/packages/common/src/utils/redis.test.js
@@ -1,0 +1,54 @@
+const { parseRedisConnectionString } = require('./redis');
+
+describe('redis utils', () => {
+	describe('parseRedisConnectionString', () => {
+		const validConnectionString =
+			'some.example.org:6380,password=some_password,ssl=True,abortConnect=False';
+
+		it('parses valid connection string correctly', () => {
+			const result = parseRedisConnectionString(validConnectionString);
+
+			expect(result).toEqual({
+				host: 'some.example.org',
+				port: 6380,
+				password: 'some_password',
+				ssl: true,
+				abortConnect: false
+			});
+		});
+
+		it('throws error if connection string contains too few parts', () => {
+			expect(() => {
+				parseRedisConnectionString('not,valid');
+			}).toThrowError(
+				"Redis connection string not in expected format (4 parts comma separated): 'some.example.org:6380,password=some_password,ssl=True,abortConnect=False'"
+			);
+		});
+
+		it('throws error if connection string contains too many parts', () => {
+			expect(() => {
+				parseRedisConnectionString('not,valid,too,many,parts');
+			}).toThrowError(
+				"Redis connection string not in expected format (4 parts comma separated): 'some.example.org:6380,password=some_password,ssl=True,abortConnect=False'"
+			);
+		});
+
+		it('throws error if connection string contains hostname but not port', () => {
+			expect(() => {
+				parseRedisConnectionString(
+					'example.org,password=some_password,ssl=True,abortConnect=False'
+				);
+			}).toThrowError(
+				"Hostname and port not in expected format (separated by colon): 'some.example.org:6380'"
+			);
+		});
+
+		it('throws error if connection string contains port but not hostname', () => {
+			expect(() => {
+				parseRedisConnectionString('6380,password=some_password,ssl=True,abortConnect=False');
+			}).toThrowError(
+				"Hostname and port not in expected format (separated by colon): 'some.example.org:6380'"
+			);
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/lib/session.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/session.test.js
@@ -1,34 +1,82 @@
-const session = require('../../../src/lib/session');
-const config = require('../../../src/config');
+const { configureSessionStore } = require('../../../src/lib/session');
+
+const { createClient } = require('redis');
+const session = require('express-session');
 
 jest.mock('express-session');
-jest.mock('../../../src/lib/logger');
+jest.mock('redis');
+
+let config;
+
+const mockCreateClientOnFn = jest.fn();
+const mockCreateClientConnectFn = jest.fn();
 
 describe('lib/session', () => {
-	it('should throw if unable to find the session secret', () => {
-		expect(() => session()).toThrow('Session secret must be set');
-	});
+	describe('configureSessionStore', () => {
+		beforeEach(() => {
+			config = require('../../../src/config');
 
-	it('should configure with the expected config', () => {
-		config.server.sessionSecret = 'a fake session secret';
+			createClient.mockImplementation(() => ({
+				// eslint-disable-next-line no-unused-vars
+				on: (event, callback) => mockCreateClientOnFn(event, callback),
+				connect: () => mockCreateClientConnectFn()
+			}));
+		});
 
-		const configuredSession = session();
+		it('should throw if unable to find the session secret', () => {
+			expect(() => configureSessionStore(session)).toThrow('Session secret must be set');
+		});
 
-		expect(configuredSession.cookie).toEqual({});
-		expect(configuredSession.resave).toEqual(false);
-		expect(configuredSession.saveUninitialized).toEqual(true);
-		expect(configuredSession.secret).toEqual(config.server.sessionSecret);
-	});
+		it('should configure a redis store if useRedisSessionStore is true', () => {
+			config.server.sessionSecret = 'a fake session secret';
+			config.featureFlag.useRedisSessionStore = true;
+			config.db.session.redis = {
+				host: 'example.org',
+				port: 1234,
+				ssl: false,
+				password: 'some_password'
+			};
 
-	it('should configure with the expected config when useSecureSessionCookie', () => {
-		config.server.sessionSecret = 'a fake session secret';
-		config.server.useSecureSessionCookie = true;
+			configureSessionStore(session);
 
-		const configuredSession = session();
+			expect(createClient).toHaveBeenLastCalledWith({
+				socket: {
+					host: 'example.org',
+					port: 1234,
+					tls: false
+				},
+				password: 'some_password',
+				legacyMode: true
+			});
+			expect(mockCreateClientOnFn).toBeCalledWith('connect', expect.any(Function));
+			expect(mockCreateClientOnFn).toBeCalledWith('ready', expect.any(Function));
+			expect(mockCreateClientOnFn).toBeCalledWith('end', expect.any(Function));
+			expect(mockCreateClientOnFn).toBeCalledWith('error', expect.any(Function));
+			expect(mockCreateClientOnFn).toBeCalledWith('reconnecting', expect.any(Function));
+			expect(mockCreateClientConnectFn).toBeCalled();
+		});
 
-		expect(configuredSession.cookie.secure).toEqual(true);
-		expect(configuredSession.resave).toEqual(false);
-		expect(configuredSession.saveUninitialized).toEqual(true);
-		expect(configuredSession.secret).toEqual(config.server.sessionSecret);
+		it('should configure with the expected config', () => {
+			config.server.sessionSecret = 'a fake session secret';
+
+			const configuredSession = configureSessionStore(session);
+
+			expect(configuredSession.cookie.maxAge).toEqual(14400000);
+			expect(configuredSession.resave).toEqual(false);
+			expect(configuredSession.saveUninitialized).toEqual(true);
+			expect(configuredSession.secret).toEqual(config.server.sessionSecret);
+		});
+
+		it('should configure with the expected config when useSecureSessionCookie', () => {
+			config.server.sessionSecret = 'a fake session secret';
+			config.server.useSecureSessionCookie = true;
+
+			const configuredSession = configureSessionStore(session);
+
+			expect(configuredSession.cookie.secure).toEqual(true);
+			expect(configuredSession.resave).toEqual(false);
+			expect(configuredSession.saveUninitialized).toEqual(true);
+			expect(configuredSession.secret).toEqual(config.server.sessionSecret);
+		});
 	});
 });

--- a/packages/forms-web-app/package.json
+++ b/packages/forms-web-app/package.json
@@ -52,7 +52,7 @@
 		"nunjucks": "^3.2.3",
 		"nunjucks-date-filter": "^0.1.1",
 		"pino": "^6.13.2",
-		"redis": "3.1.2",
+		"redis": "^4.5.1",
 		"slugify": "^1.6.5",
 		"string-collapse-white-space": "^9.1.0",
 		"string-strip-html": "^8.3.0",

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -1,3 +1,5 @@
+const { parseRedisConnectionString } = require('@pins/common/src/utils/redis');
+
 const httpPort = Number(process.env.PORT || 3000);
 
 module.exports = {
@@ -16,7 +18,7 @@ module.exports = {
 	},
 	db: {
 		session: {
-			redisUrl: process.env.REDIS_URL || 'redis://redis:6379'
+			redis: parseRedisConnectionString(process.env.REDIS_CONNECTION_STRING)
 		}
 	},
 	defaultPageTitle: 'The Planning Inspectorate',
@@ -29,6 +31,7 @@ module.exports = {
 		host: process.env.HOST_URL || `http://localhost:${httpPort}`, // This is used for the HTML generator
 		port: httpPort,
 		sessionSecret: process.env.SESSION_KEY,
+		sessionLengthInHours: 4,
 		// https://expressjs.com/en/5x/api.html#app.set - to account for .gov.uk
 		subdomainOffset: parseInt(process.env.SUBDOMAIN_OFFSET, 10) || 3,
 		useSecureSessionCookie: process.env.USE_SECURE_SESSION_COOKIES === 'true',

--- a/packages/forms-web-app/src/lib/session.js
+++ b/packages/forms-web-app/src/lib/session.js
@@ -1,22 +1,59 @@
 const config = require('../config');
+const logger = require('./logger');
+const { createClient } = require('redis');
+const ConnectRedis = require('connect-redis');
 
-module.exports = () => {
-	const { sessionSecret } = config.server;
+const configureSessionStore = (session) => {
+	if (!config.server.sessionSecret) throw new Error('Session secret must be set');
 
-	if (!sessionSecret) {
-		throw new Error('Session secret must be set');
-	}
-
-	const sessionConfig = {
-		secret: sessionSecret,
+	let sessionConfig = {
+		secret: config.server.sessionSecret,
 		resave: false,
 		saveUninitialized: true,
-		cookie: {}
+		cookie: {
+			maxAge: 1000 * 60 * 60 * config.server.sessionLengthInHours
+		}
 	};
 
 	if (config.server.useSecureSessionCookie) {
-		sessionConfig.cookie.secure = true; // serve secure cookies
+		sessionConfig.cookie.secure = true;
+	}
+
+	if (config.featureFlag.useRedisSessionStore) {
+		sessionConfig.store = configureRedisStore(session);
 	}
 
 	return sessionConfig;
+};
+
+const configureRedisStore = (session) => {
+	const RedisStore = ConnectRedis(session);
+
+	const redisConfig = config.db.session.redis;
+
+	const redisClient = createClient({
+		socket: {
+			host: redisConfig.host,
+			port: redisConfig.port,
+			tls: redisConfig.ssl
+		},
+		password: redisConfig.password,
+		legacyMode: true
+	});
+
+	redisClient.on('connect', () => logger.info('Initiating connection to redis server...'));
+	redisClient.on('ready', () => logger.info('Connected to redis server successfully...'));
+	redisClient.on('end', () => logger.info('Disconnected from redis server...'));
+	redisClient.on('error', (err) =>
+		logger.error(`Could not establish a connection with redis server: ${err}`)
+	);
+	redisClient.on('reconnecting', () => logger.info('Reconnecting to redis server...'));
+
+	redisClient.connect();
+
+	return new RedisStore({ client: redisClient });
+};
+
+module.exports = {
+	configureSessionStore
 };


### PR DESCRIPTION
changes to the web app to enable using redis as session store:

- update version of redis node library
- amend local config to use redis server with a password, as the azure redis server does
- helper function to parse the redis connection string provided by azure redis