### PR TITLE
ASB-1640: fix document filtering issues

### DIFF
--- a/packages/applications-service-api/__tests__/unit/repositories/document.backoffice.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/document.backoffice.repository.test.js
@@ -57,6 +57,22 @@ describe('document repository', () => {
 			expect(mockFindMany.mock.calls[0][0].where.AND[2].OR[0].AND[0].stage).toEqual('examination');
 			expect(mockCount.mock.calls[0][0].where.AND[2].OR[0].AND[0].stage).toEqual('examination');
 		});
+
+		it('calls findMany and count with filters including type if provided', async () => {
+			await getDocuments({
+				caseReference: caseReference,
+				filters: [
+					{ name: 'stage', value: 'examination', type: [{ value: 'Additional Submissions' }] }
+				]
+			});
+
+			expect(mockFindMany.mock.calls[0][0].where.AND[2].OR[0].AND[1].filter1['in'][0]).toEqual(
+				'Additional Submissions'
+			);
+			expect(mockCount.mock.calls[0][0].where.AND[2].OR[0].AND[1].filter1['in'][0]).toEqual(
+				'Additional Submissions'
+			);
+		});
 	});
 
 	describe('getFilters', () => {

--- a/packages/applications-service-api/src/lib/config.js
+++ b/packages/applications-service-api/src/lib/config.js
@@ -70,6 +70,7 @@ module.exports = {
 			baseUrl: process.env.APP_APPLICATIONS_BASE_URL
 		}
 	},
+	isProduction: process.env.NODE_ENV === 'production',
 	itemsPerPage: Number(process.env.DOCUMENTS_PER_PAGE || 20),
 	timetableItemsPerPage: 100,
 	documentsHost:

--- a/packages/applications-service-api/src/lib/prisma.js
+++ b/packages/applications-service-api/src/lib/prisma.js
@@ -1,16 +1,39 @@
 const { PrismaClient } = require('@prisma/client');
+const { isProduction } = require('./config');
+const logger = require('./logger');
 
 let prismaClientInstance;
 
 const createPrismaClient = () => {
+	const logOption = isProduction
+		? ['query', 'info', 'warn', 'error']
+		: [{ emit: 'event', level: 'query' }, 'info', 'warn', 'error'];
+
 	if (!prismaClientInstance) {
 		prismaClientInstance = new PrismaClient({
-			log: ['query', 'info', 'warn', 'error']
+			log: logOption
 		});
-
 	}
 
+	if (!isProduction) registerQueryLogger(prismaClientInstance);
+
 	return prismaClientInstance;
+};
+
+const registerQueryLogger = (prismaClient) => {
+	prismaClient.$on('query', async (e) => {
+		try {
+			const params = JSON.parse(e.params);
+			let sql = `${e.query}`;
+			params.forEach((param, index) => {
+				let value = typeof param === 'string' ? `'${param}'` : param;
+				sql = sql.replace(`@P${index + 1}`, value);
+			});
+			logger.info(sql);
+		} catch (e) {
+			logger.error(e);
+		}
+	});
 };
 
 module.exports = { prismaClient: createPrismaClient() };

--- a/packages/applications-service-api/src/repositories/document.backoffice.repository.js
+++ b/packages/applications-service-api/src/repositories/document.backoffice.repository.js
@@ -47,7 +47,7 @@ const getDocuments = async (query) => {
 			}
 
 			if (filter.type && filter.type.length > 0)
-				filterStatement['AND']['filter1'] = filter.type.map((type) => type.value);
+				filterStatement['AND'].push({ filter1: { in: filter.type.map((type) => type.value) } });
 
 			filters.push(filterStatement);
 		});

--- a/packages/back-office-subscribers/nsip-documents/index.js
+++ b/packages/back-office-subscribers/nsip-documents/index.js
@@ -1,4 +1,5 @@
 module.exports = async (context, message) => {
+	context.log(`invoking nsip-documents function with message: ${JSON.stringify(message)}`);
 	context.bindings.document = {
 		...message,
 		modifiedAt: new Date()

--- a/packages/back-office-subscribers/nsip-project/index.js
+++ b/packages/back-office-subscribers/nsip-project/index.js
@@ -13,6 +13,7 @@ const excludedProperties = [
 ];
 
 module.exports = async (context, message) => {
+	context.log(`invoking nsip-project function with message: ${JSON.stringify(message)}`);
 	context.bindings.project = parseMessage(message);
 };
 

--- a/packages/forms-web-app/src/pages/projects/documents/utils/documents/body/mapQueryToFilterBody.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/documents/body/mapQueryToFilterBody.js
@@ -1,10 +1,10 @@
 const { makeIntoArray } = require('../../../../../examination/select-file/utils/helpers');
 const mapQueryToFilterBody = (query) =>
 	Object.entries(query).map(([key, value]) => {
-		const [name, splitValue] = key.split('-');
+		const [name, ...splitValue] = key.split('-');
 		return {
 			name,
-			value: splitValue,
+			value: splitValue.join('-'),
 			type: makeIntoArray(value).map((item) => ({
 				value: item
 			}))

--- a/packages/forms-web-app/src/pages/projects/documents/utils/documents/body/mapQueryToFilterBody.test.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/documents/body/mapQueryToFilterBody.test.js
@@ -1,7 +1,11 @@
 const { mapQueryToFilterBody } = require('./mapQueryToFilterBody');
 describe('When mapping the query params to a filter body for v3 api request', () => {
 	describe('and there are values', () => {
-		const mockQuery = { 'stage-1': 'Fella', 'stage-2': ['fella 1', 'fella 2'] };
+		const mockQuery = {
+			'stage-1': 'Fella',
+			'stage-2': ['fella 1', 'fella 2'],
+			'stage-pre-examination': 'baz'
+		};
 		const result = mapQueryToFilterBody(mockQuery);
 		it('should return the filters mapped to the body object', () => {
 			expect(result).toEqual([
@@ -25,6 +29,11 @@ describe('When mapping the query params to a filter body for v3 api request', ()
 						}
 					],
 					value: '2'
+				},
+				{
+					name: 'stage',
+					type: [{ value: 'baz' }],
+					value: 'pre-examination'
 				}
 			]);
 		});


### PR DESCRIPTION
fixes a couple of issues with filtering on documents page (Back Office document integration only)

- `type` property in request was ignored: Prisma query was not being constructed correctly 
- `pre-examination` stage filter ignored: Parsing of query params uses `-` as a separator so was conflicting with `-` in `pre-examination` string

also added some more verbose logging to azure functions and prisma queries (local + dev only)