### PR TITLE
fix: register of apps default sort DateOfDCOSubmission to descending

### DIFF
--- a/packages/forms-web-app/src/pages/register-of-applications/utils/get-register-of-applications-query-string.js
+++ b/packages/forms-web-app/src/pages/register-of-applications/utils/get-register-of-applications-query-string.js
@@ -6,7 +6,7 @@ const getRegisterOfApplicationsQueryString = ({ page, searchTerm, itemsPerPage, 
 		page: page || 1,
 		searchTerm: searchTerm || '',
 		size: itemsPerPage || 25,
-		sort: sortBy || '+DateOfDCOSubmission',
+		sort: sortBy || '-DateOfDCOSubmission',
 		stage: registerOfApplicationsStages
 	});
 

--- a/packages/forms-web-app/src/pages/register-of-applications/utils/get-register-of-applications-query-string.unit.test.js
+++ b/packages/forms-web-app/src/pages/register-of-applications/utils/get-register-of-applications-query-string.unit.test.js
@@ -14,7 +14,7 @@ describe('register-of-applications/utils/get-register-of-applications-query-stri
 
 				it('should return the default register of applications query string', () => {
 					expect(registerOfApplicationsQueryString).toEqual(
-						'?page=1&searchTerm=&size=25&sort=%2BDateOfDCOSubmission&stage=acceptance&stage=pre_examination&stage=examination&stage=recommendation&stage=decision&stage=post_decision&stage=withdrawn'
+						'?page=1&searchTerm=&size=25&sort=-DateOfDCOSubmission&stage=acceptance&stage=pre_examination&stage=examination&stage=recommendation&stage=decision&stage=post_decision&stage=withdrawn'
 					);
 				});
 			});


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-1897

Update to https://github.com/Planning-Inspectorate/applications-service/pull/841 changes DateOfDCOSubmission sort from ascending to descending

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
