### PR TITLE
fix(applications-service-api): validate applications filter values

### DIFF
--- a/packages/applications-service-api/__tests__/integration/applications.test.js
+++ b/packages/applications-service-api/__tests__/integration/applications.test.js
@@ -20,12 +20,10 @@ jest.mock('../../src/lib/prisma', () => ({
 }));
 
 const mockFindAndCountAll = jest.fn();
-const mockCount = jest.fn();
 const mockProjectFindOne = jest.fn();
 jest.mock('../../src/models', () => ({
 	Project: {
 		findAndCountAll: (query) => mockFindAndCountAll(query),
-		count: () => mockCount(),
 		findOne: (attributes) => mockProjectFindOne(attributes)
 	}
 }));
@@ -85,8 +83,10 @@ describe('/api/v1/applications', () => {
 
 	describe('get all applications', () => {
 		beforeEach(() => {
-			mockFindAndCountAll.mockResolvedValueOnce({ rows: APPLICATIONS_NI_FILTER_COLUMNS });
-			mockCount.mockResolvedValueOnce(APPLICATIONS_NI_DB.length);
+			mockFindAndCountAll.mockResolvedValueOnce({
+				rows: APPLICATIONS_NI_FILTER_COLUMNS,
+				count: APPLICATIONS_NI_DB.length
+			});
 		});
 		it('happy path', async () => {
 			mockFindAndCountAll.mockResolvedValueOnce({

--- a/packages/applications-service-api/__tests__/unit/services/application.ni.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/application.ni.service.test.js
@@ -5,20 +5,19 @@ const {
 } = require('../../../src/services/application.ni.service');
 const {
 	getApplication: getApplicationRepository,
-	getAllApplications: getAllApplicationsRepository,
-	getAllApplicationsCount: getAllApplicationsCountRepository
+	getAllApplications: getAllApplicationsRepository
 } = require('../../../src/repositories/project.ni.repository');
 const mapApplicationsToCSV = require('../../../src/utils/map-applications-to-csv');
 const {
 	APPLICATION_FO,
 	APPLICATIONS_NI_DB,
-	APPLICATIONS_FO
+	APPLICATIONS_FO,
+	APPLICATIONS_FO_FILTERS
 } = require('../../__data__/application');
 
 jest.mock('../../../src/repositories/project.ni.repository', () => ({
 	getApplication: jest.fn(),
-	getAllApplications: jest.fn(),
-	getAllApplicationsCount: jest.fn()
+	getAllApplications: jest.fn()
 }));
 
 jest.mock('../../../src/utils/map-applications-to-csv', () => jest.fn());
@@ -50,15 +49,16 @@ describe('application.ni.service', () => {
 	});
 
 	describe('getAllApplications', () => {
-		let availableFilters = [];
 		beforeEach(() => {
 			getAllApplicationsRepository
-				.mockResolvedValueOnce({ applications: availableFilters })
+				.mockResolvedValueOnce({
+					applications: APPLICATIONS_NI_DB,
+					count: APPLICATIONS_NI_DB.length
+				})
 				.mockResolvedValueOnce({
 					applications: APPLICATIONS_NI_DB,
 					count: APPLICATIONS_NI_DB.length
 				});
-			getAllApplicationsCountRepository.mockResolvedValueOnce(APPLICATIONS_NI_DB.length);
 		});
 
 		describe('pagination', () => {
@@ -272,7 +272,7 @@ describe('application.ni.service', () => {
 				totalPages: 1,
 				currentPage: 1,
 				totalItemsWithoutFilters: APPLICATIONS_FO.length,
-				filters: availableFilters
+				filters: APPLICATIONS_FO_FILTERS
 			});
 		});
 	});

--- a/packages/applications-service-api/__tests__/unit/utils/application.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/application.mapper.test.js
@@ -20,6 +20,48 @@ describe('application.mapper', () => {
 
 			expect(result).toEqual(APPLICATIONS_FO_FILTERS);
 		});
+
+		it('excludes undefined values from filter counts', () => {
+			const result = buildApiFiltersFromNIApplications([
+				{ Stage: 1, Region: 'South East', Proposal: 'BC08 - Leisure' },
+				{ Stage: null, Region: 'North East', Proposal: 'EN01 - Generating Stations' },
+				{ Stage: 2, Region: null, Proposal: 'BC08 - Leisure' },
+				{ Stage: 2, Region: 'South East', Proposal: null }
+			]);
+
+			expect(result).toEqual([
+				{ name: 'stage', label: 'Pre-application', value: 'pre_application', count: 1 },
+				{ name: 'stage', label: 'Acceptance', value: 'acceptance', count: 2 },
+				{ name: 'region', label: 'South East', value: 'south_east', count: 2 },
+				{ name: 'region', label: 'North East', value: 'north_east', count: 1 },
+				{
+					name: 'sector',
+					label: 'Business and Commercial',
+					value: 'business_and_commercial',
+					count: 2
+				},
+				{ name: 'sector', label: 'Energy', value: 'energy', count: 1 }
+			]);
+		});
+
+		it('excludes invalid values from filter counts', () => {
+			const result = buildApiFiltersFromNIApplications([
+				{ Stage: 1, Region: 'NOT A REGION', Proposal: 'BC08 - Leisure' },
+				{ Stage: null, Region: 'North East', Proposal: 'NOT A PROPOSAL' },
+				{ Stage: 200, Region: null, Proposal: 'BC08 - Leisure' }
+			]);
+
+			expect(result).toEqual([
+				{ name: 'stage', label: 'Pre-application', value: 'pre_application', count: 1 },
+				{ name: 'region', label: 'North East', value: 'north_east', count: 1 },
+				{
+					name: 'sector',
+					label: 'Business and Commercial',
+					value: 'business_and_commercial',
+					count: 2
+				}
+			]);
+		});
 	});
 
 	describe('mapApplicationFiltersToNI', () => {

--- a/packages/applications-service-api/src/repositories/project.ni.repository.js
+++ b/packages/applications-service-api/src/repositories/project.ni.repository.js
@@ -42,10 +42,7 @@ const getAllApplications = async (options = {}) => {
 	return { applications: rows, count };
 };
 
-const getAllApplicationsCount = async () => db.Project.count();
-
 module.exports = {
 	getApplication,
-	getAllApplications,
-	getAllApplicationsCount
+	getAllApplications
 };

--- a/packages/applications-service-api/src/services/application.ni.service.js
+++ b/packages/applications-service-api/src/services/application.ni.service.js
@@ -1,7 +1,6 @@
 const {
 	getApplication: getApplicationRepository,
-	getAllApplications: getAllApplicationsRepository,
-	getAllApplicationsCount
+	getAllApplications: getAllApplicationsRepository
 } = require('../repositories/project.ni.repository');
 const mapApplicationsToCSV = require('../utils/map-applications-to-csv');
 const {
@@ -19,7 +18,9 @@ const getNIApplication = async (caseReference) => {
 const getAllNIApplications = async (query) => {
 	const { pageNo, size, offset, order } = createQueryFilters(query);
 
-	const availableFilters = await getAvailableFilters();
+	const { applications: allApplications, count: totalItemsWithoutFilters } =
+		await getAllApplicationsRepository();
+	const availableFilters = buildApiFiltersFromNIApplications(allApplications);
 
 	const repositoryOptions = {
 		offset,
@@ -31,7 +32,6 @@ const getAllNIApplications = async (query) => {
 	if (!isEmpty(appliedFilters)) repositoryOptions.filters = appliedFilters;
 
 	const { applications, count } = await getAllApplicationsRepository(repositoryOptions);
-	const totalItemsWithoutFilters = await getAllApplicationsCount();
 
 	return {
 		applications: applications.map(addMapZoomLevelAndLongLat),
@@ -81,13 +81,6 @@ const createQueryFilters = (query) => {
 		offset: size * (pageNo - 1),
 		order
 	};
-};
-
-const getAvailableFilters = async () => {
-	const { applications } = await getAllApplicationsRepository({
-		attributes: ['Stage', 'Region', 'Proposal']
-	});
-	return buildApiFiltersFromNIApplications(applications);
 };
 
 module.exports = {


### PR DESCRIPTION
## Describe your changes

ASB-1909

Fixes bug where `Region`, `Stage` or `Proposal` in the NI database were set to an unexpected value, which was then returned in the list of `filters` from the `GET /applications`.

![Screenshot 2023-09-29 at 15 46 55](https://github.com/Planning-Inspectorate/applications-service/assets/33483916/46ef6b2b-c0a1-4fe2-a5fb-30a1fe963364)

Updated the NI-to-API mapping object (`NI_MAPPING`) to include `Region` rather than relying on naming convention being followed, and does not return a filter value if it is not found in the mapping.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
