### PR TITLE
fix(applications-service-api): update prisma client binary targets

### DIFF
--- a/packages/applications-service-api/prisma/schema.prisma
+++ b/packages/applications-service-api/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl"]
+  binaryTargets = ["native", "linux-musl", "linux-musl-arm64-openssl-3.0.x", "windows"]
 }
 
 datasource db {


### PR DESCRIPTION
- adds linux arm64 and windows as binary targets for the Prisma Client library