### PR TITLE
fix(forms-web-app): add additional filtering for exam library doc selection

### DIFF
--- a/packages/forms-web-app/src/pages/projects/documents/utils/documents/search-examination-library-document.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/documents/search-examination-library-document.js
@@ -8,7 +8,9 @@ const searchExaminationLibraryDocument = async (case_ref) => {
 		searchTerm: examinationLibraryDocumentSearchTerm
 	});
 	const { data } = await searchDocumentsV3(examinationLibraryDocumentBody);
-	return data?.documents[0];
+	return data?.documents.filter(
+		(document) => document.type?.toLowerCase() === examinationLibraryDocumentSearchTerm
+	)[0];
 };
 
 module.exports = { searchExaminationLibraryDocument };

--- a/packages/forms-web-app/src/pages/projects/documents/utils/documents/search-examination-library-document.test.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/documents/search-examination-library-document.test.js
@@ -9,34 +9,55 @@ jest.mock('../../../../../services/document.service', () => ({
 describe('controllers/projects/documents/utils/documents/search-examination-library-document', () => {
 	describe('#searchExaminationLibraryDocument', () => {
 		describe('When searching for the examination library document', () => {
-			const body = { text: 'mock body' };
+			const mockBody = { text: 'mock body' };
 			describe('and there is an examination library document returned in an array', () => {
-				let result;
-				const mockBody = { ...body };
-				beforeEach(async () => {
-					searchDocumentsV3.mockReturnValue({
-						data: {
-							documents: [{ name: 'mock examination library document' }]
-						}
-					});
-					result = await searchExaminationLibraryDocument(mockBody);
+				const mockExamLibraryDocument = {
+					name: 'mock examination library document',
+					type: 'Examination Library'
+				};
+
+				searchDocumentsV3.mockReturnValueOnce({
+					data: {
+						documents: [
+							mockExamLibraryDocument,
+							{ name: 'some other examination library document' }
+						]
+					}
 				});
-				it('should return the examination library document object', () => {
-					expect(result).toEqual({ name: 'mock examination library document' });
+
+				it('should return the examination library document object', async () => {
+					const result = await searchExaminationLibraryDocument(mockBody);
+
+					expect(result).toEqual(mockExamLibraryDocument);
 				});
 			});
+
 			describe('and there is no an examination library document returned in an array', () => {
-				let result;
-				const mockBody = { ...body };
-				beforeEach(async () => {
-					searchDocumentsV3.mockReturnValue({
-						data: {
-							documents: []
-						}
-					});
-					result = await searchExaminationLibraryDocument(mockBody);
+				searchDocumentsV3.mockReturnValueOnce({
+					data: {
+						documents: []
+					}
 				});
-				it('should return undefined', () => {
+
+				it('should return undefined', async () => {
+					const result = await searchExaminationLibraryDocument(mockBody);
+
+					expect(result).not.toBeDefined();
+				});
+			});
+
+			describe('and there is no an document with type of examination library returned in an array', () => {
+				searchDocumentsV3.mockReturnValueOnce({
+					data: {
+						documents: [
+							{ name: 'some examination library document', type: 'not examination library' }
+						]
+					}
+				});
+
+				it('should return undefined', async () => {
+					const result = await searchExaminationLibraryDocument(mockBody);
+
 					expect(result).not.toBeDefined();
 				});
 			});


### PR DESCRIPTION
documents with the name "Examination Library" may not be _the_ examination library document, so some extra filtering is required to ensure we select the right document. This PR adds an additional check that the document's `type` attribute is equal to `Examination Library`, which should ensure we get the correct document. 