### PR TITLE
fix: mssql volume mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,8 @@ services:
       - 1433:1433
     hostname: mssql
     volumes:
-      - ./init/mssql:/var/opt/mssql
+      - ./init/mssql/mssql.conf:/var/opt/mssql/mssql.conf
+      - ./init/mssql/data:/var/opt/mssql/data
 
 #  redis-commander:
 #    container_name: redis-commander


### PR DESCRIPTION
Windows can't map whole '/var/opt/mssql' directory as a volume and would prevent container from starting