### PR TITLE
fix(applications-service-api): allow lowercase letters in caseref validation

### DIFF
--- a/packages/applications-service-api/__tests__/unit/middleware/validator/openapi.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/validator/openapi.test.js
@@ -31,8 +31,8 @@ describe('openapi validator', () => {
 					"must have required property 'interestedParty'",
 					"must have required property 'deadline'",
 					"must have required property 'submissionType'",
-					"'caseReference' must NOT have more than 12 characters",
-					'\'caseReference\' must match pattern "^[A-Z]{2}\\d{6,8}$"'
+					"'caseReference' must NOT have more than 10 characters",
+					'\'caseReference\' must match pattern "^[A-Za-z]{2}\\d{6,8}$"'
 				]
 			});
 
@@ -69,6 +69,55 @@ describe('openapi validator', () => {
 			expect(() => validateRequestWithOpenAPI(request, res, next)).toThrowError(
 				expect.objectContaining(expectedError)
 			);
+		});
+
+		describe('case reference pattern validation', () => {
+			it.each(['EN000001', 'EN0000001', 'EN00000001', 'en000001', 'en0000001', 'en00000001'])(
+				'returns no errors if case reference is in valid format',
+				(caseReference) => {
+					const request = {
+						baseUrl: '/api/v1/applications',
+						route: {
+							path: '/:caseReference'
+						},
+						method: 'GET',
+						params: {
+							caseReference: caseReference
+						}
+					};
+					expect(() => validateRequestWithOpenAPI(request, res, next)).not.toThrowError();
+				}
+			);
+
+			it.each([
+				'EN00001',
+				'EN000000001',
+				'en00001',
+				'en000000001',
+				'a',
+				'aaaaaaaa',
+				'11111111',
+				'enn000001'
+			])('returns error if case reference is in invalid format', (caseReference) => {
+				const request = {
+					baseUrl: '/api/v1/applications',
+					route: {
+						path: '/:caseReference'
+					},
+					method: 'GET',
+					params: {
+						caseReference: caseReference
+					}
+				};
+
+				try {
+					validateRequestWithOpenAPI(request, res, next);
+				} catch (error) {
+					const errors = error.message.errors;
+					const lastError = errors[errors.length - 1];
+					expect(lastError).toEqual('\'caseReference\' must match pattern "^[A-Za-z]{2}\\d{6,8}$"');
+				}
+			});
 		});
 	});
 });

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -24,9 +24,9 @@ paths:
           required: true
           schema:
             type: string
-            minLength: 2
-            maxLength: 12
-            pattern: '^[A-Z]{2}\d{6,8}$'
+            minLength: 8
+            maxLength: 10
+            pattern: '^[A-Za-z]{2}\d{6,8}$'
           description: Case / Project unique identifier
       responses:
         '200':
@@ -411,9 +411,9 @@ paths:
           required: true
           schema:
             type: string
-            minLength: 2
-            maxLength: 12
-            pattern: '^[A-Z]{2}\d{6,8}$'
+            minLength: 8
+            maxLength: 10
+            pattern: '^[A-Za-z]{2}\d{6,8}$'
           description: Case / Project unique identifier
       responses:
         '200':
@@ -441,9 +441,9 @@ paths:
           required: true
           schema:
             type: string
-            minLength: 2
-            maxLength: 12
-            pattern: '^[A-Z]{2}\d{6,8}$'
+            minLength: 8
+            maxLength: 10
+            pattern: '^[A-Za-z]{2}\d{6,8}$'
           description: Case / Project unique identifier
       requestBody:
         content:


### PR DESCRIPTION
- amends openapi spec (and therefore validation rules) that restrict characters that case be used in `caseReference`
    - amend min/max length to reflect rules imposed by regex
    - allow lowercase letters