### PR TITLE
fix: representation function only create service user if id exists in message

### DIFF
--- a/packages/back-office-subscribers/nsip-representation/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-representation/__tests__/index.test.js
@@ -200,4 +200,32 @@ describe('nsip-representation', () => {
 			});
 		});
 	});
+	describe('when representedId is missing', () => {
+		it('does not createOrConnect represented', async () => {
+			const mockMessageWithoutRepresented = {
+				...mockMessage,
+				representedId: null
+			};
+			const mockRepresentationWithoutRepresented = {
+				...mockRepresentation,
+				represented: undefined
+			};
+			await sendMessage(mockContext, mockMessageWithoutRepresented);
+			assertRepresentationUpsert(mockRepresentationWithoutRepresented);
+		});
+	});
+	describe('when representativeId is missing', () => {
+		it('does not createOrConnect representative', async () => {
+			const mockMessageWithoutRepresentative = {
+				...mockMessage,
+				representativeId: null
+			};
+			const mockRepresentationWithoutRepresentative = {
+				...mockRepresentation,
+				representative: undefined
+			};
+			await sendMessage(mockContext, mockMessageWithoutRepresentative);
+			assertRepresentationUpsert(mockRepresentationWithoutRepresentative);
+		});
+	});
 });

--- a/packages/back-office-subscribers/nsip-representation/index.js
+++ b/packages/back-office-subscribers/nsip-representation/index.js
@@ -37,31 +37,34 @@ module.exports = async (context, message) => {
 			representationFrom: message.representationFrom,
 			representationType: message.representationType,
 			registerFor: message.registerFor,
-			// connect (create if it does not exist) to serviceUser with representedId
-			represented: {
-				connectOrCreate: {
-					where: {
-						serviceUserId: message.representedId
-					},
-					create: {
-						serviceUserId: message.representedId
-					}
-				}
-			},
-			// connect (create if it does not exist) to serviceUser with representativeId
-			representative: {
-				connectOrCreate: {
-					where: {
-						serviceUserId: message.representativeId
-					},
-					create: {
-						serviceUserId: message.representativeId
-					}
-				}
-			},
 			attachmentIds: message.attachmentIds?.join(','),
 			modifiedAt: new Date()
 		};
+
+		if (message.representedId) {
+			representation.represented = {
+				connectOrCreate: {
+					where: {
+						serviceUserId: message.representedId
+					},
+					create: {
+						serviceUserId: message.representedId
+					}
+				}
+			};
+		}
+		if (message.representativeId) {
+			representation.representative = {
+				connectOrCreate: {
+					where: {
+						serviceUserId: message.representativeId
+					},
+					create: {
+						serviceUserId: message.representativeId
+					}
+				}
+			};
+		}
 
 		await tx.representation.upsert({
 			where: {


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-2178

PR adds a check to consumer function to only createOrConnect represented Or representative if the representedId and representativeId exists in the message.

## Useful information to review or test

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
