### PR TITLE
feat: bo project-update function update with prisma

### DIFF
--- a/packages/back-office-subscribers/nsip-project-update/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-project-update/__tests__/index.test.js
@@ -1,53 +1,138 @@
-const subject = require('../index');
+const sendMessage = require('../index');
+const { prismaClient } = require('../../lib/prisma');
+
+const mockFindUnique = jest.fn();
+const mockUpsert = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+	prismaClient: {
+		$transaction: jest.fn().mockImplementation((callback) =>
+			callback({
+				projectUpdate: {
+					findUnique: mockFindUnique,
+					upsert: mockUpsert
+				}
+			})
+		)
+	}
+}));
+
+const mockCurrentTime = new Date('2023-01-01T09:00:00.000Z');
+const mockPastTime = new Date('2023-01-01T08:00:00.000Z');
+const mockFutureTime = new Date('2023-01-01T10:00:00.000Z');
+const mockContext = {
+	log: jest.fn(),
+	bindingData: {
+		enqueuedTimeUtc: mockCurrentTime.toUTCString(),
+		deliveryCount: 1,
+		messageId: 123
+	}
+};
+
+const mockMessage = {
+	id: 1,
+	caseReference: 'BC0110001',
+	updateDate: '2023-07-28',
+	updateName: 'July Update',
+	updateContentEnglish: 'this is an update',
+	updateContentWelsh: 'diweddariad yw hwn',
+	updateStatus: 'published'
+};
+
+const mockProjectUpdate = {
+	projectUpdateId: 1,
+	caseReference: 'BC0110001',
+	updateDate: '2023-07-28',
+	updateName: 'July Update',
+	updateContentEnglish: 'this is an update',
+	updateContentWelsh: 'diweddariad yw hwn',
+	updateStatus: 'published',
+	modifiedAt: mockCurrentTime
+};
+
+const assertProjectUpdateUpsert = (mockUpsert) => {
+	expect(mockUpsert).toHaveBeenCalledWith({
+		where: {
+			projectUpdateId: 1
+		},
+		update: mockProjectUpdate,
+		create: mockProjectUpdate
+	});
+	expect(mockContext.log).toHaveBeenCalledWith(`upserted projectUpdate with projectUpdateId: 1`);
+};
 
 describe('nsip-project-update', () => {
-	const message = {
-		id: 1,
-		caseReference: 'BC0110001',
-		updateDate: '2023-07-28',
-		updateName: 'July Update',
-		updateContentEnglish: 'this is an update',
-		updateContentWelsh: 'diweddariad yw hwn',
-		updateStatus: 'published'
-	};
+	beforeEach(() => {
+		mockFindUnique.mockReset();
+		mockUpsert.mockReset();
+	});
+	beforeAll(() => {
+		jest.useFakeTimers('modern');
+		jest.setSystemTime(mockCurrentTime);
+	});
+	afterAll(() => {
+		jest.useRealTimers();
+	});
 
-	beforeAll(() => jest.useFakeTimers());
-	afterAll(() => jest.useRealTimers());
+	it('logs message', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockContext.log).toHaveBeenCalledWith('invoking nsip-project-update function');
+	});
+	it('skips update if projectUpdateId is missing', async () => {
+		await sendMessage(mockContext, {});
+		expect(mockContext.log).toHaveBeenCalledWith('skipping update as projectUpdateId is missing');
+	});
+	it('start transaction', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(prismaClient.$transaction).toHaveBeenCalled();
+	});
+	it('finds existing projectUpdate to determine if it should update', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockFindUnique).toHaveBeenCalledWith({
+			where: {
+				projectUpdateId: mockMessage.id
+			}
+		});
+	});
+	describe('when no projectUpdate exists in database', () => {
+		it('creates new projectUpdate for projectUpdateId', async () => {
+			mockFindUnique.mockResolvedValue(null);
+			await sendMessage(mockContext, mockMessage);
+			assertProjectUpdateUpsert(mockUpsert);
+		});
+	});
 
-	describe('index', () => {
-		it('assigns project update data to binding in correct format', async () => {
-			const dateNow = new Date();
-			jest.setSystemTime(dateNow);
-
-			const mockContext = {
-				log: jest.fn(),
-				bindingData: {
-					enqueuedTimeUtc: 1,
-					deliveryCount: 1,
-					messageId: 123
-				},
-				bindings: {
-					projectUpdate: jest.fn()
-				}
-			};
-
-			await subject(mockContext, message);
-
-			const expectedProjectUpdate = {
-				projectUpdateId: 1,
-				caseReference: 'BC0110001',
-				updateDate: '2023-07-28',
-				updateName: 'July Update',
-				updateContentEnglish: 'this is an update',
-				updateContentWelsh: 'diweddariad yw hwn',
-				updateStatus: 'published',
-				modifiedAt: dateNow
-			};
-
-			expect(mockContext.bindings.projectUpdate).toEqual(expectedProjectUpdate);
-			expect(mockContext.log).toBeCalledWith(
-				`invoking nsip-project-update function with message: ${JSON.stringify(message)}`
-			);
+	describe('when projectUpdate exists in database', () => {
+		describe('and the message is older than the existing projectUpdate', () => {
+			it('does not update the projectUpdate', async () => {
+				mockFindUnique.mockResolvedValue(mockProjectUpdate);
+				const mockContextWithPastTime = {
+					...mockContext,
+					bindingData: {
+						...mockContext.bindingData,
+						enqueuedTimeUtc: mockPastTime.toUTCString()
+					}
+				};
+				await sendMessage(mockContextWithPastTime, mockMessage);
+				expect(mockUpsert).not.toHaveBeenCalled();
+				expect(mockContext.log).toHaveBeenCalledWith(
+					'skipping update of projectUpdate with projectUpdateId: 1 as it is not newer than existing'
+				);
+			});
+		});
+		describe('and the message is newer than the existing projectUpdate', () => {
+			it('updates the projectUpdate', async () => {
+				mockFindUnique.mockResolvedValue(mockProjectUpdate);
+				const mockContextWithFutureTime = {
+					...mockContext,
+					bindingData: {
+						...mockContext.bindingData,
+						enqueuedTimeUtc: mockFutureTime.toUTCString()
+					}
+				};
+				await sendMessage(mockContextWithFutureTime, mockMessage);
+				assertProjectUpdateUpsert(mockUpsert);
+			});
 		});
 	});
 });

--- a/packages/back-office-subscribers/nsip-project-update/function.json
+++ b/packages/back-office-subscribers/nsip-project-update/function.json
@@ -8,13 +8,6 @@
 			"subscriptionName": "applications-nsip-project-update-subscription",
 			"connection": "ServiceBusConnection",
 			"accessRights": "listen"
-		},
-		{
-			"name": "projectUpdate",
-			"type": "sql",
-			"direction": "out",
-			"commandText": "dbo.ProjectUpdate",
-			"connectionStringSetting": "SqlConnectionString"
 		}
 	],
 	"disabled": false

--- a/packages/back-office-subscribers/nsip-project-update/index.js
+++ b/packages/back-office-subscribers/nsip-project-update/index.js
@@ -1,13 +1,50 @@
+const { prismaClient } = require('../lib/prisma');
+
 module.exports = async (context, message) => {
-	context.log(`invoking nsip-project-update function with message: ${JSON.stringify(message)}`);
-	context.bindings.projectUpdate = {
-		projectUpdateId: message.id,
-		caseReference: message.caseReference,
-		updateDate: message.updateDate,
-		updateName: message.updateName,
-		updateContentEnglish: message.updateContentEnglish,
-		updateContentWelsh: message.updateContentWelsh,
-		updateStatus: message.updateStatus,
-		modifiedAt: new Date()
-	};
+	context.log(`invoking nsip-project-update function`);
+
+	const projectUpdateId = message.id;
+
+	if (!projectUpdateId) {
+		context.log(`skipping update as projectUpdateId is missing`);
+		return;
+	}
+	return await prismaClient.$transaction(async (tx) => {
+		const existingProjectUpdate = await tx.projectUpdate.findUnique({
+			where: {
+				projectUpdateId
+			}
+		});
+
+		const shouldUpdate =
+			!existingProjectUpdate ||
+			new Date(context.bindingData.enqueuedTimeUtc) >
+				new Date(existingProjectUpdate.modifiedAt.toUTCString());
+
+		if (shouldUpdate) {
+			const projectUpdate = {
+				projectUpdateId,
+				caseReference: message.caseReference,
+				updateDate: message.updateDate,
+				updateName: message.updateName,
+				updateContentEnglish: message.updateContentEnglish,
+				updateContentWelsh: message.updateContentWelsh,
+				updateStatus: message.updateStatus,
+				modifiedAt: new Date()
+			};
+
+			await tx.projectUpdate.upsert({
+				where: {
+					projectUpdateId
+				},
+				update: projectUpdate,
+				create: projectUpdate
+			});
+			context.log(`upserted projectUpdate with projectUpdateId: ${projectUpdateId}`);
+		} else {
+			context.log(
+				`skipping update of projectUpdate with projectUpdateId: ${projectUpdateId} as it is not newer than existing`
+			);
+		}
+	});
 };

--- a/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-project/__tests__/index.test.js
@@ -87,9 +87,7 @@ describe('nsip-project', () => {
 	});
 	it('skips update if caseReference is missing', async () => {
 		await sendMessage(mockContext, {});
-		expect(mockContext.log).toHaveBeenCalledWith(
-			'skipping update of events as caseReference is missing'
-		);
+		expect(mockContext.log).toHaveBeenCalledWith('skipping update as caseReference is missing');
 		expect(mockFindUnique).not.toHaveBeenCalled();
 	});
 	it('start transaction', async () => {

--- a/packages/back-office-subscribers/nsip-project/index.js
+++ b/packages/back-office-subscribers/nsip-project/index.js
@@ -6,7 +6,7 @@ module.exports = async (context, message) => {
 	const caseReference = message.caseReference;
 
 	if (!caseReference) {
-		context.log(`skipping update of events as caseReference is missing`);
+		context.log(`skipping update as caseReference is missing`);
 		return;
 	}
 


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-1974

This techdeb PR updates the back-office subscriber function for project-update to use Prisma. Similar to the convention we have set in exam-timetable, we use transactions and ensure we check the timestamps to only consume new data. 

## Useful information to review or test

1. Follow the readme on the back-office subscribers function to set it up
2. Run azurite `npx azurite` and this function `npm run start:dev nsip-project-update`
3. Make a POST request to `http://localhost:7071/admin/functions/nsip-project-update` with this body:
```
{
    "input": "{\"id\":9,\"caseReference\":\"BC0110001\",\"updateDate\":\"2023-07-28\",\"updateName\":\"July Update\",\"updateContentEnglish\":\"this is an update\",\"updateContentWelsh\":\"diweddariad yw hwn\",\"updateStatus\":\"published\""
}
```

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
