### PR TITLE
fix: get applications empty parameters converted to array

### DIFF
--- a/packages/applications-service-api/__tests__/unit/middleware/parseQueryParamProperties.test.js
+++ b/packages/applications-service-api/__tests__/unit/middleware/parseQueryParamProperties.test.js
@@ -45,6 +45,20 @@ describe('parseQueryParamProperties middleware', () => {
 				}
 			});
 		});
+
+		it('converts empty string to empty array', () => {
+			const req = {
+				query: {
+					foo: ''
+				}
+			};
+			normaliseArrayQueryParams(['foo'])(req, {}, jest.fn());
+			expect(req).toEqual({
+				query: {
+					foo: []
+				}
+			});
+		});
 	});
 
 	describe('parseIntegerQueryParams', () => {

--- a/packages/applications-service-api/src/middleware/parseQueryParamProperties.js
+++ b/packages/applications-service-api/src/middleware/parseQueryParamProperties.js
@@ -8,7 +8,10 @@ const { parseInteger } = require('../utils/parse');
 const normaliseArrayQueryParams = (paramNames) => (req, res, next) => {
 	paramNames.forEach((paramName) => {
 		const paramValue = req.query?.[paramName];
+		// convert non-array to array
 		if (paramValue) req.query[paramName] = Array.isArray(paramValue) ? paramValue : [paramValue];
+		// convert empty string to empty array
+		if (paramValue === '') req.query[paramName] = [];
 	});
 	next();
 };


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/ASB-1836

normaliseArrayQueryParams was converting non array filters into array so they pass the validation check from open-api, however empty strings were being ignored. normaliseArrayQueryParams now converts empty strings to empty array which passes the open-api check as expected.