### PR TITLE
fix(is-registration-open.js): fix issue with reps being closed on deadline date

### DIFF
--- a/packages/forms-web-app/src/pages/projects/register/index/_utils/is-registration-open.js
+++ b/packages/forms-web-app/src/pages/projects/register/index/_utils/is-registration-open.js
@@ -1,7 +1,9 @@
 const dayjs = require('dayjs');
 const isSameOrAfter = require('dayjs/plugin/isSameOrAfter');
+const isSameOrBefore = require('dayjs/plugin/isSameOrBefore');
 
 dayjs.extend(isSameOrAfter);
+dayjs.extend(isSameOrBefore);
 
 const isRegistrationOpen = (openDate, closedDate) => {
 	const dayToday = dayjs();
@@ -10,7 +12,7 @@ const isRegistrationOpen = (openDate, closedDate) => {
 
 	return (
 		dayToday.isSameOrAfter(registrationOpenDate) &&
-		(dayToday.isBefore(registrationClosedDate) || !closedDate)
+		(dayToday.isSameOrBefore(registrationClosedDate, 'day') || !closedDate)
 	);
 };
 

--- a/packages/forms-web-app/src/pages/projects/register/index/_utils/is-registration-open.unit.test.js
+++ b/packages/forms-web-app/src/pages/projects/register/index/_utils/is-registration-open.unit.test.js
@@ -58,8 +58,8 @@ describe('projects/register/index/_utils/is-registration-open', () => {
 					registrationOpen = isRegistrationOpen(openDate, closeDate);
 				});
 
-				it('should return false', () => {
-					expect(registrationOpen).toEqual(false);
+				it('should return true', () => {
+					expect(registrationOpen).toEqual(true);
 				});
 			});
 		});


### PR DESCRIPTION
Relevant reps registration is closing on the start of deadline date rather than the end of the day.

## Describe your changes

<!--
    ASB-1994 - https://pins-ds.atlassian.net/browse/ASB-1994
-->

<!--
Bug found in production with RR closing early, this change modifies the is period open to check date and include deadline day.
-->

## Useful information to review or test

<!--
We need to set the DateOfRelevantRepresentationClose date in DB to todays date.
-->

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes
