### PR TITLE
feat(applications-service-api): add applications totalItemsWithoutFilters property

### DIFF
--- a/packages/applications-service-api/__tests__/unit/services/application.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/application.service.test.js
@@ -5,7 +5,8 @@ const {
 } = require('../../../src/services/application.service');
 const {
 	getApplication: getApplicationRepository,
-	getAllApplications: getAllApplicationsRepository
+	getAllApplications: getAllApplicationsRepository,
+	getAllApplicationsCount: getAllApplicationsCountRepository
 } = require('../../../src/repositories/project.ni.repository');
 const mapApplicationsToCSV = require('../../../src/utils/map-applications-to-csv');
 const {
@@ -16,7 +17,8 @@ const {
 
 jest.mock('../../../src/repositories/project.ni.repository', () => ({
 	getApplication: jest.fn(),
-	getAllApplications: jest.fn()
+	getAllApplications: jest.fn(),
+	getAllApplicationsCount: jest.fn()
 }));
 
 jest.mock('../../../src/utils/map-applications-to-csv', () => jest.fn());
@@ -57,6 +59,7 @@ describe('application.service', () => {
 					applications: APPLICATIONS_NI_DB,
 					count: APPLICATIONS_NI_DB.length
 				});
+			getAllApplicationsCountRepository.mockResolvedValueOnce(APPLICATIONS_NI_DB.length);
 		});
 		describe('pagination', () => {
 			describe('when page num', () => {
@@ -248,6 +251,7 @@ describe('application.service', () => {
 				itemsPerPage: 25,
 				totalPages: 1,
 				currentPage: 1,
+				totalItemsWithoutFilters: APPLICATIONS_FO.length,
 				filters: availableFilters
 			});
 		});

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -150,6 +150,33 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Application'
+                  filters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          enum:
+                            - stage
+                            - region
+                            - sector
+                          example: stage
+                          description: Name of property to filter by
+                        value:
+                          oneOf:
+                            - type: string
+                            - type: number
+                          example: 1
+                          description: Value of property to filter by
+                        label:
+                          type: string
+                          example: Pre-application
+                          description: Display name for the filter value
+                        count:
+                          type: number
+                          example: 5
+                          description: Number of documents matching the filter
                   totalItems:
                     type: number
                     example: 1

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -179,6 +179,7 @@ paths:
                           description: Number of documents matching the filter
                   totalItems:
                     type: number
+                    description: Count of items with provided filters applied
                     example: 1
                   itemsPerPage:
                     type: number
@@ -189,6 +190,10 @@ paths:
                   currentPage:
                     type: number
                     example: 1
+                  totalItemsWithoutFilters:
+                    type: number
+                    description: Count of items with no filters applied
+                    example: 10
         '404':
           description: No applications found
 

--- a/packages/applications-service-api/src/controllers/applications.js
+++ b/packages/applications-service-api/src/controllers/applications.js
@@ -22,10 +22,15 @@ const getApplication = async (req, res) => {
 };
 
 const getAllApplications = async (req, res) => {
-	logger.debug(`Retrieving all applications ...`);
-
-	const { applications, totalItems, currentPage, itemsPerPage, totalPages, filters } =
-		await getAllApplicationsFromApplicationApiService(req.query);
+	const {
+		applications,
+		totalItems,
+		currentPage,
+		itemsPerPage,
+		totalPages,
+		filters,
+		totalItemsWithoutFilters
+	} = await getAllApplicationsFromApplicationApiService(req.query);
 
 	const response = {
 		applications,
@@ -33,6 +38,7 @@ const getAllApplications = async (req, res) => {
 		currentPage,
 		itemsPerPage,
 		totalPages,
+		totalItemsWithoutFilters,
 		filters
 	};
 

--- a/packages/applications-service-api/src/services/application.service.js
+++ b/packages/applications-service-api/src/services/application.service.js
@@ -1,6 +1,7 @@
 const {
 	getApplication: getApplicationRepository,
-	getAllApplications: getAllApplicationsRepository
+	getAllApplications: getAllApplicationsRepository,
+	getAllApplicationsCount
 } = require('../repositories/project.ni.repository');
 const mapApplicationsToCSV = require('../utils/map-applications-to-csv');
 const { addMapZoomLvlAndLongLat } = require('../utils/add-map-zoom-and-longlat');
@@ -30,6 +31,7 @@ const getAllApplications = async (query) => {
 	if (!isEmpty(appliedFilters)) repositoryOptions.filters = appliedFilters;
 
 	const { applications, count } = await getAllApplicationsRepository(repositoryOptions);
+	const totalItemsWithoutFilters = await getAllApplicationsCount();
 
 	return {
 		applications: applications.map((document) => addMapZoomLvlAndLongLat(document)),
@@ -37,6 +39,7 @@ const getAllApplications = async (query) => {
 		itemsPerPage: size,
 		totalPages: Math.ceil(Math.max(1, count) / size),
 		currentPage: pageNo,
+		totalItemsWithoutFilters,
 		filters: availableFilters
 	};
 };


### PR DESCRIPTION
Adds `totalItemsWithoutFilters` property to the `/api/v1/applications` endpoint response. This property represents the total number of applications _without any_ filters applied. The `totalItems` property is left as-is, and continues to represent the total number of applications _with_ filters applied.

This satisfies a missed requirement (raised in ASB-1850) that the frontend needs to show the total 'unfiltered' count in the link to the CSV download, which is a list of all unfiltered applications.

Example response:

```
{
    "applications": [
        // 4 applications
    ],
    "totalItems": 4,
    "currentPage": 1,
    "itemsPerPage": 25,
    "totalPages": 1,
    "totalItemsWithoutFilters": 21, // <----------------- new property
    "filters": [
        // some filters
    ]
}
```