### PR TITLE
feat(applications-service-api): delete subscription endpoint

### DIFF
--- a/packages/applications-service-api/__tests__/integration/subscriptions.test.js
+++ b/packages/applications-service-api/__tests__/integration/subscriptions.test.js
@@ -177,4 +177,65 @@ describe('/api/v1/subscriptions/:caseReference', () => {
 			});
 		});
 	});
+
+	describe('DELETE', () => {
+		const encryptedEmail = encrypt('test@example.org');
+
+		it('given valid encrypted email and caseReference that exists, returns 200', async () => {
+			mockFindUnique.mockResolvedValueOnce({
+				projectName: 'drax',
+				projectEmailAddress: 'drax@example.org',
+				caseReference: 'BC0110001'
+			});
+
+			const response = await request
+				.delete('/api/v1/subscriptions/AA0000000')
+				.query({ email: encryptedEmail })
+				.send();
+
+			expect(response.status).toEqual(200);
+		});
+
+		it('given missing email, returns 400', async () => {
+			const response = await request.delete('/api/v1/subscriptions/BC0110001').send();
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				code: 400,
+				errors: ["must have required property 'email'"]
+			});
+		});
+
+		it('returns 404 if project is not found', async () => {
+			mockFindUnique.mockResolvedValueOnce(null);
+
+			const response = await request
+				.delete('/api/v1/subscriptions/XX0000000')
+				.query({ email: encryptedEmail })
+				.send();
+
+			expect(response.status).toEqual(404);
+			expect(response.body).toEqual({
+				code: 404,
+				errors: ['Project with case reference XX0000000 not found']
+			});
+		});
+
+		it('given invalid encrypted email, returns 500', async () => {
+			mockFindUnique.mockResolvedValueOnce({
+				projectName: 'drax',
+				projectEmailAddress: 'drax@example.org',
+				caseReference: 'BC0110001'
+			});
+
+			const response = await request
+				.delete('/api/v1/subscriptions/BC0110001')
+				.query({
+					email: 'bad_encrypted_email'
+				})
+				.send();
+
+			expect(response.status).toEqual(500);
+		});
+	});
 });

--- a/packages/applications-service-api/__tests__/unit/services/backoffice.publish.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/backoffice.publish.service.test.js
@@ -1,18 +1,21 @@
 jest.mock('../../../src/lib/eventClient');
 
 const { sendMessages } = require('../../../src/lib/eventClient');
-const { publishNSIPSubscription } = require('../../../src/services/backoffice.publish.service');
+const {
+	publishCreateNSIPSubscription,
+	publishDeleteNSIPSubscription
+} = require('../../../src/services/backoffice.publish.service');
 
 describe('back office publish service', () => {
-	describe('publishNSIPSubscription', () => {
-		const mockTime = new Date('2023-07-06T11:06:00.000Z');
+	afterEach(() => jest.resetAllMocks());
 
-		afterEach(() => jest.resetAllMocks());
+	describe('publishCreateNSIPSubscription', () => {
+		const mockTime = new Date('2023-07-06T11:06:00.000Z');
 
 		it('invokes event client with correct message', async () => {
 			jest.spyOn(Date, 'now').mockImplementation(() => mockTime.getTime());
 
-			await publishNSIPSubscription('BC0110001', 'foo@example.org', [
+			await publishCreateNSIPSubscription('BC0110001', 'foo@example.org', [
 				'applicationDecided',
 				'registrationOpen'
 			]);
@@ -31,6 +34,28 @@ describe('back office publish service', () => {
 					applicationProperties: {
 						version: '0.1',
 						type: 'Create'
+					}
+				}
+			]);
+		});
+	});
+
+	describe('publishDeleteNSIPSubscription', () => {
+		it('invokes event client with correct message', async () => {
+			await publishDeleteNSIPSubscription('BC0110001', 'foo@example.org');
+
+			expect(sendMessages).toBeCalledWith('register-nsip-subscription', [
+				{
+					body: {
+						nsipSubscription: {
+							caseReference: 'BC0110001',
+							emailAddress: 'foo@example.org',
+						}
+					},
+					contentType: 'application/json',
+					applicationProperties: {
+						version: '0.1',
+						type: 'Delete'
 					}
 				}
 			]);

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -591,6 +591,44 @@ paths:
                 $ref: '#/components/schemas/NotFoundError'
         '500':
           description: Internal server error
+    delete:
+      description: Delete an email update subscription
+      tags:
+        - Subscription
+      parameters:
+        - in: path
+          name: caseReference
+          example: 'EN010116'
+          required: true
+          schema:
+            type: string
+            minLength: 8
+            maxLength: 10
+            pattern: '^[A-Za-z]{2}\d{6,8}$'
+          description: Case / Project unique identifier
+        - in: query
+          name: email
+          required: true
+          schema:
+            type: string
+            description: encrypted string of email address
+      responses:
+        '200':
+          description: Successfully deleted subscription
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Case not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+        '500':
+          description: Internal server error
 
   '/api/v1/advice':
     get:

--- a/packages/applications-service-api/src/controllers/subscriptions.js
+++ b/packages/applications-service-api/src/controllers/subscriptions.js
@@ -3,7 +3,10 @@ const { sendSubscriptionCreateNotification } = require('../lib/notify');
 const { getApplication } = require('../services/application.v2.service');
 const ApiError = require('../error/apiError');
 const moment = require('moment');
-const { publishNSIPSubscription } = require('../services/backoffice.publish.service');
+const {
+	publishCreateNSIPSubscription,
+	publishDeleteNSIPSubscription
+} = require('../services/backoffice.publish.service');
 
 const createSubscription = async (req, res) => {
 	const { email, subscriptionTypes } = req.body;
@@ -39,21 +42,38 @@ const confirmSubscription = async (req, res) => {
 	const encryptedSubscriptionDetails = req.body.subscriptionDetails;
 	const { caseReference } = req.params;
 
-	const project = await getApplication(caseReference);
-	if (!project) throw ApiError.notFound(`Project with case reference ${caseReference} not found`);
+	await validateCaseReference(caseReference);
 
 	const { email, subscriptionTypes, date } = JSON.parse(decrypt(encryptedSubscriptionDetails));
 
 	validateSubscriptionDate(date);
 
-	await publishNSIPSubscription(caseReference, email, subscriptionTypes);
+	await publishCreateNSIPSubscription(caseReference, email, subscriptionTypes);
 
-	res.status(200).send();
+	res.send();
 };
+
+const deleteSubscription = async (req, res) => {
+	const { caseReference } = req.params;
+	const { email } = req.query;
+
+	await validateCaseReference(caseReference);
+
+	const decryptedEmail = decrypt(email);
+
+	await publishDeleteNSIPSubscription(caseReference, decryptedEmail);
+
+	res.send();
+};
+
+const validateCaseReference = async (caseReference) => {
+	const project = await getApplication(caseReference);
+	if (!project) throw ApiError.notFound(`Project with case reference ${caseReference} not found`);
+}
 
 const validateSubscriptionDate = (subscriptionCreatedAt) => {
 	const expiryTime = moment(subscriptionCreatedAt).add(48, 'hours');
 	if (moment().isAfter(expiryTime)) throw ApiError.badRequest('Subscription details have expired');
 };
 
-module.exports = { createSubscription, confirmSubscription };
+module.exports = { createSubscription, confirmSubscription, deleteSubscription };

--- a/packages/applications-service-api/src/routes/subscriptions.js
+++ b/packages/applications-service-api/src/routes/subscriptions.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const { validateRequestWithOpenAPI } = require('../middleware/validator/openapi');
-const { createSubscription, confirmSubscription } = require('../controllers/subscriptions');
+const { createSubscription, confirmSubscription, deleteSubscription } = require('../controllers/subscriptions');
 const { asyncRoute } = require('@pins/common/src/utils/async-route');
 
 const router = express.Router();
 
 router.post('/:caseReference', validateRequestWithOpenAPI, asyncRoute(createSubscription));
 router.put('/:caseReference', validateRequestWithOpenAPI, asyncRoute(confirmSubscription));
+router.delete('/:caseReference', validateRequestWithOpenAPI, asyncRoute(deleteSubscription));
 
 module.exports = router;

--- a/packages/applications-service-api/src/services/backoffice.publish.service.js
+++ b/packages/applications-service-api/src/services/backoffice.publish.service.js
@@ -1,26 +1,46 @@
 const config = require('../lib/config');
 const { sendMessages } = require('../lib/eventClient');
 
-const publishNSIPSubscription = async (caseReference, email, subscriptionTypes) => {
-	const body = {
-		nsipSubscription: {
-			caseReference: caseReference,
-			emailAddress: email,
-			startDate: new Date(Date.now())
+const publishCreateNSIPSubscription = async (caseReference, email, subscriptionTypes) => {
+	const message = {
+		body: {
+			nsipSubscription: {
+				caseReference: caseReference,
+				emailAddress: email,
+				startDate: new Date(Date.now())
+			},
+			subscriptionTypes: subscriptionTypes
 		},
-		subscriptionTypes: subscriptionTypes
+		contentType: 'application/json',
+		applicationProperties: {
+			version: '0.1',
+			type: 'Create'
+		}
 	};
 
 	await sendMessages(config.backOfficeIntegration.serviceBus.topics.REGISTER_NSIP_SUBSCRIPTION, [
-		{
-			body,
-			contentType: 'application/json',
-			applicationProperties: {
-				version: '0.1',
-				type: 'Create'
-			}
-		}
+		message
 	]);
 };
 
-module.exports = { publishNSIPSubscription };
+const publishDeleteNSIPSubscription = async (caseReference, email) => {
+	const message = {
+		body: {
+			nsipSubscription: {
+				caseReference: caseReference,
+				emailAddress: email
+			}
+		},
+		contentType: 'application/json',
+		applicationProperties: {
+			version: '0.1',
+			type: 'Delete'
+		}
+	};
+
+	await sendMessages(config.backOfficeIntegration.serviceBus.topics.REGISTER_NSIP_SUBSCRIPTION, [
+		message
+	]);
+};
+
+module.exports = { publishCreateNSIPSubscription, publishDeleteNSIPSubscription };


### PR DESCRIPTION
adds `DELETE /api/v1/subscriptions/{caseReference}` endpoint

takes encrypted email as query param and publishes message to back office 'delete nsip subscription' topic, containing email + case ref