### PR TITLE
fix(applications-service-api): ni submission complete bug

### DIFF
--- a/packages/applications-service-api/__tests__/unit/repositories/submission.ni.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/submission.ni.repository.test.js
@@ -1,6 +1,8 @@
 const {
 	getSubmission,
-	createSubmission, updateSubmission
+	createSubmission,
+	updateSubmission,
+	updateSubmissionsBySubmissionId
 } = require('../../../src/repositories/submission.ni.repository');
 
 const mockCreate = jest.fn();
@@ -49,6 +51,14 @@ describe('submission ni repository', () => {
 			await updateSubmission(123, { name: 'foo' });
 
 			expect(mockUpdate).toHaveBeenCalledWith({ name: 'foo' }, { where: { id: 123 } });
+		});
+	});
+
+	describe('updateSubmissionsBySubmissionId', () => {
+		it('invokes db method correctly', async () => {
+			await updateSubmissionsBySubmissionId(123, { name: 'foo' });
+
+			expect(mockUpdate).toHaveBeenCalledWith({ name: 'foo' }, { where: { submissionId: 123 } });
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/services/submission.ni.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/submission.ni.service.test.js
@@ -12,7 +12,8 @@ jest.mock('../../../src/repositories/submission.ni.repository');
 const {
 	getSubmission: getSubmissionRepository,
 	createSubmission: createSubmissionRepository,
-	updateSubmission: updateSubmissionRepository
+	updateSubmission: updateSubmissionRepository,
+	updateSubmissionsBySubmissionId: updateSubmissionsBySubmissionIdRepository
 } = require('../../../src/repositories/submission.ni.repository');
 
 jest.mock('../../../src/services/ni.file.service');
@@ -132,7 +133,7 @@ describe('submission service', () => {
 				id: submissionId,
 				...SUBMISSION_DB_CREATE_OUTPUT
 			});
-			updateSubmissionRepository.mockResolvedValueOnce({
+			updateSubmissionsBySubmissionIdRepository.mockResolvedValueOnce({
 				id: submissionId,
 				...SUBMISSION_DB_CREATE_OUTPUT,
 				validated: mockTime
@@ -141,7 +142,9 @@ describe('submission service', () => {
 
 			await completeNISubmission(submissionId);
 
-			expect(updateSubmissionRepository).toBeCalledWith(submissionId, { validated: mockTime });
+			expect(updateSubmissionsBySubmissionIdRepository).toBeCalledWith(submissionId, {
+				validated: mockTime
+			});
 			expect(sendSubmissionNotificationMock).toBeCalledWith({
 				submissionId: submissionId,
 				email: 'joe@example.org',

--- a/packages/applications-service-api/src/repositories/submission.ni.repository.js
+++ b/packages/applications-service-api/src/repositories/submission.ni.repository.js
@@ -14,8 +14,16 @@ const updateSubmission = async (id, submissionData) =>
 		}
 	});
 
+const updateSubmissionsBySubmissionId = async (submissionId, submissionData) =>
+	db.Submission.update(submissionData, {
+		where: {
+			submissionId: submissionId
+		}
+	});
+
 module.exports = {
 	getSubmission,
 	createSubmission,
-	updateSubmission
+	updateSubmission,
+	updateSubmissionsBySubmissionId
 };

--- a/packages/applications-service-api/src/services/submission.ni.service.js
+++ b/packages/applications-service-api/src/services/submission.ni.service.js
@@ -5,7 +5,8 @@ const { submitUserUploadedFile, submitRepresentationFile } = require('./ni.file.
 const {
 	getSubmission: getSubmissionRepository,
 	createSubmission: createSubmissionRepository,
-	updateSubmission: updateSubmissionRepository
+	updateSubmission: updateSubmissionRepository,
+	updateSubmissionsBySubmissionId: updateSubmissionsBySubmissionIdRepository
 } = require('../repositories/submission.ni.repository');
 
 const PLACEHOLDER_SUBMISSION_ID = 0;
@@ -78,7 +79,7 @@ const completeNISubmission = async (submissionId) => {
 		throw ApiError.notFound(`Project with case reference ${submission.caseReference} not found`);
 
 	await Promise.all([
-		updateSubmissionRepository(submissionId, { validated: new Date() }),
+		updateSubmissionsBySubmissionIdRepository(submissionId, { validated: new Date() }),
 		sendSubmissionNotification({
 			submissionId: submission.id,
 			email: submission.email,


### PR DESCRIPTION
## Describe your changes

ASB-xxxx

Fix regression introduced by #850 where completing a NI submission does not set the `validated` field for every row in the submissions table with the given `submissionId`, only the first one.

The change which caused the regression has been reverted - switching the function back to updating by `submissionId`, rather than `id`.

## Useful information to review or test

- Prior to the change introduced in https://github.com/Planning-Inspectorate/applications-service/pull/850/files#diff-e320b91b50789dde422e5a21d6b3aae480a27ead3782b5fa2ecd5b3927b39913 - the `completeSubmission` function was calling `updateSubmissionsBySubmissionId`. When that function was moved (new name `completeNISubmission`), the `updateSubmissionsBySubmissionId` was removed in favour of `updateSubmission` (which updated by `id`, not `submissionId`).

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
