### PR TITLE
 fix(applications-service-api): add required property validation to interested-party endpoint

### DIFF
--- a/packages/applications-service-api/__tests__/integration/interestedParty.test.js
+++ b/packages/applications-service-api/__tests__/integration/interestedParty.test.js
@@ -328,5 +328,21 @@ describe('/api/v1/interested-party', () => {
 				);
 			});
 		});
+
+		describe('request with missing required properties', () => {
+			it('should return 400 error with message', async () => {
+				const response = await request.post('/api/v1/interested-party').send({});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					code: 400,
+					errors: [
+						"must have required property 'case_ref'",
+						"must have required property 'behalf'",
+						"must have required property 'comment'"
+					]
+				});
+			});
+		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/utils/openapi.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/openapi.test.js
@@ -1,4 +1,5 @@
 const { loadOpenAPISpec, createRequestValidator } = require('../../../src/utils/openapi');
+const OpenAPIRequestValidator = require('openapi-request-validator').default;
 
 describe('openapi utils', () => {
 	describe('loadOpenAPISpec', () => {
@@ -6,6 +7,29 @@ describe('openapi utils', () => {
 			const result = loadOpenAPISpec();
 
 			expect(result['openapi']).toMatch(/\d\.\d\.\d/);
+		});
+	});
+
+	describe('createRequestValidator', () => {
+		describe('when route exists in openapi spec', () => {
+			it.each([
+				['POST', '/api/v1/interested-party'],
+				['POST', '/api/v1/interested-party/'],
+				['GET', '/api/v1/applications/:caseReference'],
+				['GET', '/api/v1/applications/{caseReference}'],
+				['GET', '/api/v1/applications/:caseReference/'],
+				['GET', '/api/v1/applications/{caseReference}/']
+			])('should return validator object for route path - %s %s', (verb, path) => {
+				expect(createRequestValidator(verb, path)).toBeInstanceOf(OpenAPIRequestValidator);
+			});
+		});
+
+		describe('when route does not exist in openapi spec', () => {
+			it('should return an error', () => {
+				expect(() =>
+					createRequestValidator('POST', '/api/v1/interested-party/NOT-A-VALID-ROUTE')
+				).toThrowError();
+			});
 		});
 	});
 

--- a/packages/applications-service-api/api/openapi.yaml
+++ b/packages/applications-service-api/api/openapi.yaml
@@ -1299,6 +1299,10 @@ components:
 
     InterestedPartyReqBody:
       type: object
+      required:
+        - case_ref
+        - behalf
+        - comment
       properties:
         case_ref:
           type: string

--- a/packages/applications-service-api/src/routes/interested-party.js
+++ b/packages/applications-service-api/src/routes/interested-party.js
@@ -2,9 +2,14 @@ const express = require('express');
 
 const interestedPartyController = require('../controllers/interested-party');
 const { asyncRoute } = require('@pins/common/src/utils/async-route');
+const { validateRequestWithOpenAPI } = require('../middleware/validator/openapi');
 
 const router = express.Router();
 
-router.post('/', asyncRoute(interestedPartyController.createInterestedParty));
+router.post(
+	'/',
+	validateRequestWithOpenAPI,
+	asyncRoute(interestedPartyController.createInterestedParty)
+);
 
 module.exports = router;

--- a/packages/applications-service-api/src/utils/openapi.js
+++ b/packages/applications-service-api/src/utils/openapi.js
@@ -3,38 +3,43 @@ const path = require('path');
 const yaml = require('js-yaml');
 const logger = require('../lib/logger');
 const config = require('../lib/config');
-const { memoizeWith } = require("ramda");
-const OpenAPIRequestValidator = require("openapi-request-validator").default;
+const { memoizeWith } = require('ramda');
+const OpenAPIRequestValidator = require('openapi-request-validator').default;
 
 // eslint-disable-next-line no-unused-vars
-const loadOpenAPISpec = memoizeWith(Object, _ => {
-    let spec;
-    try {
-        const fileContents = fs.readFileSync(path.join(config.docs.api.path, 'openapi.yaml'), 'utf8');
-        spec = yaml.safeLoad(fileContents);
-        logger.debug(`Loaded api spec doc`);
-    } catch (err) {
-        logger.error(`problem loading api spec doc\n${err}`);
-    }
-    return spec;
+const loadOpenAPISpec = memoizeWith(Object, (_) => {
+	let spec;
+	try {
+		const fileContents = fs.readFileSync(path.join(config.docs.api.path, 'openapi.yaml'), 'utf8');
+		spec = yaml.safeLoad(fileContents);
+		logger.debug(`Loaded api spec doc`);
+	} catch (err) {
+		logger.error(`problem loading api spec doc\n${err}`);
+	}
+	return spec;
 });
 
 const createRequestValidator = (verb, path) => {
-    try {
-        const openAPISpec = loadOpenAPISpec();
-        const requestSpec = openAPISpec.paths[path.replace(/(:(\w+))/g, "{$2}")][verb.toLowerCase()];
+	try {
+		const openAPISpec = loadOpenAPISpec();
 
-        return new OpenAPIRequestValidator({
-            ...requestSpec,
-            schemas: openAPISpec.components.schemas
-        });
-    } catch (error) {
-        logger.error(`OpenAPI spec for ${verb} ${path} not found`, error);
-        throw error;
-    }
-}
+		// reformat placeholders: /foo/:bar -> /foo/{bar}
+		// and remove trailing slash
+		const formattedPath = path.replace(/(:(\w+))/g, '{$2}').replace(/\/$/, '');
+
+		const requestSpec = openAPISpec.paths[formattedPath][verb.toLowerCase()];
+
+		return new OpenAPIRequestValidator({
+			...requestSpec,
+			schemas: openAPISpec.components.schemas
+		});
+	} catch (error) {
+		logger.error(`OpenAPI spec for ${verb} ${path} not found`, error);
+		throw error;
+	}
+};
 
 module.exports = {
-    loadOpenAPISpec,
-    createRequestValidator
-}
+	loadOpenAPISpec,
+	createRequestValidator
+};


### PR DESCRIPTION
## Describe your changes

ASB-1468 (AC4)

Adds validation to the request body of `POST /api/v1/interested-party` endpoint, as per AC4 of ASB-1468 (missed in previous PR - #906)

Also fixes bug in the openapi validation helper where it throws an error if the request path has a trailing slash

## Useful information to review or test

change to `utils/openapi.js` looks larger than it is due to prettier reformatting the file to current linting standards. The change is one extra string `replace` call

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
