### PR TITLE
fix(applications-service-api): return 200 when no project updates for case

### DIFF
--- a/packages/applications-service-api/__tests__/integration/projectUpdates.test.js
+++ b/packages/applications-service-api/__tests__/integration/projectUpdates.test.js
@@ -2,21 +2,16 @@ const { request } = require('../__data__/supertest');
 const { PROJECT_UPDATE_DB, PROJECT_UPDATE_RESPONSE } = require('../__data__/projectUpdates');
 
 const mockProjectUpdateFindMany = jest.fn();
-const mockProjectFindUnique = jest.fn();
 jest.mock('../../src/lib/prisma', () => ({
 	prismaClient: {
 		projectUpdate: {
 			findMany: (query) => mockProjectUpdateFindMany(query)
-		},
-		project: {
-			findUnique: (query) => mockProjectFindUnique(query)
 		}
 	}
 }));
 
 describe('/api/v1/project-updates/{{caseReference}}', () => {
 	it('returns project updates when case has some', async () => {
-		mockProjectFindUnique.mockResolvedValueOnce({ id: 1 });
 		mockProjectUpdateFindMany.mockResolvedValueOnce([PROJECT_UPDATE_DB]);
 
 		const response = await request.get('/api/v1/project-updates/BC0110001');
@@ -26,7 +21,6 @@ describe('/api/v1/project-updates/{{caseReference}}', () => {
 	});
 
 	it('returns no project updates when case has none', async () => {
-		mockProjectFindUnique.mockResolvedValueOnce({ id: 1 });
 		mockProjectUpdateFindMany.mockResolvedValueOnce([]);
 
 		const response = await request.get('/api/v1/project-updates/BC0110001');
@@ -41,17 +35,7 @@ describe('/api/v1/project-updates/{{caseReference}}', () => {
 		expect(response.status).toEqual(400);
 	});
 
-	it('returns 404 when case not found', async () => {
-		mockProjectFindUnique.mockResolvedValueOnce(null);
-
-		const response = await request.get('/api/v1/project-updates/BC0110001');
-
-		expect(response.status).toEqual(404);
-	});
-
 	it('returns 500 when unhandled error occurs', async () => {
-		mockProjectFindUnique.mockRejectedValueOnce(new Error('some error'));
-
 		const response = await request.get('/api/v1/project-updates/BC0110001');
 
 		expect(response.status).toEqual(500);

--- a/packages/applications-service-api/__tests__/unit/controllers/project-updates.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/project-updates.test.js
@@ -1,13 +1,11 @@
 jest.mock('../../../src/services/application.v2.service');
 jest.mock('../../../src/repositories/projectUpdate.repository');
 
-const { getApplication } = require('../../../src/services/application.v2.service');
 const { getProjectUpdates } = require('../../../src/controllers/project-updates');
 
 const {
 	getProjectUpdates: getProjectUpdatesRepository
 } = require('../../../src/repositories/projectUpdate.repository');
-const { APPLICATION_DB } = require('../../__data__/application');
 const { PROJECT_UPDATE_DB, PROJECT_UPDATE_RESPONSE } = require('../../__data__/projectUpdates');
 
 describe('project updates controller', () => {
@@ -26,7 +24,6 @@ describe('project updates controller', () => {
 		afterEach(() => jest.resetAllMocks());
 
 		it('returns project updates when case has some', async () => {
-			getApplication.mockResolvedValueOnce(APPLICATION_DB);
 			getProjectUpdatesRepository.mockResolvedValueOnce([PROJECT_UPDATE_DB]);
 
 			await getProjectUpdates(req, mockRes);
@@ -37,7 +34,6 @@ describe('project updates controller', () => {
 		});
 
 		it('returns no project updates when case has none', async () => {
-			getApplication.mockResolvedValueOnce(APPLICATION_DB);
 			getProjectUpdatesRepository.mockResolvedValueOnce([]);
 
 			await getProjectUpdates(req, mockRes);
@@ -47,21 +43,9 @@ describe('project updates controller', () => {
 			});
 		});
 
-		it('returns 404 when case not found', async () => {
-			getApplication.mockResolvedValueOnce(null);
-
-			await expect(getProjectUpdates(req, mockRes)).rejects.toEqual({
-				code: 404,
-				message: {
-					errors: ['Application BC0110001 was not found']
-				}
-			});
-		});
-
 		it('returns 500 when unhandled error occurs', async () => {
 			const expectedError = new Error('some error');
 
-			getApplication.mockResolvedValueOnce(APPLICATION_DB);
 			getProjectUpdatesRepository.mockRejectedValueOnce(expectedError);
 
 			await expect(getProjectUpdates(req, mockRes)).rejects.toThrow(expectedError);

--- a/packages/applications-service-api/src/controllers/project-updates.js
+++ b/packages/applications-service-api/src/controllers/project-updates.js
@@ -1,14 +1,9 @@
-const { getApplication } = require('../services/application.v2.service');
 const {
 	getProjectUpdates: getProjectUpdatesRepository
 } = require('../repositories/projectUpdate.repository');
-const ApiError = require('../error/apiError');
 
 const getProjectUpdates = async (req, res) => {
 	const { caseReference } = req.params;
-
-	const application = await getApplication(caseReference);
-	if (!application) throw ApiError.applicationNotFound(caseReference);
 
 	const projectUpdatesDB = await getProjectUpdatesRepository(caseReference);
 


### PR DESCRIPTION
remove validation that a case exists before looking for project-updates in the db