### PR TITLE
fix: validation case reference in back office examtimetable function

### DIFF
--- a/packages/back-office-subscribers/nsip-exam-timetable/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable/__tests__/index.test.js
@@ -109,6 +109,12 @@ describe('nsip-exam-timetable', () => {
 		expect(mockContext.log).toBeCalledWith(`invoking nsip-exam-timetable function`);
 	});
 
+	it('skips update if caseReference is missing', async () => {
+		await sendMessage(mockContext, {});
+		expect(mockContext.log).toBeCalledWith(`skipping update of events as caseReference is missing`);
+		expect(mockFindMany).not.toBeCalled();
+	});
+
 	it('start transaction', async () => {
 		await sendMessage(mockContext, mockMessage);
 		expect(prismaClient.$transaction).toBeCalled();

--- a/packages/back-office-subscribers/nsip-exam-timetable/index.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable/index.js
@@ -6,6 +6,11 @@ module.exports = async (context, message) => {
 	const currentTime = new Date();
 	const caseReference = message.caseReference;
 
+	if (!caseReference) {
+		context.log(`skipping update of events as caseReference is missing`);
+		return;
+	}
+
 	return await prismaClient.$transaction(async (tx) => {
 		// note: because of the nesting, it's much faster easier to remove and then add any events because back office will send all events
 


### PR DESCRIPTION
## Describe your changes

Quick fix to check for `caseReference` to exist in message or we log and skip the message. Previous PR for reference: https://github.com/Planning-Inspectorate/applications-service/pull/876


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
