### PR TITLE
fix(applications-service-api): ni interested party db encoding error handling

### DIFF
--- a/packages/applications-service-api/__tests__/integration/interestedParty.test.js
+++ b/packages/applications-service-api/__tests__/integration/interestedParty.test.js
@@ -208,6 +208,33 @@ describe('/api/v1/interested-party', () => {
 					});
 				});
 			});
+
+			describe('Database insert failure', () => {
+				it('returns 400 error', async () => {
+					const errorMessage =
+						"Incorrect string value: '\xF0\x9D\x99\xB1\xF0\x9D...' for column 'mename' at row 1";
+					mockInterestedPartyCreate.mockImplementationOnce(() => {
+						throw {
+							name: 'SequelizeDatabaseError',
+							parent: {
+								code: 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD'
+							},
+							message: errorMessage
+						};
+					});
+
+					const response = await request.post('/api/v1/interested-party').send({
+						...INTERESTED_PARTY_SELF_API,
+						'full-name': 'M. 𝙱𝔍'
+					});
+
+					expect(response.status).toEqual(400);
+					expect(response.body).toEqual({
+						code: 400,
+						errors: [errorMessage]
+					});
+				});
+			});
 		});
 
 		describe('Back Office project', () => {

--- a/packages/applications-service-api/__tests__/unit/repositories/interestedParty.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/interestedParty.repository.test.js
@@ -1,0 +1,94 @@
+const {
+	createInterestedParty,
+	updateInterestedParty
+} = require('../../../src/repositories/interestedParty.ni.repository');
+
+const mockInterestedPartyCreate = jest.fn();
+const mockInterestedPartyUpdate = jest.fn();
+jest.mock('../../../src/models', () => {
+	return {
+		InterestedParty: {
+			create: (data) => mockInterestedPartyCreate(data),
+			update: (id, data) => mockInterestedPartyUpdate(id, data)
+		}
+	};
+});
+
+describe('interestedParty NI repository', () => {
+	describe('createInterestedParty', () => {
+		describe('when submitting valid data', () => {
+			it('should call create and return result', async () => {
+				const input = { some: 'data' };
+				mockInterestedPartyCreate.mockResolvedValueOnce({
+					dataValues: {
+						id: 1234,
+						...input
+					}
+				});
+
+				const result = await createInterestedParty(input);
+
+				expect(mockInterestedPartyCreate).toHaveBeenCalledWith(input);
+				expect(result).toEqual({
+					id: 1234,
+					...input
+				});
+			});
+
+			describe('when database returns an error', () => {
+				it('should rethrow the error', async () => {
+					const someError = {
+						name: 'Some Other Error'
+					};
+
+					mockInterestedPartyCreate.mockImplementationOnce(() => {
+						throw someError;
+					});
+
+					await expect(() => createInterestedParty({})).rejects.toEqual(someError);
+				});
+			});
+		});
+
+		describe('when submitting data with invalid characters', () => {
+			it('should throw api error with 400 code and message', async () => {
+				const errorMessage =
+					"Incorrect string value: '\xF0\x9D\x99\xB1\xF0\x9D...' for column 'mename' at row 1";
+
+				mockInterestedPartyCreate.mockImplementationOnce(() => {
+					throw {
+						name: 'SequelizeDatabaseError',
+						parent: {
+							code: 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD'
+						},
+						message: errorMessage
+					};
+				});
+
+				await expect(() => createInterestedParty({})).rejects.toEqual({
+					code: 400,
+					message: {
+						errors: [errorMessage]
+					}
+				});
+			});
+		});
+	});
+
+	describe('updateInterestedParty', () => {
+		describe('when submitting valid data and id', () => {
+			it('should invoke update', async () => {
+				const id = 1;
+				const data = { some: 'data' };
+
+				await updateInterestedParty(id, data);
+
+				expect(mockInterestedPartyUpdate).toHaveBeenCalledWith(data, {
+					where: {
+						ID: id
+					}
+				});
+			});
+		});
+	});
+});

--- a/packages/applications-service-api/src/repositories/interestedParty.ni.repository.js
+++ b/packages/applications-service-api/src/repositories/interestedParty.ni.repository.js
@@ -1,8 +1,20 @@
 const db = require('../models');
+const ApiError = require('../error/apiError');
 
 const createInterestedParty = async (data) => {
-	const result = await db.InterestedParty.create(data);
-	return result.dataValues;
+	try {
+		const result = await db.InterestedParty.create(data);
+		return result.dataValues;
+	} catch (e) {
+		if (
+			e.name === 'SequelizeDatabaseError' &&
+			e.parent.code === 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD'
+		) {
+			throw ApiError.badRequest(e.message);
+		} else {
+			throw e;
+		}
+	}
 };
 
 const updateInterestedParty = async (id, data) =>


### PR DESCRIPTION
## Describe your changes

ASB-2080

Add some additional error handling for the scenario where inserting a row into the NI database for a table/column which does not have utf8 character encoding enabled.

Also added a unit test for the interested party repository.

## Useful information to review or test

Sequelize throws a specific error for this scenario (`ER_TRUNCATED_WRONG_VALUE_FOR_FIELD`)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
