### PR TITLE
feat: document unpublish bo function

### DIFF
--- a/packages/back-office-subscribers/nsip-document-unpublish/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-document-unpublish/__tests__/index.test.js
@@ -1,0 +1,48 @@
+const sendMessage = require('../index');
+
+const mockDeleteMany = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+	prismaClient: {
+		document: {
+			deleteMany: (query) => mockDeleteMany(query)
+		}
+	}
+}));
+
+const mockContext = {
+	log: jest.fn(),
+	bindingData: {
+		enqueuedTimeUtc: '2023-01-01T09:00:00.000Z',
+		deliveryCount: 1,
+		messageId: 123
+	}
+};
+
+const mockMessage = {
+	documentId: 'mock-document-id'
+};
+
+describe('nsip-document-unpublish', () => {
+	it('logs message', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockContext.log).toHaveBeenCalledWith('invoking nsip-document-unpublish function');
+	});
+
+	it('skips unpublish if documentId is missing', async () => {
+		await sendMessage(mockContext, {});
+		expect(mockContext.log).toHaveBeenCalledWith('skipping unpublish as documentId is missing');
+	});
+
+	it('unpublishes document', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockDeleteMany).toHaveBeenCalledWith({
+			where: {
+				documentId: mockMessage.documentId
+			}
+		});
+		expect(mockContext.log).toHaveBeenCalledWith(
+			`unpublished document with documentId: ${mockMessage.documentId}`
+		);
+	});
+});

--- a/packages/back-office-subscribers/nsip-document-unpublish/function.json
+++ b/packages/back-office-subscribers/nsip-document-unpublish/function.json
@@ -1,0 +1,14 @@
+{
+	"bindings": [
+		{
+			"type": "serviceBusTrigger",
+			"direction": "in",
+			"name": "message",
+			"topicName": "nsip-document",
+			"subscriptionName": "applications-nsip-document-unpublish",
+			"connection": "ServiceBusConnection",
+			"accessRights": "listen"
+		}
+	],
+	"disabled": false
+}

--- a/packages/back-office-subscribers/nsip-document-unpublish/index.js
+++ b/packages/back-office-subscribers/nsip-document-unpublish/index.js
@@ -1,0 +1,20 @@
+const { prismaClient } = require('../lib/prisma');
+
+module.exports = async (context, message) => {
+	context.log(`invoking nsip-document-unpublish function`);
+	const documentId = message.documentId;
+
+	if (!documentId) {
+		context.log(`skipping unpublish as documentId is missing`);
+		return;
+	}
+
+	// we use deleteMany to avoid the need to check if the document exists
+	await prismaClient.document.deleteMany({
+		where: {
+			documentId
+		}
+	});
+
+	context.log(`unpublished document with documentId: ${documentId}`);
+};


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-1469

This PR adds the back-office subscriber function for unpublishing documents. 

## Useful information to review or test

1. Follow the readme on the back-office subscribers function to set it up
2. Run azurite `npx azurite` and this function `npm run start:dev nsip-document-unpublish`
3. Make a POST request to `http://localhost:7071/admin/functions/nsip-document-unpublish` with this body:
```
{
    "input": "{\"documentId\":\"mock-document-id\"}"
}
```

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
