### PR TITLE
fix(applications-service-api): fix issue updating interestedParty

### DIFF
--- a/packages/applications-service-api/__tests__/unit/services/interestedParty.ni.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/interestedParty.ni.service.test.js
@@ -8,14 +8,21 @@ const { APPLICATION_FO } = require('../../__data__/application');
 jest.mock('../../../src/repositories/interestedParty.ni.repository');
 jest.mock('../../../src/repositories/project.ni.repository');
 jest.mock('../../../src/lib/notify');
+jest.mock('../../../src/utils/date-utils');
 const {
-	createInterestedParty: createInterestedPartyRepository
+	createInterestedParty: createInterestedPartyRepository,
+	updateInterestedParty
 } = require('../../../src/repositories/interestedParty.ni.repository');
 const { getApplication } = require('../../../src/repositories/project.ni.repository');
 const { sendIPRegistrationConfirmationEmailToIP } = require('../../../src/lib/notify');
+const { getDate } = require('../../../src/utils/date-utils');
 
 describe('interestedParty.ni.service', () => {
 	describe('createInterestedParty', () => {
+		const mockDate = new Date('2022-12-09 13:30:00');
+
+		beforeEach(() => getDate.mockReturnValueOnce(mockDate));
+
 		it('invokes create repository', async () => {
 			getApplication.mockResolvedValueOnce({ dataValues: APPLICATION_FO });
 			createInterestedPartyRepository.mockResolvedValueOnce({
@@ -42,6 +49,7 @@ describe('interestedParty.ni.service', () => {
 				ipRef: '123456',
 				projectEmail: 'webteam@planninginspectorate.gov.uk'
 			});
+			expect(updateInterestedParty).toHaveBeenCalledWith(123456, { emailed: mockDate });
 		});
 	});
 });

--- a/packages/applications-service-api/src/routes/interested-party.js
+++ b/packages/applications-service-api/src/routes/interested-party.js
@@ -1,9 +1,10 @@
 const express = require('express');
 
 const interestedPartyController = require('../controllers/interested-party');
+const { asyncRoute } = require('@pins/common/src/utils/async-route');
 
 const router = express.Router();
 
-router.post('/', interestedPartyController.createInterestedParty);
+router.post('/', asyncRoute(interestedPartyController.createInterestedParty));
 
 module.exports = router;

--- a/packages/applications-service-api/src/services/interestedParty.ni.service.js
+++ b/packages/applications-service-api/src/services/interestedParty.ni.service.js
@@ -5,6 +5,7 @@ const {
 	createInterestedParty: createInterestedPartyRepository,
 	updateInterestedParty
 } = require('../repositories/interestedParty.ni.repository');
+const { getDate } = require('../utils/date-utils');
 
 const createInterestedParty = async (createInterestedPartyRequest) => {
 	const interestedParty = IPFactory.createIP(createInterestedPartyRequest.behalf).get(
@@ -27,7 +28,7 @@ const createInterestedParty = async (createInterestedPartyRequest) => {
 		ipRef,
 		projectEmail
 	});
-	await updateInterestedParty(interestedPartyNI.id, { emailed: new Date() });
+	await updateInterestedParty(interestedPartyNI.ID, { emailed: getDate() });
 
 	return interestedPartyNI;
 };


### PR DESCRIPTION
## Describe your changes

Fix for bug introduced by https://github.com/Planning-Inspectorate/applications-service/pull/898 where the wrong field (should be `ID` not `id`) was being passed to the update query which sets the `emailed` field in the interested party table in the NI DB (to indicate an email confirmation has been sent to the interested party). Added a unit test which was missed from aforementioned PR that would have caught this

Also added the async route wrapper to allow exceptions to be caught and returned as a HTTP response, rather than crashing the whole node process.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
