### PR TITLE
fix(routes): remove exam timetable from usePrivateBetaV1RoutesOnly

### DIFF
--- a/packages/forms-web-app/src/routes/index.js
+++ b/packages/forms-web-app/src/routes/index.js
@@ -21,11 +21,11 @@ router.use(routesConfig.project.directory, projectsRouter);
 router.use('/', footerPagesRouter);
 router.use('/cookies', cookieRouter);
 if (!config.featureFlag.usePrivateBetaV1RoutesOnly) {
-	router.use(routesConfig.examination.directory, isProcessingSubmission, examinationRouter);
 	router.use('/project-search', projectSearchRouter);
 }
 router.use('/register', registerRouter);
 router.use('/register-have-your-say', registerRouter);
+router.use(routesConfig.examination.directory, isProcessingSubmission, examinationRouter);
 router.use(interestedPartyRouter);
 router.use(decisionMakingProcessGuideRouter);
 router.use('/interested-party/confirm-your-email', confirmEmailRouter);

--- a/packages/forms-web-app/src/routes/projects/index.js
+++ b/packages/forms-web-app/src/routes/projects/index.js
@@ -35,10 +35,6 @@ if (!usePrivateBetaV1RoutesOnly) {
 	router.get('/', projectSearchController.getProjectList);
 	router.get('/all-examination-documents', allExaminationDocsController.getAllExaminationDocuments);
 	router.get('/recommendations', recommendationsController.getRecommendations);
-	router.post(
-		subDirectory + pages.examinationTimetable.route,
-		examinationTimetable.postExaminationTimetable
-	);
 	router.get('/:case_ref', projectsController.getExamination);
 }
 
@@ -57,6 +53,10 @@ if (allowExaminationTimetable) {
 	router.get(
 		`${subDirectory}${pages.examinationTimetable.route}`,
 		examinationTimetable.getExaminationTimetable
+	);
+	router.post(
+		`${subDirectory}${pages.examinationTimetable.route}`,
+		examinationTimetable.postExaminationTimetable
 	);
 }
 


### PR DESCRIPTION
 Feature flag usePrivateBetaV1RoutesOnly is blocking route to having your say.
 
 This change moves the exam timetable and having your say routes out of the scope of usePrivateBetaV1RoutesOnly.