### PR TITLE
feat: unpublish advice bo function

### DIFF
--- a/packages/back-office-subscribers/nsip-advice-unpublish/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-advice-unpublish/__tests__/index.test.js
@@ -1,0 +1,48 @@
+const sendMessage = require('../index');
+
+const mockDeleteMany = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+	prismaClient: {
+		advice: {
+			deleteMany: (query) => mockDeleteMany(query)
+		}
+	}
+}));
+
+const mockContext = {
+	log: jest.fn(),
+	bindingData: {
+		enqueuedTimeUtc: '2023-01-01T09:00:00.000Z',
+		deliveryCount: 1,
+		messageId: 123
+	}
+};
+
+const mockMessage = {
+	adviceId: 'mock-advice-id'
+};
+
+describe('nsip-advice-unpublish', () => {
+	it('logs message', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockContext.log).toHaveBeenCalledWith('invoking nsip-advice-unpublish function');
+	});
+
+	it('skips unpublish if adviceId is missing', async () => {
+		await sendMessage(mockContext, {});
+		expect(mockContext.log).toHaveBeenCalledWith('skipping unpublish as adviceId is missing');
+	});
+
+	it('unpublishes advice', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockDeleteMany).toHaveBeenCalledWith({
+			where: {
+				adviceId: mockMessage.adviceId
+			}
+		});
+		expect(mockContext.log).toHaveBeenCalledWith(
+			`unpublished advice with adviceId: ${mockMessage.adviceId}`
+		);
+	});
+});

--- a/packages/back-office-subscribers/nsip-advice-unpublish/function.json
+++ b/packages/back-office-subscribers/nsip-advice-unpublish/function.json
@@ -1,0 +1,14 @@
+{
+	"bindings": [
+		{
+			"type": "serviceBusTrigger",
+			"direction": "in",
+			"name": "message",
+			"topicName": "nsip-s51-advice",
+			"subscriptionName": "applications-nsip-advice-unpublish",
+			"connection": "ServiceBusConnection",
+			"accessRights": "listen"
+		}
+	],
+	"disabled": false
+}

--- a/packages/back-office-subscribers/nsip-advice-unpublish/index.js
+++ b/packages/back-office-subscribers/nsip-advice-unpublish/index.js
@@ -1,0 +1,20 @@
+const { prismaClient } = require('../lib/prisma');
+
+module.exports = async (context, message) => {
+	context.log(`invoking nsip-advice-unpublish function`);
+	const adviceId = message.adviceId;
+
+	if (!adviceId) {
+		context.log(`skipping unpublish as adviceId is missing`);
+		return;
+	}
+
+	// we use deleteMany to avoid the need to check if the advice exists
+	await prismaClient.advice.deleteMany({
+		where: {
+			adviceId
+		}
+	});
+
+	context.log(`unpublished advice with adviceId: ${adviceId}`);
+};


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-2089

This PR creates a back office subscriber function to unpublish s51 advice messages (remove from DB)

## Useful information to review or test

1. Follow the readme on the back-office subscribers function to set it up
2. Run azurite `npx azurite` and this function `npm run start:dev nsip-advice-unpublish`
3. Make a POST request to `http://localhost:7071/admin/functions/nsip-advice-unpublish` with this body:
```
{
    "input": "{\"adviceId\":2}"
}
```

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes