### PR TITLE
fix: re-added missing adviceID in NI attachment repository

### DIFF
--- a/packages/applications-service-api/__tests__/unit/services/advice.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/advice.service.test.js
@@ -18,6 +18,9 @@ const {
 	mapBackOfficeAdviceToApi,
 	mapNIAdviceToApi
 } = require('../../../src/utils/advice.mapper');
+const {
+	findDocumentsByCaseReferenceAndAdviceID
+} = require('../../../src/repositories/document.ni.repository');
 const config = require('../../../src/lib/config');
 
 jest.mock('../../../src/repositories/advice.backoffice.repository');
@@ -113,6 +116,10 @@ describe('Advice Service', () => {
 			it('should get advice from ni repository', async () => {
 				await getAdviceById('123', 'NI-CASEID');
 				expect(getNIAdviceByIdRepository).toHaveBeenCalledWith('123', 'NI-CASEID');
+			});
+			it('should get attachments from ni repository', async () => {
+				await getAdviceById('123', 'NI-CASEID');
+				expect(findDocumentsByCaseReferenceAndAdviceID).toHaveBeenCalledWith('NI-CASEID', '123');
 			});
 			it('should map advice to api', async () => {
 				await getAdviceById('123', 'NI-CASEID');

--- a/packages/applications-service-api/src/repositories/document.ni.repository.js
+++ b/packages/applications-service-api/src/repositories/document.ni.repository.js
@@ -134,8 +134,12 @@ const fetchDocumentsByDocumentType = async (requestQuery) => {
 	return await db.Document.findOne(dbQuery);
 };
 
-const findDocumentsByCaseReference = async (caseReference) => {
-	const documents = await db.Attachment.findAllAttachmentsWithCase(caseReference);
+const findDocumentsByCaseReferenceAndAdviceID = async (caseReference, adviceID) => {
+	const documents = await db.Attachment.findAllAttachmentsWithCase(caseReference, {
+		where: {
+			adviceID
+		}
+	});
 	return documents?.map(({ dataValues }) => dataValues);
 };
 
@@ -144,5 +148,5 @@ module.exports = {
 	getAvailableFilters,
 	getDocumentsByDataId,
 	fetchDocumentsByDocumentType,
-	findDocumentsByCaseReference
+	findDocumentsByCaseReferenceAndAdviceID
 };

--- a/packages/applications-service-api/src/services/advice.service.js
+++ b/packages/applications-service-api/src/services/advice.service.js
@@ -7,7 +7,9 @@ const {
 	getAllAdviceByCaseReference: getAllNIAdvice,
 	getAdviceById: getNIAdviceById
 } = require('../repositories/advice.ni.repository');
-const { findDocumentsByCaseReference } = require('../repositories/document.ni.repository');
+const {
+	findDocumentsByCaseReferenceAndAdviceID
+} = require('../repositories/document.ni.repository');
 const {
 	mapBackOfficeAdviceListToApi,
 	mapBackOfficeAdviceToApi,
@@ -65,7 +67,7 @@ const getAdviceById = async (adviceID, caseReference) => {
 	} else {
 		const advice = await getNIAdviceById(adviceID, caseReference);
 		if (!advice) return;
-		const attachments = await findDocumentsByCaseReference(caseReference);
+		const attachments = await findDocumentsByCaseReferenceAndAdviceID(caseReference, adviceID);
 		return mapNIAdviceToApi({
 			...advice,
 			attachments


### PR DESCRIPTION
## Describe your changes

[PR to extend advice endpoint for BO integration](https://github.com/Planning-Inspectorate/applications-service/pull/921) accidentally removed adviceID filter in query. This PR adds it back.


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
