### PR TITLE
fix(project-info): routes for case-id that should be blocked return 404 correctly 

### DIFF
--- a/packages/forms-web-app/src/pages/projects/_middleware/middleware.component.test.js
+++ b/packages/forms-web-app/src/pages/projects/_middleware/middleware.component.test.js
@@ -118,10 +118,13 @@ describe('projects _middleware', () => {
 	});
 	describe('#projectMigrationMiddleware', () => {
 		const next = jest.fn();
-		const res = {};
+		const res = {
+			status: jest.fn().mockReturnThis(),
+			render: jest.fn()
+		};
 
 		describe('when the project case-ref is in config.featureFlag.projectMigrationCaseReferences', () => {
-			it('should call next() without any errors', () => {
+			it('should call next()', () => {
 				const req = {
 					params: { case_ref: 'mock-case-ref-in-config' }
 				};
@@ -130,14 +133,13 @@ describe('projects _middleware', () => {
 			});
 		});
 		describe('when the project case-ref is not in config.featureFlag.projectMigrationCaseReferences', () => {
-			it('should call next with an error', () => {
+			it('should call res.status(404).render("error/not-found")', () => {
 				const req = {
 					params: { case_ref: 'mock-case-ref-not-in-config' }
 				};
 				projectMigrationMiddleware(req, res, next);
-				expect(next).toHaveBeenCalledWith(
-					new Error('Project migration feature flag not enabled for this project')
-				);
+				expect(res.status).toHaveBeenCalledWith(404);
+				expect(res.render).toHaveBeenCalledWith('error/not-found');
 			});
 		});
 	});

--- a/packages/forms-web-app/src/pages/projects/_middleware/middleware.js
+++ b/packages/forms-web-app/src/pages/projects/_middleware/middleware.js
@@ -39,7 +39,7 @@ const projectMigrationMiddleware = (req, res, next) => {
 	if (config.featureFlag.projectMigrationCaseReferences.includes(req.params.case_ref)) {
 		next();
 	} else {
-		next(new Error('Project migration feature flag not enabled for this project'));
+		res.status(404).render('error/not-found');
 	}
 };
 


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/ASB-1754

Routes used to return 500 instead of 404.