### PR TITLE
fix(forms-web-app): fix labels on document date filters

### DIFF
--- a/packages/forms-web-app/src/pages/projects/documents/utils/filters/dates/fixtures/expected-from-date-is-before-to-date-dates-filter-obj.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/filters/dates/fixtures/expected-from-date-is-before-to-date-dates-filter-obj.js
@@ -4,10 +4,9 @@ const expectedFromDateIsBeforeToDateDatesFilterObj = {
 			label: 'Date from',
 			tags: [
 				{
-					alt: 'Remove documents published before 1 January 2023 filter',
 					icon: 'close',
 					link: '?date-to-day=2&date-to-month=1&date-to-year=2023',
-					text: '1 January 2023'
+					textHtml: `<span class="govuk-visually-hidden">Remove documents published before</span> 1 January 2023 <span class="govuk-visually-hidden">filter</span>`
 				}
 			]
 		},
@@ -15,10 +14,9 @@ const expectedFromDateIsBeforeToDateDatesFilterObj = {
 			label: 'Date to',
 			tags: [
 				{
-					alt: 'Remove documents published after 2 January 2023 filter',
 					icon: 'close',
 					link: '?date-from-day=1&date-from-month=1&date-from-year=2023',
-					text: '2 January 2023'
+					textHtml: `<span class="govuk-visually-hidden">Remove documents published after</span> 2 January 2023 <span class="govuk-visually-hidden">filter</span>`
 				}
 			]
 		}

--- a/packages/forms-web-app/src/pages/projects/documents/utils/filters/dates/utils/get-active-date-filters.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/filters/dates/utils/get-active-date-filters.js
@@ -10,26 +10,24 @@ const getActiveDateFilters = (query) => {
 	const { datePublishedFrom, datePublishedTo } = getDatesFilterPublishedDates(query);
 
 	if (datePublishedFrom) {
-		const formattedDatePublishedFrom = formatDate(datePublishedFrom);
 		activeFilterDatesArray.push(
 			getActiveDateFilterViewModel(
 				query,
 				'Date from',
-				`Remove documents published before ${formattedDatePublishedFrom} filter`,
-				formattedDatePublishedFrom,
+				`documents published before`,
+				formatDate(datePublishedFrom),
 				datesFilterFormGroupsConfig.from.name
 			)
 		);
 	}
 
 	if (datePublishedTo) {
-		const formattedDatePublishedTo = formatDate(datePublishedTo);
 		activeFilterDatesArray.push(
 			getActiveDateFilterViewModel(
 				query,
 				'Date to',
-				`Remove documents published after ${formattedDatePublishedTo} filter`,
-				formattedDatePublishedTo,
+				`documents published after`,
+				formatDate(datePublishedTo),
 				datesFilterFormGroupsConfig.to.name
 			)
 		);

--- a/packages/forms-web-app/src/pages/projects/documents/utils/filters/dates/view-model/get-active-date-filter-view-model.js
+++ b/packages/forms-web-app/src/pages/projects/documents/utils/filters/dates/view-model/get-active-date-filter-view-model.js
@@ -2,13 +2,12 @@ const {
 	getParamsWithoutActiveDatesFilter
 } = require('../utils/get-params-without-active-dates-filter');
 
-const getActiveDateFilterViewModel = (query, label, tagAlt, tagText, inputNamePrefix) => ({
+const getActiveDateFilterViewModel = (query, label, filterName, filterValue, inputNamePrefix) => ({
 	label,
 	tags: [
 		{
-			alt: tagAlt,
 			icon: 'close',
-			text: tagText,
+			textHtml: `<span class="govuk-visually-hidden">Remove ${filterName}</span> ${filterValue} <span class="govuk-visually-hidden">filter</span>`,
 			link: getParamsWithoutActiveDatesFilter(query, inputNamePrefix)
 		}
 	]


### PR DESCRIPTION
fixes regression caused by [ASB-1202](https://github.com/Planning-Inspectorate/applications-service/pull/669/files#diff-10937d44ec7e52d5a04a6dd385cc11212ea9e7e2fe3d48d4966d0badf38f4d3aR24) where the 'remove date from/to' filter buttons on the documents page no longer had labels

