### PR TITLE
feat(applications-service-api): add regex validation for caseReference

### DIFF
--- a/packages/applications-service-api/__tests__/unit/middleware/validator/openapi.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/validator/openapi.test.js
@@ -25,13 +25,14 @@ describe('openapi validator', () => {
 
 			const expectedError = new ApiError(400, {
 				errors: [
-					"'representation' must not have more than 65234 characters",
+					"'representation' must NOT have more than 65234 characters",
 					"must have required property 'name'",
 					"must have required property 'email'",
 					"must have required property 'interestedParty'",
 					"must have required property 'deadline'",
 					"must have required property 'submissionType'",
-					"'caseReference' must not have more than 12 characters"
+					"'caseReference' must NOT have more than 12 characters",
+					'\'caseReference\' must match pattern "^[A-Z]{2}\\d{6,8}$"'
 				]
 			});
 

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -24,7 +24,10 @@ paths:
           required: true
           schema:
             type: string
-          description: Unique identifier
+            minLength: 2
+            maxLength: 12
+            pattern: '^[A-Z]{2}\d{6,8}$'
+          description: Case / Project unique identifier
       responses:
         '200':
           description: Returns an application
@@ -410,6 +413,7 @@ paths:
             type: string
             minLength: 2
             maxLength: 12
+            pattern: '^[A-Z]{2}\d{6,8}$'
           description: Case / Project unique identifier
       responses:
         '200':
@@ -439,6 +443,7 @@ paths:
             type: string
             minLength: 2
             maxLength: 12
+            pattern: '^[A-Z]{2}\d{6,8}$'
           description: Case / Project unique identifier
       requestBody:
         content:

--- a/packages/applications-service-api/src/middleware/validator/openapi.js
+++ b/packages/applications-service-api/src/middleware/validator/openapi.js
@@ -11,9 +11,9 @@ const validateRequestWithOpenAPI = (req, res, next) => {
 			errors.errors.map((e) => {
 				if (
 					e.errorCode &&
-					e.errorCode.match(/(maxLength|minLength|type|enum)\.openapi\.requestValidation/)
+					e.errorCode.match(/(enum|maxLength|minLength|pattern|type)\.openapi\.requestValidation/)
 				) {
-					return `'${e.path}' ${e.message.toLowerCase()}`;
+					return `'${e.path}' ${e.message}`;
 				}
 				return e.message;
 			})


### PR DESCRIPTION
- adds regex validation for `caseReference` path param on these endpoints:
  - `/api/v1/applications/{caseReference}`
  - `/api/v1/timetables/{caseReference}`
  - `/api/v1/submissions/{caseReference}`

regex checks caseref starts with 2 characters, followed by 6-8 digits. NI uses 6 digits, BO uses 7, allowing 8 for future growth