### PR TITLE
feat(applications-service-api): allow subscribing to project updates for ni application

### DIFF
--- a/packages/applications-service-api/__tests__/__data__/application.js
+++ b/packages/applications-service-api/__tests__/__data__/application.js
@@ -69,7 +69,7 @@ const APPLICATION_FO = {
 	PromoterName: 'North Lincolnshire Green Energy Park Limited',
 	PromoterFirstName: 'Joe',
 	PromoterLastName: 'Bloggs',
-	ApplicantEmailAddress: 'chris.bungay@planninginspectorate.gov.uk',
+	ApplicantEmailAddress: 'joe.bloggs@planninginspectorate.gov.uk',
 	ApplicantPhoneNumber: '01314960000',
 	WebAddress: 'https://northlincolnshiregreenenergypark.co.uk/',
 	ProjectEmailAddress: 'webteam@planninginspectorate.gov.uk',
@@ -101,7 +101,7 @@ const APPLICATION_FO = {
 
 // application data as currently returned by /applications/{caseReference} endpoints.
 // To be deprecated in favour of new format as seen below in APPLICATION_API
-const APPLICATION_API_LEGACY = {
+const APPLICATION_API_V1 = {
 	...omit(APPLICATION_FO, ['LatLong']),
 	LongLat: ['-0.7028315466694124', '53.620079146110655'],
 	MapZoomLevel: 6,
@@ -120,6 +120,7 @@ const APPLICATION_API = {
 	applicantName: 'North Lincolnshire Green Energy Park Limited',
 	applicantFirstName: 'Joe',
 	applicantLastName: 'Bloggs',
+	applicantEmailAddress: 'joe.bloggs@planninginspectorate.gov.uk',
 	applicantPhoneNumber: '01314960000',
 	applicantWebsite: 'https://northlincolnshiregreenenergypark.co.uk/',
 	easting: 485899,
@@ -572,6 +573,6 @@ module.exports = {
 	APPLICATIONS_NI_FILTER_COLUMNS,
 	APPLICATIONS_FO,
 	APPLICATIONS_FO_FILTERS,
-	APPLICATION_API_LEGACY,
+	APPLICATION_API_V1,
 	APPLICATION_API
 };

--- a/packages/applications-service-api/__tests__/setup-jest.js
+++ b/packages/applications-service-api/__tests__/setup-jest.js
@@ -5,6 +5,4 @@ process.env.MYSQL_PASSWORD = 'password';
 process.env.MYSQL_DATABASE = 'database';
 process.env.MYSQL_HOST = 'host';
 process.env.MYSQL_PORT = '3306';
-process.env.BACK_OFFICE_INTEGRATION_GET_APPLICATION_CASE_REFERENCES = 'EN0110004';
-process.env.BACK_OFFICE_INTEGRATION_GET_DOCUMENTS_CASE_REFERENCES = 'EN0110004';
 process.env.APPLICATIONS_WEB_BASE_URL = 'http://forms-web-app:9004';

--- a/packages/applications-service-api/__tests__/unit/controllers/applications.v2.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/applications.v2.test.js
@@ -6,7 +6,7 @@ jest.mock('../../../src/services/application.service');
 const mockGetApplication = require('../../../src/services/application.service').getApplication;
 
 const { getApplication } = require('../../../src/controllers/applications.v2');
-const { APPLICATION_API, APPLICATION_API_LEGACY } = require('../../__data__/application');
+const { APPLICATION_API, APPLICATION_API_V1 } = require('../../__data__/application');
 
 describe('applications v2 controller', () => {
 	let res;
@@ -19,7 +19,7 @@ describe('applications v2 controller', () => {
 		describe('parsing regions', () => {
 			const req = {
 				params: {
-					caseReference: 'EN0110004'
+					caseReference: 'BC0110001'
 				}
 			};
 
@@ -33,7 +33,7 @@ describe('applications v2 controller', () => {
 				const responseBody = res._getData();
 
 				expect(responseBody).toEqual({
-					...APPLICATION_API_LEGACY,
+					...APPLICATION_API_V1,
 					DateOfDCOAcceptance_NonAcceptance: null,
 					ApplicantEmailAddress: 'TBC',
 					ApplicantPhoneNumber: 'TBC',

--- a/packages/applications-service-api/__tests__/unit/controllers/subscriptions.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/subscriptions.test.js
@@ -3,7 +3,7 @@ jest.mock('../../../src/lib/notify');
 jest.mock('../../../src/lib/crypto');
 jest.mock('../../../src/services/backoffice.publish.service');
 
-const { getBackOfficeApplication } = require('../../../src/services/application.service');
+const { getApplication } = require('../../../src/services/application.service');
 const { sendSubscriptionCreateNotification } = require('../../../src/lib/notify');
 const { encrypt, decrypt } = require('../../../src/lib/crypto');
 const {
@@ -17,6 +17,7 @@ const {
 	publishCreateNSIPSubscription,
 	publishDeleteNSIPSubscription
 } = require('../../../src/services/backoffice.publish.service');
+const { APPLICATION_API } = require('../../__data__/application');
 
 describe('subscriptions controller', () => {
 	const mockTime = new Date('2023-07-06T11:06:00.000Z');
@@ -40,11 +41,7 @@ describe('subscriptions controller', () => {
 		};
 
 		it('invokes notify with correct project and subscription details', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseReference: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			encrypt.mockReturnValueOnce('some_encrypted_string');
 
 			await createSubscription(req, mockRes);
@@ -56,9 +53,9 @@ describe('subscriptions controller', () => {
 				email: 'user@example.org',
 				subscriptionDetails: 'some_encrypted_string',
 				project: {
-					email: 'drax@example.org',
-					name: 'drax',
-					caseReference: 'BC0110001'
+					email: 'webteam@planninginspectorate.gov.uk',
+					name: 'North Lincolnshire Green Energy Park',
+					caseReference: 'EN010116'
 				}
 			});
 			expect(mockRes.send).toBeCalledWith({
@@ -67,7 +64,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws not found error if project with case reference does not exist', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce(null);
+			getApplication.mockResolvedValueOnce(null);
 
 			const expectedError = new ApiError(404, {
 				errors: ['Project with case reference BC0110001 not found']
@@ -77,11 +74,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws error if notify fails', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseRef: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			encrypt.mockReturnValueOnce('some_encrypted_string');
 
 			const expectedError = new Error('some error');
@@ -102,11 +95,7 @@ describe('subscriptions controller', () => {
 		};
 
 		it('given valid subscriptionDetails, invokes publishCreateNSIPSubscription, and returns 200', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseRef: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			when(decrypt)
 				.calledWith('some_encrypted_string')
 				.mockReturnValue(
@@ -128,7 +117,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws not found error if project with case reference does not exist', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce(null);
+			getApplication.mockResolvedValueOnce(null);
 
 			const expectedError = new ApiError(404, {
 				errors: ['Project with case reference BC0110001 not found']
@@ -138,11 +127,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws bad request error if subscriptionDetails have expired', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseRef: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			when(decrypt)
 				.calledWith('some_encrypted_string')
 				.mockReturnValue(
@@ -161,11 +146,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws error if publishCreateNSIPSubscription fails', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseRef: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			when(decrypt)
 				.calledWith('some_encrypted_string')
 				.mockReturnValue(
@@ -200,11 +181,7 @@ describe('subscriptions controller', () => {
 		])(
 			'throws error if required property is missing from subscriptionDetails',
 			async (missingPropertyName, payload) => {
-				getBackOfficeApplication.mockResolvedValueOnce({
-					projectName: 'drax',
-					projectEmailAddress: 'drax@example.org',
-					caseRef: 'BC0110001'
-				});
+				getApplication.mockResolvedValueOnce(APPLICATION_API);
 				when(decrypt).calledWith('some_encrypted_string').mockReturnValue(JSON.stringify(payload));
 
 				const expectedError = new ApiError(500, {
@@ -227,11 +204,7 @@ describe('subscriptions controller', () => {
 		};
 
 		it('given valid encrypted email, invokes publishDeleteNSIPSubscription, and returns 200', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseRef: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			when(decrypt).calledWith('some_encrypted_string').mockReturnValue('user@example.org');
 
 			await deleteSubscription(req, mockRes);
@@ -242,7 +215,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws not found error if project with case reference does not exist', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce(null);
+			getApplication.mockResolvedValueOnce(null);
 
 			const expectedError = new ApiError(404, {
 				errors: ['Project with case reference BC0110001 not found']
@@ -252,11 +225,7 @@ describe('subscriptions controller', () => {
 		});
 
 		it('throws error if publishDeleteNSIPSubscription fails', async () => {
-			getBackOfficeApplication.mockResolvedValueOnce({
-				projectName: 'drax',
-				projectEmailAddress: 'drax@example.org',
-				caseRef: 'BC0110001'
-			});
+			getApplication.mockResolvedValueOnce(APPLICATION_API);
 			when(decrypt).calledWith('some_encrypted_string').mockReturnValue('user@example.org');
 
 			publishDeleteNSIPSubscription.mockRejectedValueOnce(new Error('some publishing error'));

--- a/packages/applications-service-api/__tests__/unit/services/application.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/application.service.test.js
@@ -1,7 +1,4 @@
-const {
-	getBackOfficeApplication,
-	getApplication
-} = require('../../../src/services/application.service');
+const { getApplication } = require('../../../src/services/application.service');
 
 jest.mock('../../../src/repositories/project.repository');
 const { getByCaseReference } = require('../../../src/repositories/project.repository');
@@ -47,16 +44,6 @@ describe('application.service', () => {
 
 			expect(getNIApplication).toHaveBeenCalledWith('EN010009');
 			expect(mapNIApplicationToApi).toHaveBeenCalledWith(APPLICATION_FO);
-		});
-	});
-
-	describe('getBackOfficeApplication', () => {
-		it('invokes repository', async () => {
-			const caseReference = 'EN010009';
-
-			await getBackOfficeApplication(caseReference);
-
-			expect(getByCaseReference).toBeCalledWith(caseReference);
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/services/application.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/application.service.test.js
@@ -1,13 +1,61 @@
-const { getBackOfficeApplication } = require('../../../src/services/application.service');
+const {
+	getBackOfficeApplication,
+	getApplication
+} = require('../../../src/services/application.service');
 
 jest.mock('../../../src/repositories/project.repository');
 const { getByCaseReference } = require('../../../src/repositories/project.repository');
 
+jest.mock('../../../src/services/application.ni.service');
+const { getNIApplication } = require('../../../src/services/application.ni.service');
+
+jest.mock('../../../src/utils/application.mapper');
+const {
+	mapBackOfficeApplicationToApi,
+	mapNIApplicationToApi
+} = require('../../../src/utils/application.mapper');
+const { APPLICATION_DB, APPLICATION_FO } = require('../../__data__/application');
+
+jest.mock('../../../src/lib/config', () => ({
+	backOfficeIntegration: {
+		applications: {
+			getApplication: {
+				caseReferences: ['BC0110001']
+			}
+		}
+	},
+	logger: {
+		level: 'info'
+	}
+}));
+
 describe('application.service', () => {
+	describe('getApplication', () => {
+		it('invokes getBackOfficeApplication if BO caseReference', async () => {
+			getByCaseReference.mockResolvedValueOnce(APPLICATION_DB);
+
+			await getApplication('BC0110001');
+
+			expect(getByCaseReference).toHaveBeenCalledWith('BC0110001');
+			expect(mapBackOfficeApplicationToApi).toHaveBeenCalledWith(APPLICATION_DB);
+		});
+
+		it('invokes getNIApplication if NI caseReference', async () => {
+			getNIApplication.mockResolvedValueOnce(APPLICATION_FO);
+
+			await getApplication('EN010009');
+
+			expect(getNIApplication).toHaveBeenCalledWith('EN010009');
+			expect(mapNIApplicationToApi).toHaveBeenCalledWith(APPLICATION_FO);
+		});
+	});
+
 	describe('getBackOfficeApplication', () => {
 		it('invokes repository', async () => {
-			const caseReference = 'EN0110004';
+			const caseReference = 'EN010009';
+
 			await getBackOfficeApplication(caseReference);
+
 			expect(getByCaseReference).toBeCalledWith(caseReference);
 		});
 	});

--- a/packages/applications-service-api/__tests__/unit/utils/mapLocation.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/mapLocation.test.js
@@ -1,28 +1,10 @@
 const {
-	addMapZoomLvlAndLongLat,
 	mapZoomLevel,
 	mapNorthingEastingToLongLat,
 	mapLongLat
 } = require('../../../src/utils/mapLocation');
 
 describe('map and location utils', () => {
-	describe('addMapZoomLvlAndLongLat', () => {
-		it.each([
-			[
-				{ LatLong: '53.620, -0.702', MapZoomLevel: 'Region' },
-				{ LongLat: ['-0.702', '53.620'], MapZoomLevel: 6 }
-			],
-			[
-				{ LatLong: '   53.620   , -0.702   ', MapZoomLevel: 'Region' },
-				{ LongLat: ['-0.702', '53.620'], MapZoomLevel: 6 }
-			],
-			[{ LatLong: '53.620, -0.702' }, { LongLat: ['-0.702', '53.620'], MapZoomLevel: 5 }],
-			[{ MapZoomLevel: 'Region' }, { MapZoomLevel: 6 }]
-		])('adds LongLat and MapZoomLevel', (input, expectedOutput) => {
-			expect(addMapZoomLvlAndLongLat(input)).toEqual(expectedOutput);
-		});
-	});
-
 	describe('mapLongLat', () => {
 		it.each([
 			[undefined, []],
@@ -38,8 +20,8 @@ describe('map and location utils', () => {
 			['borough', 8],
 			['COUNTRY', 5],
 			['JUNCTION', 12],
-			['unknown', 14],
-			[undefined, 14]
+			['unknown', 5],
+			[undefined, 5]
 		])('maps lat/long string to long/lat array', (input, expectedOutput) => {
 			expect(mapZoomLevel(input)).toEqual(expectedOutput);
 		});

--- a/packages/applications-service-api/src/services/application.ni.service.js
+++ b/packages/applications-service-api/src/services/application.ni.service.js
@@ -4,16 +4,16 @@ const {
 	getAllApplicationsCount
 } = require('../repositories/project.ni.repository');
 const mapApplicationsToCSV = require('../utils/map-applications-to-csv');
-const { addMapZoomLvlAndLongLat } = require('../utils/mapLocation');
 const {
 	buildApiFiltersFromNIApplications,
-	mapApplicationFiltersToNI
+	mapApplicationFiltersToNI,
+	addMapZoomLevelAndLongLat
 } = require('../utils/application.mapper');
 const { isEmpty } = require('lodash');
 
 const getNIApplication = async (caseReference) => {
 	const application = await getApplicationRepository(caseReference);
-	return application?.dataValues ? addMapZoomLvlAndLongLat(application.dataValues) : null;
+	return addMapZoomLevelAndLongLat(application?.dataValues);
 };
 
 const getAllNIApplications = async (query) => {
@@ -34,7 +34,7 @@ const getAllNIApplications = async (query) => {
 	const totalItemsWithoutFilters = await getAllApplicationsCount();
 
 	return {
-		applications: applications.map((document) => addMapZoomLvlAndLongLat(document)),
+		applications: applications.map(addMapZoomLevelAndLongLat),
 		totalItems: count,
 		itemsPerPage: size,
 		totalPages: Math.ceil(Math.max(1, count) / size),
@@ -46,9 +46,7 @@ const getAllNIApplications = async (query) => {
 
 const getAllNIApplicationsDownload = async () => {
 	const { applications } = await getAllApplicationsRepository();
-	const applicationsWithMapZoomLvlAndLongLat = applications.map((document) =>
-		addMapZoomLvlAndLongLat(document)
-	);
+	const applicationsWithMapZoomLvlAndLongLat = applications.map(addMapZoomLevelAndLongLat);
 	return mapApplicationsToCSV(applicationsWithMapZoomLvlAndLongLat);
 };
 

--- a/packages/applications-service-api/src/services/application.service.js
+++ b/packages/applications-service-api/src/services/application.service.js
@@ -1,4 +1,6 @@
-const { getByCaseReference } = require('../repositories/project.repository');
+const {
+	getByCaseReference: getBackOfficeApplication
+} = require('../repositories/project.repository');
 const { getNIApplication } = require('./application.ni.service');
 const config = require('../lib/config');
 const {
@@ -14,9 +16,6 @@ const getApplication = async (caseReference) =>
 const isBackOfficeApplication = (caseReference) =>
 	config.backOfficeIntegration.applications.getApplication.caseReferences.includes(caseReference);
 
-const getBackOfficeApplication = (caseReference) => getByCaseReference(caseReference);
-
 module.exports = {
-	getApplication,
-	getBackOfficeApplication
+	getApplication
 };

--- a/packages/applications-service-api/src/utils/mapLocation.js
+++ b/packages/applications-service-api/src/utils/mapLocation.js
@@ -1,31 +1,7 @@
 const OSPoint = require('ospoint');
 
-const addMapZoomLvlAndLongLat = (document) => {
-	const area = ['COUNTRY', 'REGION', 'COUNTY', 'BOROUGH', 'DISTRICT', 'CITY', 'TOWN', 'JUNCTION'];
-	const ZOOM_LEVEL_OFFSET = 5;
-
-	const zoomLevelArea = document.MapZoomLevel || 'COUNTRY';
-	const MapZoomLevel = ZOOM_LEVEL_OFFSET + area.indexOf(zoomLevelArea.toUpperCase());
-
-	let LongLat;
-	if (document.LatLong) {
-		const latLong = document.LatLong.split(',').map((s) => s.trim());
-		LongLat = [latLong[1], latLong[0]];
-	}
-
-	const application = {
-		...document,
-		MapZoomLevel,
-		LongLat
-	};
-
-	delete application.LatLong;
-
-	return application;
-};
-
 const mapZoomLevel = (zoomLevelName) => {
-	const DEFAULT_ZOOM_LEVEL = 14;
+	const DEFAULT_ZOOM_LEVEL = 5;
 
 	if (!zoomLevelName) return DEFAULT_ZOOM_LEVEL;
 
@@ -59,7 +35,6 @@ const mapNorthingEastingToLongLat = (northing, easting) => {
 };
 
 module.exports = {
-	addMapZoomLvlAndLongLat,
 	mapZoomLevel,
 	mapLongLat,
 	mapNorthingEastingToLongLat


### PR DESCRIPTION
- rework `controllers/subscriptions.js` to use new `getApplication` service function, which allows the endpoint to process `caseReference`s that are either for applications in the NI database, or from Back Office
- refactoring:
  - make `getBackOfficeApplication` private as this was the only place it was in use and is now superseded by `getApplication`
  - move `addMapZoomLevelAndLongLat` to `application.mapper.js` and simplify implementation
  - fix incorrect default zoom level