### PR TITLE
test: fix tests for automation

### DIFF
--- a/e2e-tests/cypress/e2e/decision-making-process-guide/decision-making-process-guide.js
+++ b/e2e-tests/cypress/e2e/decision-making-process-guide/decision-making-process-guide.js
@@ -1,11 +1,7 @@
 import { Given, Then, And } from 'cypress-cucumber-preprocessor/steps';
 
 Given('I navigate to Decision making process guide page', () => {
-	cy.visit('/project-search', { failOnStatusCode: false });
-	cy.clickProjectLink('North Lincolnshire Green Energy Park');
-	cy.clickLinkTonavigateToPage(
-		'Find out more about the decision making process for national infrastructure projects'
-	);
+	cy.visit('/decision-making-process-guide', { failOnStatusCode: false });
 });
 
 Then('I am on the {string} page', (pageName) => {

--- a/e2e-tests/cypress/e2e/get-involved-in-preliminary-meeting/get-involved-in-preliminary-meeting.js
+++ b/e2e-tests/cypress/e2e/get-involved-in-preliminary-meeting/get-involved-in-preliminary-meeting.js
@@ -4,8 +4,9 @@ const getInvolvedInPreliminaryMeeting = new PO_GetInvolvedInPreliminaryMeeting()
 
 Given('I navigate to Get involved in the preliminary meeting page', () => {
 	cy.visit('/having-your-say-guide');
-	// cy.get('button.ui-step-nav__button.ui-step-nav__button--controls.js-step-controls-button').click();
-	cy.get('#get-involved-in-the-preliminary-meeting').click();
+	cy.get(
+		'button.ui-step-nav__button.ui-step-nav__button--controls.js-step-controls-button'
+	).click();
 	cy.clickLinkTonavigateToPage('get involved in the preliminary meeting');
 });
 

--- a/e2e-tests/cypress/e2e/overview-page.feature
+++ b/e2e-tests/cypress/e2e/overview-page.feature
@@ -23,11 +23,6 @@ Feature: Overview page
     Scenario: click on Examination timetable link
         When I click on "Examination timetable" link
 
-    Scenario: click on All Examination documents link
-        When I click on "All Examination documents" link
-        Then I click on required "Return to the project overview" link
-        Then I am on the "North Lincolnshire Green Energy Park project information" page
-
     Scenario: click on Recommendation and decision link
         When I click on "Recommendation and decision" link
         Then I click on required "Return to the project overview" link

--- a/e2e-tests/cypress/e2e/project-application-documents.feature
+++ b/e2e-tests/cypress/e2e/project-application-documents.feature
@@ -159,7 +159,6 @@ Feature: Project Application documents page
 			| Data              |
 			| 1                 |
 			| 2                 |
-			| 3                 |
 			| Next set of pages |
 		Then I verify text "Showing 1 to 25 of 46 results" is present on the page
 		Then I verify that only "25" results present on each page
@@ -169,19 +168,15 @@ Feature: Project Application documents page
 			| Previous set of pages |
 			| 1                     |
 			| 2                     |
-			| 3                     |
 			| Next set of pages     |
-		Then I verify text "Showing 21 to 40 of 46 results" is present on the page
-		Then I verify that only "25" results present on each page
-		When I navigate to page "3" of the results
+		Then I verify text "Showing 26 to 46 of 46 results" is present on the page
+		Then I verify that only "21" results present on each page
 		Then I verify below pagination is present on the page
 			| Data                  |
 			| Previous set of pages |
 			| 1                     |
 			| 2                     |
-			| 3                     |
-		Then I verify text "Showing 41 to 46 of 46 results" is present on the page
-		Then I verify that only "6" results present on each page
+
 
 	Scenario: verify Next/Previous pagination links on Project application documents page
 		Given I navigate to "North Lincolnshire Green Energy Park" project Overview page
@@ -192,35 +187,14 @@ Feature: Project Application documents page
 			| Previous set of pages |
 			| 1                     |
 			| 2                     |
-			| 3                     |
 			| Next set of pages     |
-		Then I verify text "Showing 21 to 40 of 46 results" is present on the page
-		Then I verify that only "25" results present on each page
-		When I navigate to page "Next set of pages" of the results
-		Then I verify below pagination is present on the page
-			| Data                  |
-			| Previous set of pages |
-			| 1                     |
-			| 2                     |
-			| 3                     |
-		Then I verify text "Showing 41 to 46 of 46 results" is present on the page
-		Then I verify that only "6" results present on each page
-		When I navigate to page "Previous set of pages" of the results
-		Then I verify below pagination is present on the page
-			| Data                  |
-			| Previous set of pages |
-			| 1                     |
-			| 2                     |
-			| 3                     |
-			| Next set of pages     |
-		Then I verify text "Showing 21 to 40 of 46 results" is present on the page
-		Then I verify that only "25" results present on each page
+		Then I verify text "Showing 26 to 46 of 46 results" is present on the page
+		Then I verify that only "21" results present on each page
 		When I navigate to page "Previous set of pages" of the results
 		Then I verify below pagination is present on the page
 			| Data              |
 			| 1                 |
 			| 2                 |
-			| 3                 |
 			| Next set of pages |
 		Then I verify text "Showing 1 to 25 of 46 results" is present on the page
 		Then I verify that only "25" results present on each page
@@ -234,7 +208,7 @@ Feature: Project Application documents page
 			| 2                 |
 			| 3                 |
 			| ...               |
-			| 8                 |
+			| 7                 |
 			| Next set of pages |
 		Then I verify text "Showing 1 to 25 of 152 results" is present on the page
 		Then I verify that only "25" results present on each page
@@ -247,9 +221,9 @@ Feature: Project Application documents page
 			| 3                     |
 			| 4                     |
 			| ...                   |
-			| 8                     |
+			| 7                     |
 			| Next set of pages     |
-		Then I verify text "Showing 41 to 60 of 152 results" is present on the page
+		Then I verify text "Showing 51 to 75 of 152 results" is present on the page
 		Then I verify that only "25" results present on each page
 		When I navigate to page "4" of the results
 		Then I verify below pagination is present on the page
@@ -261,9 +235,9 @@ Feature: Project Application documents page
 			| 4                     |
 			| 5                     |
 			| ...                   |
-			| 8                     |
+			| 7                     |
 			| Next set of pages     |
-		Then I verify text "Showing 61 to 80 of 152 results" is present on the page
+		Then I verify text "Showing 76 to 100 of 152 results" is present on the page
 		Then I verify that only "25" results present on each page
 		When I navigate to page "Previous set of pages" of the results
 		Then I verify below pagination is present on the page
@@ -274,9 +248,9 @@ Feature: Project Application documents page
 			| 3                     |
 			| 4                     |
 			| ...                   |
-			| 8                     |
+			| 7                     |
 			| Next set of pages     |
-		Then I verify text "Showing 41 to 60 of 152 results" is present on the page
+		Then I verify text "Showing 51 to 75 of 152 results" is present on the page
 		Then I verify that only "25" results present on each page
 		When I navigate to page "Next set of pages" of the results
 		Then I verify below pagination is present on the page
@@ -288,18 +262,18 @@ Feature: Project Application documents page
 			| 4                     |
 			| 5                     |
 			| ...                   |
-			| 8                     |
+			| 7                     |
 			| Next set of pages     |
-		Then I verify text "Showing 61 to 80 of 152 results" is present on the page
+		Then I verify text "Showing 76 to 100 of 152 results" is present on the page
 		Then I verify that only "25" results present on each page
-		When I navigate to page "8" of the results
+		When I navigate to page "7" of the results
 		Then I verify below pagination is present on the page
 			| Data                  |
 			| Previous set of pages |
 			| 1                     |
 			| ...                   |
+			| 5                     |
 			| 6                     |
 			| 7                     |
-			| 8                     |
-		Then I verify text "Showing 141 to 152 of 152 results" is present on the page
-		Then I verify that only "12" results present on each page
+		Then I verify text "Showing 151 to 152 of 152 results" is present on the page
+		Then I verify that only "2" results present on each page

--- a/e2e-tests/cypress/e2e/project-application-documents/PageObjects/PO_ProjectAppDocs.js
+++ b/e2e-tests/cypress/e2e/project-application-documents/PageObjects/PO_ProjectAppDocs.js
@@ -1,38 +1,37 @@
-const accordionId = 'ui-checkbox-accordion__section-switch--';
 const checkboxId = 'ui-checkbox-accordion__checkboxes-section--';
 
 const filterKeys = {
 	'pre-application': {
-		accordionId: accordionId + 'stage-1',
-		checkboxId: checkboxId + 'stage-1'
+		accordionIndex: 0,
+		checkboxId: checkboxId + '1'
 	},
 	'developers-application': {
-		accordionId: accordionId + "category-Developer's Application",
-		checkboxId: checkboxId + "category-Developer's Application"
+		accordionIndex: 1,
+		checkboxId: checkboxId + '2'
 	},
 	acceptance: {
-		accordionId: accordionId + 'stage-2',
-		checkboxId: checkboxId + 'stage-2'
+		accordionIndex: 2,
+		checkboxId: checkboxId + '3'
 	},
 	'pre-examination': {
-		accordionId: accordionId + 'stage-3',
-		checkboxId: checkboxId + 'stage-3'
+		accordionIndex: 3,
+		checkboxId: checkboxId + '4'
 	},
 	examination: {
-		accordionId: accordionId + 'stage-4',
-		checkboxId: checkboxId + 'stage-4'
+		accordionIndex: 4,
+		checkboxId: checkboxId + '5'
 	},
 	recommendation: {
-		accordionId: accordionId + 'stage-5',
-		checkboxId: checkboxId + 'stage-5'
+		accordionIndex: 5,
+		checkboxId: checkboxId + '6'
 	},
 	decision: {
-		accordionId: accordionId + 'stage-6',
-		checkboxId: checkboxId + 'stage-6'
+		accordionIndex: 6,
+		checkboxId: checkboxId + '7'
 	},
 	'post-decision': {
-		accordionId: accordionId + 'stage-7',
-		checkboxId: checkboxId + 'stage-7'
+		accordionIndex: 7,
+		checkboxId: checkboxId + '8'
 	}
 };
 
@@ -166,7 +165,7 @@ class PO_ProjectAppDocs {
 		if (caseCondition === 'show all' || caseCondition === 'hide all')
 			cy.get('#show-hide-all-filters').click();
 		else if (Object.hasOwnProperty.call(filterKeys, caseCondition))
-			cy.get(`[id="${filterKeys[caseCondition].accordionId}"]`).click({ force: true });
+			cy.get('summary').eq(filterKeys[caseCondition].accordionIndex).click({ force: true });
 		else throw new Error(`Test failed: is the filter ${caseCondition} in filterKeys`);
 	}
 
@@ -187,7 +186,7 @@ class PO_ProjectAppDocs {
 	}
 
 	filterNameWithSumOfItems(sectionName, label, sum) {
-		cy.get(`[for="${filterKeys[sectionName].accordionId}"]`).contains(`${label} (${sum})`);
+		cy.get('details').contains(`${label} (${sum})`);
 	}
 }
 

--- a/e2e-tests/cypress/e2e/register-to-say-about-national-infra-project/register-to-say-about-national-infra-project.js
+++ b/e2e-tests/cypress/e2e/register-to-say-about-national-infra-project/register-to-say-about-national-infra-project.js
@@ -7,7 +7,7 @@ Given('I have navigated to the "Have your say" guide', () => {
 });
 
 Given('I have selected the "Have your say" link from the related guides section', () => {
-	cy.clickOnHref('/having-your-say-guide/');
+	cy.clickOnHref('/having-your-say-guide');
 });
 
 Given('I have viewed the overview page for a project', () => {

--- a/e2e-tests/cypress/e2e/registration-comments/PageObjects/PO_RegComments.js
+++ b/e2e-tests/cypress/e2e/registration-comments/PageObjects/PO_RegComments.js
@@ -40,7 +40,7 @@ class PO_RegComments {
 	assertNoRegCommentsOnThePage() {
 		cy.get('[data-cy="no-comments-available"]').should(
 			'contain.text',
-			'There are no registration comments to display. Registration comments will be published after the registration period has closed.'
+			'There are no registration comments to display.'
 		);
 	}
 

--- a/e2e-tests/cypress/e2e/registration-comments/registration-comments.js
+++ b/e2e-tests/cypress/e2e/registration-comments/registration-comments.js
@@ -83,7 +83,7 @@ Then('I am informed that no results were found', () => {
 Then(
 	'I am given the option to clear the search to list all available registration comments',
 	() => {
-		cy.get('a[data-cy="clear-search"]').should('contain.text', 'Clear search and filters');
+		cy.get('a[data-cy="clear-search"]').should('contain.text', 'Clear');
 	}
 );
 

--- a/e2e-tests/cypress/support/common-methods/assertUserOnThePage.js
+++ b/e2e-tests/cypress/support/common-methods/assertUserOnThePage.js
@@ -245,7 +245,7 @@ module.exports = (pageName) => {
 			cy.get('h1')
 				.invoke('text')
 				.then((text) => {
-					expect(text).to.contain('UK address details');
+					expect(text).to.contain('What is your address');
 				});
 			cy.url().should('include', '/address');
 			break;

--- a/e2e-tests/cypress/support/common-methods/clickLinkTonavigateToPage.js
+++ b/e2e-tests/cypress/support/common-methods/clickLinkTonavigateToPage.js
@@ -22,7 +22,7 @@ module.exports = (pageName) => {
 			cy.clickOnHref('/having-your-say-guide/index');
 			break;
 		case 'find out more about the decision making process for national infrastructure projects':
-			cy.clickOnHref('/decision-making-process-guide/');
+			cy.clickOnHref('/decision-making-process-guide');
 			break;
 		case 'find out what you can do at this stage and check our detailed guides':
 			cy.clickOnHref('pre-application');

--- a/e2e-tests/cypress/support/common-methods/clickOnHref.js
+++ b/e2e-tests/cypress/support/common-methods/clickOnHref.js
@@ -1,4 +1,6 @@
 module.exports = (link) => {
-	cy.get('a[href*="' + link + '"]').click();
+	cy.get('a[href*="' + link + '"]')
+		.first()
+		.click();
 	cy.wait(Cypress.env('demoDelay'));
 };


### PR DESCRIPTION
Fix automation tests, approximately 50 failures.

Mainly due to changes in functionality/enhancements including:

 - New Document library format with multiple level filters
 - Paging changes for 25 documents
 - Accessibility changes resulting in change of elements being returned
 - Route changes for guide documents
 - Other content changes.