### PR TITLE
fix(applications-service-api): return 204 from PUT/DELETE subscription

### DIFF
--- a/packages/applications-service-api/__tests__/integration/subscriptions.test.js
+++ b/packages/applications-service-api/__tests__/integration/subscriptions.test.js
@@ -134,7 +134,7 @@ describe('/api/v1/subscriptions/:caseReference', () => {
 				subscriptionDetails: validPayload
 			});
 
-			expect(response.status).toEqual(200);
+			expect(response.status).toEqual(204);
 		});
 
 		it('given expired payload, returns 400', async () => {
@@ -193,7 +193,7 @@ describe('/api/v1/subscriptions/:caseReference', () => {
 				.query({ email: encryptedEmail })
 				.send();
 
-			expect(response.status).toEqual(200);
+			expect(response.status).toEqual(204);
 		});
 
 		it('given missing email, returns 400', async () => {

--- a/packages/applications-service-api/__tests__/unit/controllers/subscriptions.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/subscriptions.test.js
@@ -24,7 +24,7 @@ describe('subscriptions controller', () => {
 
 	beforeEach(() => {
 		jest.spyOn(Date, 'now').mockImplementation(() => mockTime.getTime());
-		mockRes = { send: jest.fn() };
+		mockRes = { send: jest.fn(), status: jest.fn().mockImplementation(() => mockRes) };
 	});
 	afterEach(() => jest.resetAllMocks());
 
@@ -123,6 +123,7 @@ describe('subscriptions controller', () => {
 				'applicationSubmitted',
 				'applicationDecided'
 			]);
+			expect(mockRes.status).toBeCalledWith(204);
 			expect(mockRes.send).toBeCalled();
 		});
 
@@ -185,7 +186,7 @@ describe('subscriptions controller', () => {
 	describe('deleteSubscription', () => {
 		const req = {
 			params: {
-				caseReference: 'BC0110001',
+				caseReference: 'BC0110001'
 			},
 			query: {
 				email: 'some_encrypted_string'
@@ -198,13 +199,12 @@ describe('subscriptions controller', () => {
 				projectEmailAddress: 'drax@example.org',
 				caseRef: 'BC0110001'
 			});
-			when(decrypt)
-				.calledWith('some_encrypted_string')
-				.mockReturnValue('user@example.org');
+			when(decrypt).calledWith('some_encrypted_string').mockReturnValue('user@example.org');
 
 			await deleteSubscription(req, mockRes);
 
 			expect(publishDeleteNSIPSubscription).toBeCalledWith('BC0110001', 'user@example.org');
+			expect(mockRes.status).toBeCalledWith(204);
 			expect(mockRes.send).toBeCalled();
 		});
 

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -536,6 +536,15 @@ paths:
       responses:
         '200':
           description: Successfully created subscription
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subscriptionDetails:
+                    type: string
+                    description: encrypted string containing subscription details
+                    example: 60492abe2c6eed5eb43695f8eda5a14a57a44178d28c641772db0723685b4501
         '400':
           description: Invalid request
           content:
@@ -575,7 +584,7 @@ paths:
                   type: string
                   description: encrypted string containing 'email', 'subscriptionTypes' and 'date'
       responses:
-        '200':
+        '204':
           description: Successfully confirmed subscription
         '400':
           description: Invalid request
@@ -613,7 +622,7 @@ paths:
             type: string
             description: encrypted string of email address
       responses:
-        '200':
+        '204':
           description: Successfully deleted subscription
         '400':
           description: Invalid request

--- a/packages/applications-service-api/src/controllers/subscriptions.js
+++ b/packages/applications-service-api/src/controllers/subscriptions.js
@@ -50,7 +50,7 @@ const confirmSubscription = async (req, res) => {
 
 	await publishCreateNSIPSubscription(caseReference, email, subscriptionTypes);
 
-	res.send();
+	res.status(204).send();
 };
 
 const deleteSubscription = async (req, res) => {
@@ -63,13 +63,13 @@ const deleteSubscription = async (req, res) => {
 
 	await publishDeleteNSIPSubscription(caseReference, decryptedEmail);
 
-	res.send();
+	res.status(204).send();
 };
 
 const validateCaseReference = async (caseReference) => {
 	const project = await getApplication(caseReference);
 	if (!project) throw ApiError.notFound(`Project with case reference ${caseReference} not found`);
-}
+};
 
 const validateSubscriptionDate = (subscriptionCreatedAt) => {
 	const expiryTime = moment(subscriptionCreatedAt).add(48, 'hours');


### PR DESCRIPTION
- update response status code for `PUT` and `DELETE` `/api/v1/subscriptions/{caseReference}` endpoints
- 204 (No Content) is more appropriate given there is no response body. The web app API wrapper fails when parsing responses that are 200 with no body.