### PR TITLE
fix(back-office-subscribers): parsing project message

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -10,7 +10,7 @@ parameters:
   - name: deployBackOfficeSubscribers
     type: boolean
     displayName: Deploy Back Office Subscriber Functions
-    default: false
+    default: true
   - name: runDbMigrations
     displayName: Run Database Migration
     type: boolean

--- a/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
@@ -1,23 +1,34 @@
 const subject = require('../index');
 
 describe('nsip-project', () => {
-	const project = {
+	const mockLog = jest.fn();
+
+	const projectMessage = {
 		caseId: 1,
-		caseReference: null,
+		caseReference: 'ABC',
 		projectName: 'some case',
 		projectDescription: 'some desc',
-		publishStatus: 'unpublished',
+		publishStatus: 'published',
 		sourceSystem: 'ODT',
 		applicantIds: ['1'],
 		nsipOfficerIds: [],
 		nsipAdministrationOfficerIds: [],
 		inspectorIds: [],
-		interestedPartyIds: []
+		interestedPartyIds: [],
+		regions: ['a', 'b']
+	};
+
+	const project = {
+		caseReference: 'ABC',
+		projectName: 'some case',
+		projectDescription: 'some desc',
+		publishStatus: 'published',
+		sourceSystem: 'ODT',
+		regions: 'a,b'
 	};
 
 	describe('index', () => {
-		it('invokes log', async () => {
-			const mockLog = jest.fn();
+		it('assigns project data to binding in correct format', async () => {
 			const mockContext = {
 				log: mockLog,
 				bindingData: {
@@ -30,7 +41,7 @@ describe('nsip-project', () => {
 				}
 			};
 
-			await subject(mockContext, project);
+			await subject(mockContext, projectMessage);
 
 			expect(mockContext.bindings.project).toEqual(project);
 		});

--- a/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
@@ -19,6 +19,7 @@ describe('nsip-project', () => {
 	};
 
 	const project = {
+		caseId: 1,
 		caseReference: 'ABC',
 		projectName: 'some case',
 		projectDescription: 'some desc',

--- a/packages/back-office-subscribers/nsip-project/index.js
+++ b/packages/back-office-subscribers/nsip-project/index.js
@@ -1,3 +1,30 @@
-module.exports = async (context, project) => {
-	context.bindings.project = project;
+const excludedProperties = [
+	'caseId',
+	'operationsLeadId',
+	'operationsManagerId',
+	'caseManagerId',
+	'nsipOfficerIds',
+	'nsipAdministrationOfficerIds',
+	'leadInspectorId',
+	'inspectorIds',
+	'environmentalServicesOfficerId',
+	'legalOfficerId',
+	'applicantIds',
+	'interestedPartyIds'
+];
+
+module.exports = async (context, message) => {
+	context.bindings.project = parseMessage(message);
+};
+
+const parseMessage = (message) => {
+	let output = {};
+
+	for (const [key, value] of Object.entries(message)) {
+		if (!excludedProperties.includes(key)) {
+			output[key] = Array.isArray(value) ? value.join(',') : value;
+		}
+	}
+
+	return output;
 };

--- a/packages/back-office-subscribers/nsip-project/index.js
+++ b/packages/back-office-subscribers/nsip-project/index.js
@@ -1,5 +1,4 @@
 const excludedProperties = [
-	'caseId',
 	'operationsLeadId',
 	'operationsManagerId',
 	'caseManagerId',

--- a/packages/data-service/prisma/migrations/20230405134957_init/migration.sql
+++ b/packages/data-service/prisma/migrations/20230405134957_init/migration.sql
@@ -5,6 +5,7 @@ BEGIN TRAN;
 -- CreateTable
 CREATE TABLE [dbo].[Project] (
     [id] INT NOT NULL IDENTITY(1,1),
+    [caseId] INT NOT NULL,
     [caseReference] NVARCHAR(1000),
     [projectName] NVARCHAR(1000),
     [projectDescription] NVARCHAR(1000),
@@ -55,7 +56,8 @@ CREATE TABLE [dbo].[Project] (
     [examinationTimetableId] INT,
     [createdAt] DATETIME2 CONSTRAINT [Project_createdAt_df] DEFAULT CURRENT_TIMESTAMP,
     [modifiedAt] DATETIME2 CONSTRAINT [Project_modifiedAt_df] DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT [Project_pkey] PRIMARY KEY CLUSTERED ([id])
+    CONSTRAINT [Project_pkey] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [Project_caseId_key] UNIQUE NONCLUSTERED ([caseId])
 );
 
 COMMIT TRAN;

--- a/packages/data-service/prisma/migrations/20230405153152_init/migration.sql
+++ b/packages/data-service/prisma/migrations/20230405153152_init/migration.sql
@@ -56,8 +56,8 @@ CREATE TABLE [dbo].[Project] (
     [examinationTimetableId] INT,
     [createdAt] DATETIME2 CONSTRAINT [Project_createdAt_df] DEFAULT CURRENT_TIMESTAMP,
     [modifiedAt] DATETIME2 CONSTRAINT [Project_modifiedAt_df] DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT [Project_pkey] PRIMARY KEY CLUSTERED ([id]),
-    CONSTRAINT [Project_caseId_key] UNIQUE NONCLUSTERED ([caseId])
+    CONSTRAINT [Project_pkey] PRIMARY KEY CLUSTERED ([caseId]),
+    CONSTRAINT [Project_id_key] UNIQUE NONCLUSTERED ([id])
 );
 
 COMMIT TRAN;

--- a/packages/data-service/prisma/schema.prisma
+++ b/packages/data-service/prisma/schema.prisma
@@ -12,6 +12,7 @@ datasource db {
 
 model Project {
   id                                          Int      @id @default(autoincrement())
+  caseId                                      Int      @unique
   caseReference                               String?
   projectName                                 String?
   projectDescription                          String?

--- a/packages/data-service/prisma/schema.prisma
+++ b/packages/data-service/prisma/schema.prisma
@@ -11,8 +11,8 @@ datasource db {
 }
 
 model Project {
-  id                                          Int      @id @default(autoincrement())
-  caseId                                      Int      @unique
+  id                                          Int      @unique @default(autoincrement())
+  caseId                                      Int      @id
   caseReference                               String?
   projectName                                 String?
   projectDescription                          String?


### PR DESCRIPTION
- parse incoming message, and store arrays as csv
- exclude some properties (relationships). To be added later if they are needed
- re-enable deployments for subscribers
- amend db schema to include caseId and make it the PK