### PR TITLE
test(e2e-tests): add screenshots within tests to help create sitemap

### DIFF
--- a/e2e-tests/cypress.config.js
+++ b/e2e-tests/cypress.config.js
@@ -9,7 +9,8 @@ module.exports = defineConfig({
 	env: {
 		demoDelay: 0,
 		APP_APPLICATION_BASE_URL: 'http://forms-web-app:9004',
-		TAGS: 'not (@wip or @ignore)'
+		TAGS: 'not (@wip or @ignore)',
+		captureSiteMap: false
 	},
 	projectId: 'ud8v53',
 	e2e: {

--- a/e2e-tests/cypress/e2e/common/actions.js
+++ b/e2e-tests/cypress/e2e/common/actions.js
@@ -3,12 +3,16 @@ import { Given, When } from 'cypress-cucumber-preprocessor/steps';
 Given('I am registering as an {string}', (radioChoice) => {
 	cy.visit('/project-search', { failOnStatusCode: false });
 	cy.clickProjectLink('North Lincolnshire Green Energy Park');
+	cy.captureScreenForSiteMap();
 	cy.clickOnHref('register-have-your-say');
+	cy.captureScreenForSiteMap();
 	cy.clickOnHref('who-registering-for');
+	cy.captureScreenForSiteMap();
 	cy.selectRadioOption(radioChoice);
 	cy.clickSaveAndContinue();
 });
 
 When('I click on the continue button', () => {
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 });

--- a/e2e-tests/cypress/e2e/cookies-banner/cookies-banner.js
+++ b/e2e-tests/cypress/e2e/cookies-banner/cookies-banner.js
@@ -13,10 +13,12 @@ Then('I am on the {string} page', (pageName) => {
 });
 
 And('I click on {string} cookies button', (cookieChoice) => {
+	cy.captureScreenForSiteMap();
 	cookiePage.clickOnCookieChoice(cookieChoice);
 });
 
 Then('I verify below text is present on the page', function (table) {
+	cy.captureScreenForSiteMap();
 	const data = table.hashes();
 	cy.confirmTextOnPage(data[0].Text);
 });
@@ -26,6 +28,7 @@ And('I select {string} radio choice', (radioChoice) => {
 });
 
 And('I click on save changes on cookie settings page', () => {
+	cy.captureScreenForSiteMap();
 	cookiePage.clickSaveChangesButton();
 });
 

--- a/e2e-tests/cypress/e2e/decision-making-process-guide/decision-making-process-guide.js
+++ b/e2e-tests/cypress/e2e/decision-making-process-guide/decision-making-process-guide.js
@@ -12,8 +12,10 @@ And('I click on show all link', () => {
 	cy.get(
 		'*[class^="app-step-nav__button-text app-step-nav__button-text--all js-step-controls-button-text"]'
 	).click();
+	cy.captureScreenForSiteMap();
 });
 
 And('I click on {string} link', (pageName) => {
 	cy.clickLinkTonavigateToPage(pageName);
+	cy.captureScreenForSiteMap();
 });

--- a/e2e-tests/cypress/e2e/footer-links.feature
+++ b/e2e-tests/cypress/e2e/footer-links.feature
@@ -22,3 +22,7 @@ Feature: verify footer links
     Scenario: click on Cookies
         And I click on "Cookies" footer link
         Then I am on the "Cookies settings" page
+
+		Scenario: click on Contact
+				And I click on "Contact" footer link
+				Then I am on the "Contact" page

--- a/e2e-tests/cypress/e2e/footer-links/footer-links.js
+++ b/e2e-tests/cypress/e2e/footer-links/footer-links.js
@@ -10,18 +10,27 @@ And('I click on {string} footer link', (linkType) => {
 	switch (linkType) {
 		case 'Sitemap':
 			cy.get('[data-cy="Privacy"]').click();
+			cy.captureScreenForSiteMap();
 			break;
 		case 'Terms and conditions':
 			cy.get('[data-cy="Terms and conditions"]').click();
+			cy.captureScreenForSiteMap();
 			break;
 		case 'Accessibility':
 			cy.get('[data-cy="Accessibility statement"]').click();
+			cy.captureScreenForSiteMap();
 			break;
 		case 'Privacy Notice':
 			cy.get('[data-cy="Privacy"]').click();
+			cy.captureScreenForSiteMap();
 			break;
 		case 'Cookies':
 			cy.get('[data-cy="Cookies"]').click();
+			cy.captureScreenForSiteMap();
+			break;
+		case 'Contact':
+			cy.get('[data-cy="Contact"]').click();
+			cy.captureScreenForSiteMap();
 			break;
 	}
 });

--- a/e2e-tests/cypress/e2e/project-application-documents/project-application-documents.js
+++ b/e2e-tests/cypress/e2e/project-application-documents/project-application-documents.js
@@ -25,6 +25,7 @@ Then('below rows should be returned', (table) => {
 
 When('I enter text {string} into search field', (searchInput) => {
 	projectAppDocs.enterTextIntoSearchField(searchInput);
+	cy.captureScreenForSiteMap();
 });
 
 And('I verify below pagination is present on the page', (table) => {
@@ -33,6 +34,7 @@ And('I verify below pagination is present on the page', (table) => {
 
 And('I navigate to page {string} of the results', (paginationLink) => {
 	projectAppDocs.clickOnPaginationLink(paginationLink);
+	cy.captureScreenForSiteMap();
 });
 
 And('I verify text {string} is present on the page', (resultsText) => {
@@ -79,11 +81,13 @@ Then(
 	'I verify that the {string} section expanded with {int} filters',
 	(sectionName, sectionLength) => {
 		projectAppDocs.assertSectionLength(sectionName, sectionLength);
+		cy.captureScreenForSiteMap();
 	}
 );
 
 And('I click on Apply button to apply filters', () => {
 	projectAppDocs.clickApplyFilterButton();
+	cy.captureScreenForSiteMap();
 });
 
 And('I select {string} checkbox', (checkBoxName) => {

--- a/e2e-tests/cypress/e2e/register-to-say-about-national-infra-project/register-to-say-about-national-infra-project.js
+++ b/e2e-tests/cypress/e2e/register-to-say-about-national-infra-project/register-to-say-about-national-infra-project.js
@@ -19,9 +19,11 @@ And('I click on show all link', () => {
 	cy.get(
 		'*[class^="app-step-nav__button-text app-step-nav__button-text--all js-step-controls-button-text"]'
 	).click();
+	cy.captureScreenForSiteMap();
 });
 When('I select the "How to register link"', () => {
 	cy.clickOnHref('/having-your-say-guide/registering-have-your-say');
+	cy.captureScreenForSiteMap();
 });
 
 Then(
@@ -37,22 +39,27 @@ Then('I am on the {string} page', (pageName) => {
 
 And('I click on {string} link', (pageName) => {
 	cy.clickLinkTonavigateToPage(pageName);
+	cy.captureScreenForSiteMap();
 });
 
 And('I click on Next link', () => {
 	cy.get('#main-content > div > div.govuk-grid-column-two-thirds > div > div > a > strong').click();
+	cy.captureScreenForSiteMap();
 });
 
 And('I click on Get involved in the preliminary meeting link', () => {
 	cy.get('#main-content > div > div.govuk-grid-column-two-thirds > div > div > a > span').click();
+	cy.captureScreenForSiteMap();
 });
 
 And('I click on registering to have your say about a national infrastructure project link', () => {
 	cy.get('#step-panel-registering-to-have-your-say-1').click();
+	cy.captureScreenForSiteMap();
 });
 
 And('I click on get involved in the preliminary meeting link', () => {
 	cy.get('#step-panel-get-involved-in-the-preliminary-meeting-1 > p:nth-child(2) > a').click();
+	cy.captureScreenForSiteMap();
 });
 
 And('the page does not include a link to a project', () => {

--- a/e2e-tests/cypress/e2e/registration/agent/complete-registration/complete-registration.js
+++ b/e2e-tests/cypress/e2e/registration/agent/complete-registration/complete-registration.js
@@ -28,36 +28,48 @@ const shortComment = 'I am against the proposal since it will reduce resident pa
 
 And('I have been asked to check my answers', () => {
 	fullNamePage.enterTextIntoFullNameField('TestFirstName TestMiddleName TestLastName');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	orgYouWorkFor.enterTextIntoOrgNameField('Test Organisation Name');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	emailAddress.enterTextIntoEmailField('testpins2@gmail.com');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	telNumber.enterTextIntoTelephoneNumberField('123456789');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	addressDetails.enterTextFromObjectIntoAddressFields({
 		AddressLine1: 'Address Line 1',
 		PostCode: 'NE27 0BB',
 		Country: 'United Kingdom'
 	});
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	whoYouRepresenting.selectRadioOption('A person');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	repName.enterTextIntoRepNameField('Representee FirstName Representee LastName');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	cy.selectRadioYesOrNo('Yes');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	repAddressDetails.enterTextFromObjectIntoAddressFields({
 		AddressLine1: 'Representee Address Line 1',
 		PostCode: 'NE27 0BB',
 		Country: 'United Kingdom'
 	});
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	repEmailAddress.enterTextIntoRepEmailField('representeetestpins2@gmail.com');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	repTelNumber.enterTextIntoRepTelephoneNumberField('12121212121');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	tellAboutProject.enterTextIntoCommentsField(shortComment);
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 });
 
@@ -69,6 +81,7 @@ And(
 	'I verify below data is present on Check your answers before registering page',
 	function (table) {
 		cyaBeforeReg.assertDataOnPage(table);
+		cy.captureScreenForSiteMap();
 	}
 );
 
@@ -76,18 +89,22 @@ And('User clicks on accept and continue button for {string}', (linkType) => {
 	switch (linkType) {
 		case 'myself':
 			cy.clickOnHref('/register/myself/declaration');
+			cy.captureScreenForSiteMap();
 			break;
 		case 'organisation':
 			cy.clickOnHref('/register/organisation/declaration');
+			cy.captureScreenForSiteMap();
 			break;
 		case 'on behalf':
 			cy.clickOnHref('/register/agent/declaration');
+			cy.captureScreenForSiteMap();
 			break;
 	}
 });
 
 And('User clicks on accept and register button', () => {
 	cy.get('[data-cy="button-accept-and-regoster"]').click();
+	cy.captureScreenForSiteMap();
 });
 
 And('I click on {string} change link', (linkType) => {

--- a/e2e-tests/cypress/e2e/registration/agent/who-are-you-representing/PageObjects/PO_WhoYouRepresenting.js
+++ b/e2e-tests/cypress/e2e/registration/agent/who-are-you-representing/PageObjects/PO_WhoYouRepresenting.js
@@ -3,12 +3,15 @@ class PO_WhoYouRepresenting {
 		switch (radioOption) {
 			case 'A person':
 				cy.get('[data-cy="answer-person"]').click();
+				cy.captureScreenForSiteMap();
 				break;
 			case 'An organisation or charity':
 				cy.get('[data-cy="answer-organisation"]').click();
+				cy.captureScreenForSiteMap();
 				break;
 			case 'A family group':
 				cy.get('[data-cy="answer-family"]').click();
+				cy.captureScreenForSiteMap();
 				break;
 		}
 	}

--- a/e2e-tests/cypress/e2e/registration/myself/regsitration-complete/regsitration-complete.js
+++ b/e2e-tests/cypress/e2e/registration/myself/regsitration-complete/regsitration-complete.js
@@ -17,13 +17,17 @@ Given('I navigate to UK address details page', () => {
 	cy.clickOnHref('/register-have-your-say');
 	cy.clickOnHref('who-registering-for');
 	cy.selectRadioOption('Myself');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	fullNamePage.enterTextIntoFullNameField('TestFirstName TestMiddleName TestLastName');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	cy.selectRadioYesOrNo('Yes');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	emailAddressPage.enterTextIntoEmailField('test@gmail.com');
 	cy.clickSaveAndContinue();
+	cy.captureScreenForSiteMap();
 });
 
 And('User clicks on continue button', () => {
@@ -32,6 +36,7 @@ And('User clicks on continue button', () => {
 
 And('I enter below data into address details page', function (table) {
 	addressDetails.enterTextIntoAddressFields(table);
+	cy.captureScreenForSiteMap();
 });
 
 Then('I am on the {string} page', (pageName) => {
@@ -40,22 +45,27 @@ Then('I am on the {string} page', (pageName) => {
 
 And('I enter {string} into email address field', (dataInput) => {
 	emailAddressPage.enterTextIntoEmailField(dataInput);
+	cy.captureScreenForSiteMap();
 });
 
 And('I enter {string} into telephone number field', (dataInput) => {
 	teleNumberPage.enterTextIntoTelephoneNumberField(dataInput);
+	cy.captureScreenForSiteMap();
 });
 
 And('I enter {string} into comments field', (dataInput) => {
 	tellAboutProject.enterTextIntoCommentsField(dataInput);
+	cy.captureScreenForSiteMap();
 });
 
 And('User clicks on accept and continue button for {string}', (linkType) => {
 	switch (linkType) {
 		case 'myself':
+			cy.captureScreenForSiteMap();
 			cy.clickOnHref('/register/myself/declaration');
 			break;
 		case 'organisation':
+			cy.captureScreenForSiteMap();
 			cy.clickOnHref('/register/organisation/declaration');
 			break;
 	}
@@ -63,23 +73,27 @@ And('User clicks on accept and continue button for {string}', (linkType) => {
 
 And('User clicks on accept and register button', () => {
 	cy.get('[data-cy="button-accept-and-regoster"]').click();
+	cy.captureScreenForSiteMap();
 });
 
 And(
 	'I click on find out more about having your say during the Examination of the application link',
 	() => {
 		cy.clickOnHref('/having-your-say-guide/have-your-say-examination');
+		cy.captureScreenForSiteMap();
 	}
 );
 
 And('I enter {string} into topic field', (dataInput) => {
 	tellAboutProject.enterTextIntoTopicField(dataInput);
+	cy.captureScreenForSiteMap();
 });
 
 When(
 	'user selects {string} radio option on Do you want to add another comment page',
 	(radioChoice) => {
 		cy.selectRadioYesOrNo(radioChoice);
+		cy.captureScreenForSiteMap();
 	}
 );
 
@@ -90,6 +104,7 @@ Then('I click on feedback link', () => {
 			cy.get('.govuk-link').eq(index).click();
 		}
 	});
+	cy.captureScreenForSiteMap();
 });
 
 Then('I click on go back to project page link', () => {

--- a/e2e-tests/cypress/e2e/registration/organisation/complete-registration/complete-registration.js
+++ b/e2e-tests/cypress/e2e/registration/organisation/complete-registration/complete-registration.js
@@ -16,33 +16,43 @@ const jobTitlePage = new PO_WhatIsJobTitle();
 
 Given('I have been asked to check my answers', () => {
 	fullNamePage.enterTextIntoFullNameField('TestFirstName TestMiddleName TestLastName');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	cy.selectRadioYesOrNo('Yes');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	orgNamePage.enterTextIntoOrganisationNameField('Organisation name');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	cy.assertUserOnThePage('What is your job title or volunteer role?');
 	jobTitlePage.enterTextIntoJobTitleField('Test job title');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	emailAddressPage.enterTextIntoEmailField('test@test.com');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	addressDetails.enterTextFromObjectIntoAddressFields({
 		AddressLine1: 'Address Line 1',
 		PostCode: 'NE27 0QQ',
 		Country: 'United Kingdom'
 	});
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	telephoneNumberPage.enterTextIntoTelephoneNumberField('07859894511');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	commentsPage.enterTextIntoCommentsField('This is a test comment');
+	cy.captureScreenForSiteMap();
 	cy.clickSaveAndContinue();
 	cy.assertUserOnThePage('check your answers before registering organisation');
 });
 
 When('I confirm my answers are correct', () => {
+	cy.captureScreenForSiteMap();
 	cy.clickOnHref('/register/organisation/declaration');
 });
 
 When('I accept the declaration', () => {
 	cy.get('[data-cy="button-accept-and-regoster"]').click();
+	cy.captureScreenForSiteMap();
 });

--- a/e2e-tests/cypress/support/commands/navigation-commands.js
+++ b/e2e-tests/cypress/support/commands/navigation-commands.js
@@ -25,6 +25,11 @@ Cypress.Commands.add('clickContentsLink', require('../common-methods/clickConten
 Cypress.Commands.add('selectRadioYesOrNo', require('../common-methods/selectRadioYesOrNo'));
 
 Cypress.Commands.add(
+	'captureScreenForSiteMap',
+	require('../common-methods/captureScreenForSiteMap')
+);
+
+Cypress.Commands.add(
 	'assertLinksPresentOnPage',
 	require('../common-methods/assertLinksPresentOnPage')
 );

--- a/e2e-tests/cypress/support/common-methods/assertUserOnThePage.js
+++ b/e2e-tests/cypress/support/common-methods/assertUserOnThePage.js
@@ -659,6 +659,15 @@ module.exports = (pageName) => {
 				});
 			cy.url().should('include', '/cookies-info');
 			break;
+		case 'contact':
+			cy.title().should('eq', 'Contact');
+			cy.get('h1')
+				.invoke('text')
+				.then((text) => {
+					expect(text).to.contain('Contact us');
+				});
+			cy.url().should('include', '/contact');
+			break;
 		case 'what is the name of the organisation you work for?':
 			cy.title().should(
 				'eq',

--- a/e2e-tests/cypress/support/common-methods/captureScreenForSiteMap.js
+++ b/e2e-tests/cypress/support/common-methods/captureScreenForSiteMap.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+	if (Cypress.env('captureSiteMap')) {
+		cy.screenshot({ capture: 'fullPage' });
+	}
+};


### PR DESCRIPTION
Add screenshot calls to help create sitemap using tests.

## Describe your changes

<!--
    [Issue ticket number and link](https://pins-ds.atlassian.net/browse/ASB-2139)
-->

- As part of spike to use automation tests to help create a sitemap add new function captureScreenForSiteMap which will capture a screenshot if activated via configuration.  This functionality is off by default.

- Add screenshot calls to capture main journey screens. 

- Also add some tests for footer links Contact page.


## Useful information to review or test

Output from the test runs can be found in the sitemap Mural board


## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
