### PR TITLE
fix(process.js): fix for caseRef issue causing horizon not to process submission

### DIFF
--- a/packages/forms-web-app/src/pages/examination/process-submission/utils/process.js
+++ b/packages/forms-web-app/src/pages/examination/process-submission/utils/process.js
@@ -20,7 +20,7 @@ const handleProcessSubmission = async (session) => {
 			const listOfCommentAndFiles = getListOfFormData(session, item);
 			for (let form of listOfCommentAndFiles) {
 				if (submissionId) form.append('submissionId', submissionId);
-				const response = await postSubmission(examinationSession.caseRef, form);
+				const response = await postSubmission(session.caseRef, form);
 				submissionId = response.data.submissionId;
 			}
 		}

--- a/packages/forms-web-app/src/pages/examination/process-submission/utils/process.test.js
+++ b/packages/forms-web-app/src/pages/examination/process-submission/utils/process.test.js
@@ -29,8 +29,8 @@ jest.mock('./fromDataMappers', () => ({
 describe('#process', () => {
 	describe('When processing a submission', () => {
 		const session = {
+			caseRef: 'mock-case-ref',
 			examination: {
-				caseRef: 'mock-case-ref',
 				submissionItems: ['mock submission item', 'another mock submission item']
 			}
 		};


### PR DESCRIPTION
Fix for undefined caseRef on submission.
The caseRef has moved out of the examinationSession data and into the parent session data.
This change now uses the parent session data so that the caseRef is not undefined.