### PR TITLE
Fix/asb 1963 submission filename

### DIFF
--- a/packages/applications-service-api/__tests__/integration/submission.test.js
+++ b/packages/applications-service-api/__tests__/integration/submission.test.js
@@ -284,6 +284,22 @@ describe('/api/v1/submissions', () => {
 				expect(notifyBuilder.setReference).toHaveBeenCalledWith(`Submission ${submissionId}`);
 				expect(notifyBuilder.sendEmail).toHaveBeenCalledTimes(1);
 			});
+
+			it('returns 400 error if email is provided but caseReference is missing', async () => {
+				const response = await request.post(`/api/v1/submissions/${submissionId}/complete`).send({
+					email: 'person@example.org'
+				});
+
+				expect(response.status).toEqual(400);
+			});
+
+			it('returns 400 error if caseReference is provided but email is missing', async () => {
+				const response = await request.post(`/api/v1/submissions/${submissionId}/complete`).send({
+					caseReference: BACK_OFFICE_CASE_REFERENCE
+				});
+
+				expect(response.status).toEqual(400);
+			});
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/integration/submission.test.js
+++ b/packages/applications-service-api/__tests__/integration/submission.test.js
@@ -108,7 +108,7 @@ describe('/api/v1/submissions', () => {
 			let response;
 
 			describe('submission with written representation', () => {
-				const generatedPDFFileName = `Written-Representation-${requestSubmissionId}.pdf`;
+				const generatedPDFFileName = `Written-Representation.pdf`;
 
 				describe('request with submissionId provided', () => {
 					beforeEach(async () => {
@@ -145,8 +145,6 @@ describe('/api/v1/submissions', () => {
 				});
 
 				describe('request with no submissionId', () => {
-					const generatedPDFFileName = `Written-Representation-${mockGeneratedSubmissionId}.pdf`;
-
 					beforeEach(async () => {
 						getDate.mockReturnValueOnce(new Date()).mockReturnValueOnce(mockTime);
 						response = await submissionRequest().field(

--- a/packages/applications-service-api/__tests__/unit/controllers/submissions.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/submissions.test.js
@@ -135,5 +135,25 @@ describe('submissions controller', () => {
 
 			await expect(completeSubmission(req, res)).rejects.toEqual('some error');
 		});
+
+		it.each([[{ email: 'person@example.org' }], [{ caseReference: 'BC0110001' }]])(
+			'throws error if required request body property is missing',
+			async (body) => {
+				await expect(() =>
+					completeSubmission(
+						{
+							...req,
+							body
+						},
+						res
+					)
+				).rejects.toEqual({
+					code: 400,
+					message: {
+						errors: ["must include both 'email' and 'caseReference'"]
+					}
+				});
+			}
+		);
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/services/submission.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/submission.service.test.js
@@ -32,7 +32,10 @@ const {
 	createNISubmission,
 	completeNISubmission
 } = require('../../../src/services/submission.ni.service');
-const { generateRepresentationPDF, uploadToBlobStorage } = require('../../../src/utils/file');
+const {
+	generateRepresentationPDF,
+	uploadSubmissionFileToBlobStorage
+} = require('../../../src/utils/file');
 const { publishDeadlineSubmission } = require('../../../src/services/backoffice.publish.service');
 const { getApplication } = require('../../../src/services/application.service');
 const { sendSubmissionNotification } = require('../../../src/lib/notify');
@@ -49,7 +52,7 @@ describe('submission.service', () => {
 	describe('createSubmission', () => {
 		describe('Back Office case', () => {
 			const mockGuid = 'd3ae5a1c-6b97-4708-a61f-217670ebaba1';
-			beforeEach(() => uploadToBlobStorage.mockResolvedValueOnce(mockGuid));
+			beforeEach(() => uploadSubmissionFileToBlobStorage.mockResolvedValueOnce(mockGuid));
 
 			describe('submission with submissionId supplied', () => {
 				describe('submission with user uploaded file', () => {
@@ -65,7 +68,7 @@ describe('submission.service', () => {
 
 						const result = await createSubmission(submission);
 
-						expect(uploadToBlobStorage).toBeCalledWith(submission.file);
+						expect(uploadSubmissionFileToBlobStorage).toBeCalledWith(submission.file);
 						expect(publishDeadlineSubmission).toBeCalledWith(submission, mockGuid);
 						expect(result).toEqual({ submissionId: submission.metadata.submissionId });
 					});
@@ -94,7 +97,9 @@ describe('submission.service', () => {
 
 						const result = await createSubmission(submission);
 
-						expect(uploadToBlobStorage).toBeCalledWith(generatedRepresentationFileData);
+						expect(uploadSubmissionFileToBlobStorage).toBeCalledWith(
+							generatedRepresentationFileData
+						);
 						expect(publishDeadlineSubmission).toBeCalledWith(
 							{
 								...submission,
@@ -125,7 +130,7 @@ describe('submission.service', () => {
 
 						const result = await createSubmission(submission);
 
-						expect(uploadToBlobStorage).toBeCalledWith(submission.file);
+						expect(uploadSubmissionFileToBlobStorage).toBeCalledWith(submission.file);
 						expect(publishDeadlineSubmission).toBeCalledWith(submission, mockGuid);
 						expect(result).toEqual({ submissionId: 'BC0110001-301223110613245' });
 					});
@@ -155,7 +160,9 @@ describe('submission.service', () => {
 
 						const result = await createSubmission(submission);
 
-						expect(uploadToBlobStorage).toBeCalledWith(generatedRepresentationFileData);
+						expect(uploadSubmissionFileToBlobStorage).toBeCalledWith(
+							generatedRepresentationFileData
+						);
 						expect(publishDeadlineSubmission).toBeCalledWith(
 							{
 								...submission,

--- a/packages/applications-service-api/__tests__/unit/services/submission.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/submission.service.test.js
@@ -225,30 +225,6 @@ describe('submission.service', () => {
 					}
 				});
 			});
-
-			it.each([
-				[
-					'submissionId',
-					{
-						caseReference: BACK_OFFICE_CASE_REFERENCE,
-						email: 'person@example.org'
-					}
-				],
-				[
-					'email',
-					{
-						submissionId: 1,
-						caseReference: BACK_OFFICE_CASE_REFERENCE
-					}
-				]
-			])('throws error if %s is missing', async (missingPropertyName, submissionDetails) => {
-				await expect(() => completeSubmission(submissionDetails)).rejects.toEqual({
-					code: 400,
-					message: {
-						errors: [`must have required property '${missingPropertyName}'`]
-					}
-				});
-			});
 		});
 
 		describe('NI case', () => {

--- a/packages/applications-service-api/__tests__/unit/utils/file.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/file.test.js
@@ -3,7 +3,10 @@ jest.mock('uuid');
 const { upload } = require('../../../src/lib/blobStorage');
 const uuid = require('uuid');
 
-const { generateRepresentationPDF, uploadToBlobStorage } = require('../../../src/utils/file');
+const {
+	generateRepresentationPDF,
+	uploadSubmissionFileToBlobStorage
+} = require('../../../src/utils/file');
 
 describe('file utils', () => {
 	describe('generateRepresentationPDF', () => {
@@ -17,7 +20,7 @@ describe('file utils', () => {
 		});
 	});
 
-	describe('uploadToBlobStorage', () => {
+	describe('uploadSubmissionFileToBlobStorage', () => {
 		it('invokes blob storage client with file', async () => {
 			uuid.v4.mockReturnValue('some-uuid');
 			const fileData = {
@@ -26,7 +29,7 @@ describe('file utils', () => {
 				mimeType: 'application/pdf'
 			};
 
-			await uploadToBlobStorage(fileData);
+			await uploadSubmissionFileToBlobStorage(fileData);
 
 			expect(upload).toBeCalledWith(fileData.buffer, fileData.mimeType, 'some-uuid/Test.pdf');
 		});

--- a/packages/applications-service-api/src/controllers/submissions.js
+++ b/packages/applications-service-api/src/controllers/submissions.js
@@ -1,6 +1,7 @@
 const { StatusCodes } = require('http-status-codes');
 const { createSubmission, completeSubmission } = require('../services/submission.service');
 const { getDate } = require('../utils/date-utils');
+const ApiError = require('../error/apiError');
 
 const createSubmissionController = async (req, res) => {
 	const submissionRequestData = buildSubmissionData(req);
@@ -10,11 +11,21 @@ const createSubmissionController = async (req, res) => {
 };
 
 const completeSubmissionController = async (req, res) => {
-	await completeSubmission({
+	const submissionDetails = {
 		submissionId: req.params.submissionId,
 		caseReference: req.body?.caseReference,
 		email: req.body?.email
-	});
+	};
+
+	if (
+		(submissionDetails.caseReference && !submissionDetails.email) ||
+		(submissionDetails.email && !submissionDetails.caseReference)
+	) {
+		throw ApiError.badRequest("must include both 'email' and 'caseReference'");
+	}
+
+	await completeSubmission(submissionDetails);
+
 	return res.sendStatus(StatusCodes.NO_CONTENT);
 };
 

--- a/packages/applications-service-api/src/services/submission.service.js
+++ b/packages/applications-service-api/src/services/submission.service.js
@@ -45,9 +45,6 @@ const generateSubmissionId = (caseReference) =>
 const completeBackOfficeSubmission = async (submissionDetails) => {
 	const { submissionId, caseReference, email } = submissionDetails;
 
-	if (!submissionId) throw ApiError.badRequest("must have required property 'submissionId'");
-	if (!email) throw ApiError.badRequest("must have required property 'email'");
-
 	const application = await getApplication(caseReference);
 	if (!application)
 		throw ApiError.notFound(`Project with case reference ${caseReference} not found`);

--- a/packages/applications-service-api/src/services/submission.service.js
+++ b/packages/applications-service-api/src/services/submission.service.js
@@ -3,7 +3,7 @@ const config = require('../lib/config');
 const ApiError = require('../error/apiError');
 const { createNISubmission, completeNISubmission } = require('./submission.ni.service');
 const { publishDeadlineSubmission } = require('./backoffice.publish.service');
-const { generateRepresentationPDF, uploadToBlobStorage } = require('../utils/file');
+const { generateRepresentationPDF, uploadSubmissionFileToBlobStorage } = require('../utils/file');
 const { getDate } = require('../utils/date-utils');
 const { getApplication } = require('./application.service');
 const { sendSubmissionNotification } = require('../lib/notify');
@@ -27,11 +27,11 @@ const createBackOfficeSubmission = async (submission) => {
 		submission.file = generateRepresentationPDF(
 			metadata.submissionId,
 			metadata.representation,
-			`Written-Representation-${metadata.submissionId}.pdf`
+			'Written-Representation.pdf'
 		);
 	}
 
-	const blobGuid = await uploadToBlobStorage(submission.file);
+	const blobGuid = await uploadSubmissionFileToBlobStorage(submission.file);
 	await publishDeadlineSubmission(submission, blobGuid);
 
 	return {

--- a/packages/applications-service-api/src/utils/file.js
+++ b/packages/applications-service-api/src/utils/file.js
@@ -17,7 +17,7 @@ const generateRepresentationPDF = (submissionId, submissionRepresentation, fileN
 	};
 };
 
-const uploadToBlobStorage = async (file) => {
+const uploadSubmissionFileToBlobStorage = async (file) => {
 	const blobGuid = uuid.v4();
 	const path = `${blobGuid}/${file.originalName}`;
 
@@ -27,4 +27,4 @@ const uploadToBlobStorage = async (file) => {
 	return blobGuid;
 };
 
-module.exports = { generateRepresentationPDF, uploadToBlobStorage };
+module.exports = { generateRepresentationPDF, uploadSubmissionFileToBlobStorage };


### PR DESCRIPTION
## Describe your changes

ASB-1968, ASB-1818

Updates to the `POST /api/v1/submissions/{submissionId}` and `POST /api/v1/submissions/{submissionId}/complete` endpoints

- aadb0c2d9bc8e012608937bdacf25f90b97fa4b2 simplify the file naming conventions used when uploading files to blob storage container. The PDF file generated for a written rep will have the name `Written-Representation.pdf` (previously had the submissionID included in the file name). A user uploaded file will be uploaded as-is and the file name will not be changed. 
- c53c62916d601274f98ff7c247ca4260d4c6630f fix issue with api not returning a 400 error if the `caseReference` property was missing from the request body but the `email` _was_ included. Updated the error message to be: `"must include both 'email' and 'caseReference'"`.

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
