### PR TITLE
feat: bo project-update-unpublish function update with prisma

### DIFF
--- a/packages/applications-service-api/__tests__/integration/projectUpdates.test.js
+++ b/packages/applications-service-api/__tests__/integration/projectUpdates.test.js
@@ -2,12 +2,10 @@ const { request } = require('../__data__/supertest');
 const { PROJECT_UPDATE_DB, PROJECT_UPDATE_RESPONSE } = require('../__data__/projectUpdates');
 
 const mockProjectUpdateFindMany = jest.fn();
-const mockProjectUpdateDelete = jest.fn();
 jest.mock('../../src/lib/prisma', () => ({
 	prismaClient: {
 		projectUpdate: {
-			findMany: (query) => mockProjectUpdateFindMany(query),
-			delete: (query) => mockProjectUpdateDelete(query)
+			findMany: (query) => mockProjectUpdateFindMany(query)
 		}
 	}
 }));
@@ -42,44 +40,6 @@ describe('/api/v1/project-updates', () => {
 
 		it('returns 500 when unhandled error occurs', async () => {
 			mockProjectUpdateFindMany.mockRejectedValueOnce(new Error('some error'));
-
-			const response = await request.get('/api/v1/project-updates/BC0110001');
-
-			expect(response.status).toEqual(500);
-		});
-	});
-
-	describe('DELETE /{{projectUpdateId}}', () => {
-		it('returns 204 when delete is successful', async () => {
-			const response = await request.delete('/api/v1/project-updates/1');
-
-			expect(response.status).toEqual(204);
-			expect(mockProjectUpdateDelete).toBeCalledWith({
-				where: {
-					projectUpdateId: 1
-				}
-			});
-		});
-
-		it('returns 400 when projectUpdateId is invalid', async () => {
-			const response = await request.delete('/api/v1/project-updates/NOTVALID');
-
-			expect(response.status).toEqual(400);
-		});
-
-		it('returns 404 when record is not found in database', async () => {
-			mockProjectUpdateDelete.mockRejectedValueOnce({
-				name: 'PrismaClientKnownRequestError',
-				code: 'P2025'
-			});
-
-			const response = await request.delete('/api/v1/project-updates/1');
-
-			expect(response.status).toEqual(404);
-		});
-
-		it('returns 500 when unhandled error occurs', async () => {
-			mockProjectUpdateDelete.mockRejectedValueOnce(new Error('some error'));
 
 			const response = await request.get('/api/v1/project-updates/BC0110001');
 

--- a/packages/applications-service-api/__tests__/unit/controllers/project-updates.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/project-updates.test.js
@@ -1,14 +1,10 @@
 jest.mock('../../../src/services/application.service');
 jest.mock('../../../src/repositories/projectUpdate.repository');
 
-const {
-	getProjectUpdates,
-	deleteProjectUpdate
-} = require('../../../src/controllers/project-updates');
+const { getProjectUpdates } = require('../../../src/controllers/project-updates');
 
 const {
-	getProjectUpdates: getProjectUpdatesRepository,
-	deleteProjectUpdate: deleteProjectUpdateRepository
+	getProjectUpdates: getProjectUpdatesRepository
 } = require('../../../src/repositories/projectUpdate.repository');
 const { PROJECT_UPDATE_DB, PROJECT_UPDATE_RESPONSE } = require('../../__data__/projectUpdates');
 
@@ -52,37 +48,6 @@ describe('project updates controller', () => {
 			getProjectUpdatesRepository.mockRejectedValueOnce(expectedError);
 
 			await expect(getProjectUpdates(req, mockRes)).rejects.toThrow(expectedError);
-		});
-	});
-
-	describe('deleteProjectUpdate', () => {
-		const req = {
-			params: {
-				projectUpdateId: 1
-			}
-		};
-
-		it('returns 204 when delete is successful', async () => {
-			deleteProjectUpdateRepository.mockResolvedValueOnce();
-
-			await deleteProjectUpdate(req, mockRes);
-
-			expect(mockRes.status).toBeCalledWith(204);
-			expect(mockRes.send).toBeCalled();
-		});
-
-		it('returns 404 when record is not found in database', async () => {
-			deleteProjectUpdateRepository.mockRejectedValueOnce({
-				name: 'PrismaClientKnownRequestError',
-				code: 'P2025'
-			});
-
-			await expect(deleteProjectUpdate(req, mockRes)).rejects.toEqual({
-				code: 404,
-				message: {
-					errors: ["Project Update with projectUpdateId '1' not found"]
-				}
-			});
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/repositories/projectUpdate.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/projectUpdate.repository.test.js
@@ -1,15 +1,10 @@
-const {
-	getProjectUpdates,
-	deleteProjectUpdate
-} = require('../../../src/repositories/projectUpdate.repository');
+const { getProjectUpdates } = require('../../../src/repositories/projectUpdate.repository');
 
 const mockFindMany = jest.fn();
-const mockDelete = jest.fn();
 jest.mock('../../../src/lib/prisma', () => ({
 	prismaClient: {
 		projectUpdate: {
-			findMany: (query) => mockFindMany(query),
-			delete: (query) => mockDelete(query)
+			findMany: (query) => mockFindMany(query)
 		}
 	}
 }));
@@ -26,16 +21,6 @@ describe('project update repository', () => {
 				orderBy: {
 					updateDate: 'desc'
 				}
-			});
-		});
-	});
-
-	describe('deleteProjectUpdate', () => {
-		it('calls findMany with where caseReference and orderBy updateDate', async () => {
-			await deleteProjectUpdate(1);
-
-			expect(mockDelete).toBeCalledWith({
-				where: { projectUpdateId: 1 }
 			});
 		});
 	});

--- a/packages/applications-service-api/__tests__/unit/routes/project-updates.test.js
+++ b/packages/applications-service-api/__tests__/unit/routes/project-updates.test.js
@@ -1,9 +1,6 @@
-const { get, delete: deleteFn } = require('./router-mock');
+const { get } = require('./router-mock');
 const { validateRequestWithOpenAPI } = require('../../../src/middleware/validator/openapi');
-const {
-	getProjectUpdates,
-	deleteProjectUpdate
-} = require('../../../src/controllers/project-updates');
+const { getProjectUpdates } = require('../../../src/controllers/project-updates');
 
 jest.mock('../../../src/middleware/parseFormDataProperties');
 jest.mock('@pins/common/src/utils/async-route');
@@ -34,15 +31,5 @@ describe('routes/project-updates', () => {
 			asyncRouteMock(getProjectUpdates)
 		);
 		expect(asyncRouteMockValue).toHaveBeenCalledWith(getProjectUpdates);
-
-		expect(parseIntegerParamMock).toBeCalledWith('projectUpdateId');
-
-		expect(deleteFn).toHaveBeenCalledWith(
-			'/:projectUpdateId',
-			parseIntegerParamMockValue,
-			validateRequestWithOpenAPI,
-			asyncRouteMock(deleteProjectUpdate)
-		);
-		expect(asyncRouteMockValue).toHaveBeenCalledWith(deleteProjectUpdate);
 	});
 });

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -575,32 +575,6 @@ paths:
         '500':
           description: Internal server error
 
-  '/api/v1/project-updates/{projectUpdateId}':
-    delete:
-      summary: Deletes a project update
-      description: Deletes a project update by projectUpdateId
-      tags:
-        - Project Updates
-      parameters:
-        - in: path
-          name: projectUpdateId
-          example: 123
-          required: true
-          schema:
-            type: number
-          description: Project Update unique identifier
-      responses:
-        '204':
-          description: Project Update has been successfully deleted
-        '404':
-          description: Project Update not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundError'
-        '500':
-          description: Internal server error
-
   '/api/v1/representations':
     get:
       summary: Returns project representations

--- a/packages/applications-service-api/src/controllers/project-updates.js
+++ b/packages/applications-service-api/src/controllers/project-updates.js
@@ -1,8 +1,6 @@
 const {
-	getProjectUpdates: getProjectUpdatesRepository,
-	deleteProjectUpdate: deleteProjectUpdateRepository
+	getProjectUpdates: getProjectUpdatesRepository
 } = require('../repositories/projectUpdate.repository');
-const ApiError = require('../error/apiError');
 
 const getProjectUpdates = async (req, res) => {
 	const { caseReference } = req.params;
@@ -21,22 +19,6 @@ const getProjectUpdates = async (req, res) => {
 	});
 };
 
-const deleteProjectUpdate = async (req, res) => {
-	const { projectUpdateId } = req.params;
-
-	try {
-		await deleteProjectUpdateRepository(projectUpdateId);
-	} catch (error) {
-		if (error.name === 'PrismaClientKnownRequestError' && error.code === 'P2025') {
-			throw ApiError.notFound(`Project Update with projectUpdateId '${projectUpdateId}' not found`);
-		}
-		throw error;
-	}
-
-	res.status(204).send();
-};
-
 module.exports = {
-	getProjectUpdates,
-	deleteProjectUpdate
+	getProjectUpdates
 };

--- a/packages/applications-service-api/src/repositories/projectUpdate.repository.js
+++ b/packages/applications-service-api/src/repositories/projectUpdate.repository.js
@@ -10,14 +10,6 @@ const getProjectUpdates = async (caseReference) =>
 		}
 	});
 
-const deleteProjectUpdate = async (projectUpdateId) =>
-	prismaClient.projectUpdate.delete({
-		where: {
-			projectUpdateId: projectUpdateId
-		}
-	});
-
 module.exports = {
-	getProjectUpdates,
-	deleteProjectUpdate
+	getProjectUpdates
 };

--- a/packages/applications-service-api/src/routes/project-updates.js
+++ b/packages/applications-service-api/src/routes/project-updates.js
@@ -1,17 +1,10 @@
 const express = require('express');
 const { asyncRoute } = require('@pins/common/src/utils/async-route');
-const { getProjectUpdates, deleteProjectUpdate } = require('../controllers/project-updates');
+const { getProjectUpdates } = require('../controllers/project-updates');
 const { validateRequestWithOpenAPI } = require('../middleware/validator/openapi');
-const { parseIntegerParam } = require('../middleware/parseFormDataProperties');
 
 const router = express.Router();
 
 router.get('/:caseReference', validateRequestWithOpenAPI, asyncRoute(getProjectUpdates));
-router.delete(
-	'/:projectUpdateId',
-	parseIntegerParam('projectUpdateId'),
-	validateRequestWithOpenAPI,
-	asyncRoute(deleteProjectUpdate)
-);
 
 module.exports = router;

--- a/packages/back-office-subscribers/nsip-project-update-unpublish/index.js
+++ b/packages/back-office-subscribers/nsip-project-update-unpublish/index.js
@@ -1,11 +1,20 @@
-const axios = require('axios');
+const { prismaClient } = require('../lib/prisma');
 
 module.exports = async (context, message) => {
-	context.log(
-		`invoking nsip-project-update-unpublish function with message: ${JSON.stringify(message)}`
-	);
+	context.log(`invoking nsip-project-update-unpublish function`);
+	const projectUpdateId = message.id;
 
-	await axios.delete(
-		`${process.env['APPLICATIONS_SERVICE_API_URL']}/api/v1/project-updates/${message.id}`
-	);
+	if (!projectUpdateId) {
+		context.log(`skipping unpublish as projectUpdateId is missing`);
+		return;
+	}
+
+	// we use deleteMany to avoid the need to check if the project update exists
+	await prismaClient.projectUpdate.deleteMany({
+		where: {
+			projectUpdateId
+		}
+	});
+
+	context.log(`unpublished project update with id: ${projectUpdateId}`);
 };

--- a/packages/back-office-subscribers/package.json
+++ b/packages/back-office-subscribers/package.json
@@ -10,7 +10,6 @@
 	},
 	"dependencies": {
 		"lodash.pick": "^4.4.0",
-		"axios": "^1.4.0",
 		"@prisma/client": "^4.12.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-1977

This techdebt PR updates the back-office subscriber function for project-update to use Prisma. It removes the delete project-update endpoint and all related files in `applications-service-api`.

## Useful information to review or test

1. Follow the readme on the back-office subscribers function to set it up
2. Run azurite `npx azurite` and this function `npm run start:dev nsip-project-update-update`
3. Make a POST request to `http://localhost:7071/admin/functions/nsip-project-update-update` with this body:
```
{
    "input": "{\"id\":3}"
}
```

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
