### PR TITLE
feat(data-service): pipeline option to migrate db

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -11,6 +11,10 @@ parameters:
     type: boolean
     displayName: Deploy Back Office Subscriber Functions
     default: true
+  - name: runDbMigrations
+    displayName: Run Database Migration
+    type: boolean
+    default: false
   - name: region
     displayName: Region
     type: string
@@ -71,6 +75,20 @@ extends:
                 parameters:
                   appName: pins-func-applications-service-bo-subscribers-$(ENVIRONMENT)-$(REGION_SHORT)-001
                   resourceGroup: $(resourceGroup)
+          - name: Run Database Migration
+            condition: eq(${{ parameters.runDbMigrations }}, 'true')
+            steps:
+              - checkout: self
+              - template: ../steps/azure_get_secrets.yml
+                parameters:
+                  secrets:
+                    - name: applications-service-sql-server-connection-string
+                      variable: DATABASE_URL
+              - template: ../steps/node_script.yml
+                parameters:
+                  environmentVariables:
+                    DATABASE_URL: $(DATABASE_URL)
+                  script: npm run db:migrate:deploy --workspace=@pins/data-service
     region: ${{ parameters.Region }}
     globalVariables:
       - template: azure-pipelines-variables.yml@self

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 				"packages/forms-web-app",
 				"packages/applications-service-api",
 				"packages/common",
-				"packages/back-office-subscribers"
+				"packages/back-office-subscribers",
+				"packages/data-service"
 			],
 			"devDependencies": {
 				"@commitlint/cli": "^17.0.2",
@@ -3019,6 +3020,10 @@
 			"resolved": "packages/common",
 			"link": true
 		},
+		"node_modules/@pins/data-service": {
+			"resolved": "packages/data-service",
+			"link": true
+		},
 		"node_modules/@pins/forms-web-app": {
 			"resolved": "packages/forms-web-app",
 			"link": true
@@ -3036,6 +3041,37 @@
 				"notifications-node-client": "^5.1.0",
 				"pino": "^6.7.0"
 			}
+		},
+		"node_modules/@prisma/client": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.11.0.tgz",
+			"integrity": "sha512-0INHYkQIqgAjrt7NzhYpeDQi8x3Nvylc2uDngKyFDDj1tTRQ4uV1HnVmd1sQEraeVAN63SOK0dgCKQHlvjL0KA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@prisma/engines-version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"prisma": "*"
+			},
+			"peerDependenciesMeta": {
+				"prisma": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@prisma/engines": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.11.0.tgz",
+			"integrity": "sha512-0AEBi2HXGV02cf6ASsBPhfsVIbVSDC9nbQed4iiY5eHttW9ZtMxHThuKZE1pnESbr8HRdgmFSa/Kn4OSNYuibg==",
+			"hasInstallScript": true
+		},
+		"node_modules/@prisma/engines-version": {
+			"version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.11.0-57.8fde8fef4033376662cad983758335009d522acb.tgz",
+			"integrity": "sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g=="
 		},
 		"node_modules/@redis/bloom": {
 			"version": "1.1.0",
@@ -17996,6 +18032,22 @@
 				"@types/yargs-parser": "*"
 			}
 		},
+		"node_modules/prisma": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.11.0.tgz",
+			"integrity": "sha512-4zZmBXssPUEiX+GeL0MUq/Yyie4ltiKmGu7jCJFnYMamNrrulTBc+D+QwAQSJ01tyzeGHlD13kOnqPwRipnlNw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@prisma/engines": "4.11.0"
+			},
+			"bin": {
+				"prisma": "build/index.js",
+				"prisma2": "build/index.js"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -21380,7 +21432,6 @@
 		"packages/data-service": {
 			"name": "@pins/data-service",
 			"version": "1.0.0",
-			"extraneous": true,
 			"dependencies": {
 				"@prisma/client": "^4.11.0",
 				"prisma": "^4.11.0"
@@ -21395,7 +21446,7 @@
 			"dependencies": {
 				"@ministryofjustice/frontend": "0.2.0",
 				"@pins/common": "file:../common",
-				"@planning-inspectorate/pins-components": "^2.2.5",
+				"@planning-inspectorate/pins-components": "^2.2.6",
 				"@testing-library/dom": "^7.31.2",
 				"@testing-library/jest-dom": "^5.14.1",
 				"@testing-library/user-event": "^12.8.3",
@@ -24028,6 +24079,14 @@
 				}
 			}
 		},
+		"@pins/data-service": {
+			"version": "file:packages/data-service",
+			"requires": {
+				"@prisma/client": "^4.11.0",
+				"jest": "^28.1.1",
+				"prisma": "^4.11.0"
+			}
+		},
 		"@pins/forms-web-app": {
 			"version": "file:packages/forms-web-app",
 			"requires": {
@@ -24035,7 +24094,7 @@
 				"@babel/preset-env": "^7.18.9",
 				"@ministryofjustice/frontend": "0.2.0",
 				"@pins/common": "file:../common",
-				"@planning-inspectorate/pins-components": "^2.2.5",
+				"@planning-inspectorate/pins-components": "^2.2.6",
 				"@testing-library/dom": "^7.31.2",
 				"@testing-library/jest-dom": "^5.14.1",
 				"@testing-library/user-event": "^12.8.3",
@@ -24307,6 +24366,24 @@
 				"notifications-node-client": "^5.1.0",
 				"pino": "^6.7.0"
 			}
+		},
+		"@prisma/client": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.11.0.tgz",
+			"integrity": "sha512-0INHYkQIqgAjrt7NzhYpeDQi8x3Nvylc2uDngKyFDDj1tTRQ4uV1HnVmd1sQEraeVAN63SOK0dgCKQHlvjL0KA==",
+			"requires": {
+				"@prisma/engines-version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb"
+			}
+		},
+		"@prisma/engines": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.11.0.tgz",
+			"integrity": "sha512-0AEBi2HXGV02cf6ASsBPhfsVIbVSDC9nbQed4iiY5eHttW9ZtMxHThuKZE1pnESbr8HRdgmFSa/Kn4OSNYuibg=="
+		},
+		"@prisma/engines-version": {
+			"version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.11.0-57.8fde8fef4033376662cad983758335009d522acb.tgz",
+			"integrity": "sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g=="
 		},
 		"@redis/bloom": {
 			"version": "1.1.0",
@@ -35459,6 +35536,14 @@
 						"@types/yargs-parser": "*"
 					}
 				}
+			}
+		},
+		"prisma": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.11.0.tgz",
+			"integrity": "sha512-4zZmBXssPUEiX+GeL0MUq/Yyie4ltiKmGu7jCJFnYMamNrrulTBc+D+QwAQSJ01tyzeGHlD13kOnqPwRipnlNw==",
+			"requires": {
+				"@prisma/engines": "4.11.0"
 			}
 		},
 		"process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"packages/forms-web-app",
 		"packages/applications-service-api",
 		"packages/common",
-		"packages/back-office-subscribers"
+		"packages/back-office-subscribers",
+		"packages/data-service"
 	],
 	"scripts": {
 		"commit": "cz",
@@ -23,9 +24,9 @@
 		"lint:fix": "turbo run lint --parallel --continue",
 		"prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
 		"release": "multi-semantic-release --ignore-packages=packages/common",
-		"test": "turbo run test --parallel --continue",
-		"test:cov": "turbo run test:cov --parallel --continue",
-		"test:watch": "turbo run test:watch --parallel --continue",
+		"test": "turbo run test --parallel --continue --filter=!@pins/data-service",
+		"test:cov": "turbo run test:cov --parallel --continue --filter=!@pins/data-service",
+		"test:watch": "turbo run test:watch --parallel --continue --filter=!@pins/data-service",
 		"win:common:fix": "xcopy /E /Y packages\\common node_modules\\@pins\\common\\"
 	},
 	"repository": {

--- a/packages/data-service/package.json
+++ b/packages/data-service/package.json
@@ -4,7 +4,9 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"test": "jest"
+		"test": "jest",
+		"db:migrate:dev": "npx prisma migrate dev",
+		"db:migrate:deploy": "npx prisma migrate deploy"
 	},
 	"dependencies": {
 		"@prisma/client": "^4.11.0",


### PR DESCRIPTION
- adds database migration NPM tasks which invoke Prisma migrate function
- exclude `data-service` from NPM test tasks for now, until DB is available in all environments
- adds "Run Database Migration" option to the "Deploy" pipeline in Azure DevOps. Unchecked by default. Runs `db:migrate:deploy` NPM task.