### PR TITLE
feat: rep update consumer function

### DIFF
--- a/packages/back-office-subscribers/nsip-representation-update/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-representation-update/__tests__/index.test.js
@@ -1,0 +1,65 @@
+const sendMessage = require('../index');
+
+const mockRepresentationUpdate = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+	prismaClient: {
+		representation: {
+			update: (query) => mockRepresentationUpdate(query)
+		}
+	}
+}));
+
+const mockContext = {
+	log: jest.fn(),
+	bindingData: {
+		enqueuedTimeUtc: new Date('2023-01-01T09:00:00.000Z'),
+		deliveryCount: 1,
+		messageId: 123
+	}
+};
+const mockMessage = {
+	representationId: 123,
+	status: 'PUBLISHED'
+};
+
+describe('nsip-representation-update', () => {
+	beforeEach(() => {
+		mockRepresentationUpdate.mockReset();
+	});
+
+	it('logs message', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockContext.log).toHaveBeenCalledWith('invoking nsip-representation-update function');
+	});
+	it('skips update if representationId is missing', async () => {
+		await sendMessage(mockContext, {
+			...mockMessage,
+			representationId: null
+		});
+
+		expect(mockContext.log).toHaveBeenCalledWith('skipping update as representationId is missing');
+		expect(mockRepresentationUpdate).not.toHaveBeenCalled();
+	});
+
+	it('skips update if status is missing', async () => {
+		await sendMessage(mockContext, {
+			...mockMessage,
+			status: null
+		});
+
+		expect(mockContext.log).toHaveBeenCalledWith('skipping update as status is missing');
+		expect(mockRepresentationUpdate).not.toHaveBeenCalled();
+	});
+
+	it('updates representation status', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockRepresentationUpdate).toHaveBeenCalledWith({
+			where: { representationId: mockMessage.representationId },
+			data: { status: mockMessage.status }
+		});
+		expect(mockContext.log).toHaveBeenCalledWith(
+			`updated representation ${mockMessage.representationId} to ${mockMessage.status}`
+		);
+	});
+});

--- a/packages/back-office-subscribers/nsip-representation-update/function.json
+++ b/packages/back-office-subscribers/nsip-representation-update/function.json
@@ -1,0 +1,14 @@
+{
+	"bindings": [
+		{
+			"type": "serviceBusTrigger",
+			"direction": "in",
+			"name": "message",
+			"topicName": "nsip-representation",
+			"subscriptionName": "applications-nsip-representation-update",
+			"connection": "ServiceBusConnection",
+			"accessRights": "listen"
+		}
+	],
+	"disabled": false
+}

--- a/packages/back-office-subscribers/nsip-representation-update/index.js
+++ b/packages/back-office-subscribers/nsip-representation-update/index.js
@@ -1,0 +1,20 @@
+const { prismaClient } = require('../lib/prisma');
+
+module.exports = async (context, message) => {
+	context.log(`invoking nsip-representation-update function`);
+	const { representationId, status } = message;
+
+	if (!representationId) {
+		context.log(`skipping update as representationId is missing`);
+		return;
+	} else if (!status) {
+		context.log(`skipping update as status is missing`);
+		return;
+	}
+
+	await prismaClient.representation.update({
+		where: { representationId },
+		data: { status }
+	});
+	context.log(`updated representation ${representationId} to ${status}`);
+};


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-2173

This PR creates a back office subscriber function to consume and update the status for representations

## Useful information to review or test

1. Follow the readme on the back-office subscribers function to set it up
2. Run azurite `npx azurite` and this function `npm run start:dev nsip-representation-update`
3. Make a POST request to `http://localhost:7071/admin/functions/nsip-representation-update` with this body: 
```
{
    "input": "{\"representationId\":100,\"status\":\"PUBLISHED\"}"
}
```

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes