### PR TITLE
fix(back-office-subscribers): set modifiedAt and disable log sampling

### DIFF
--- a/packages/back-office-subscribers/host.json
+++ b/packages/back-office-subscribers/host.json
@@ -3,14 +3,11 @@
 	"logging": {
 		"fileLoggingMode": "always",
 		"logLevel": {
-			"default": "Information",
-			"Host.Results": "Error",
-			"Function": "Trace",
-			"Host.Aggregator": "Trace"
+			"default": "Debug"
 		},
 		"applicationInsights": {
 			"samplingSettings": {
-				"isEnabled": true
+				"isEnabled": false
 			}
 		}
 	},

--- a/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
@@ -28,8 +28,14 @@ describe('nsip-project', () => {
 		regions: 'a,b'
 	};
 
+	beforeAll(() => jest.useFakeTimers());
+	afterAll(() => jest.useRealTimers());
+
 	describe('index', () => {
 		it('assigns project data to binding in correct format', async () => {
+			const dateNow = new Date();
+			jest.setSystemTime(dateNow);
+
 			const mockContext = {
 				log: mockLog,
 				bindingData: {
@@ -44,7 +50,12 @@ describe('nsip-project', () => {
 
 			await subject(mockContext, projectMessage);
 
-			expect(mockContext.bindings.project).toEqual(project);
+			const expectedProject = {
+				...project,
+				modifiedAt: dateNow
+			};
+
+			expect(mockContext.bindings.project).toEqual(expectedProject);
 		});
 	});
 });

--- a/packages/back-office-subscribers/nsip-project/index.js
+++ b/packages/back-office-subscribers/nsip-project/index.js
@@ -17,7 +17,9 @@ module.exports = async (context, message) => {
 };
 
 const parseMessage = (message) => {
-	let output = {};
+	let output = {
+		modifiedAt: new Date()
+	};
 
 	for (const [key, value] of Object.entries(message)) {
 		if (!excludedProperties.includes(key)) {


### PR DESCRIPTION
for the nsip-project subscriber function
- disable log sampling
- manually set `modifiedAt` field, is not set automatically by output binding