### PR TITLE
fix: get s51 advice attachments for bo integration cases

### DIFF
--- a/packages/applications-service-api/src/repositories/document.backoffice.repository.js
+++ b/packages/applications-service-api/src/repositories/document.backoffice.repository.js
@@ -83,8 +83,8 @@ const getDocumentsByIds = async (documentIds) => {
 	if (!documentIds) return [];
 	return prismaClient.document.findMany({
 		where: {
-			id: {
-				in: documentIds?.split(',').map((id) => parseInt(id))
+			documentId: {
+				in: documentIds?.split(',')
 			}
 		}
 	});


### PR DESCRIPTION
## Describe your changes

https://pins-ds.atlassian.net/browse/ASB-2157

PR fixes S51 attachments not showing up for BO cases

## Useful information to review or test

Feature branch has been deployed to dev currently and the BO case shows advice attachments below:
https://applications-service-dev.planninginspectorate.gov.uk/projects/BC0110001/s51advice/60
![image](https://github.com/Planning-Inspectorate/applications-service/assets/15147598/ab95e53a-1072-4454-9a6e-c36ad973b28d)


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
