### PR TITLE
Fix/asb 2150 document filter merge duplicates

### DIFF
--- a/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
@@ -157,6 +157,7 @@ describe('document mapper functions', () => {
 			['stage', 7, 'Post-decision'],
 			['stage', 'pre-application', 'Pre-application'],
 			['stage', 'acceptance', 'Acceptance'],
+			['stage', 'Acceptance', 'Acceptance'],
 			['stage', 'pre-examination', 'Pre-examination'],
 			['stage', 'examination', 'Examination'],
 			['stage', 'recommendation', 'Recommendation'],
@@ -180,11 +181,15 @@ describe('document mapper functions', () => {
 					}
 				];
 				const mappedFilters = mapFilters(filter);
+				const lowerCaseValue =
+					Number.isInteger(filterValue) || filterName === 'category'
+						? filterValue
+						: filterValue.toLowerCase();
 
 				expect(mappedFilters[0]).toEqual(
 					expect.objectContaining({
 						name: filterName,
-						value: filterValue,
+						value: lowerCaseValue,
 						label: expectedLabel,
 						type: [
 							{
@@ -230,6 +235,20 @@ describe('document mapper functions', () => {
 			expect(mappedFilters[0].value).toEqual('pre-application');
 			expect(mappedFilters[1].value).toEqual('examination');
 			expect(mappedFilters[2].value).toEqual('decision');
+		});
+
+		it('merges stages with uppercase and lowercase value combinations into a single filter)', () => {
+			const mappedFilters = mapFilters([
+				{ stage: 'decision', filter1: 'something', total: 1 },
+				{ stage: 'examination', filter1: 'something', total: 6 },
+				{ stage: 'Examination', filter1: 'something', total: 3 },
+				{ stage: 'pre-application', filter1: 'something', total: 1 },
+				{ stage: 'Pre-application', filter1: 'something', total: 3 }
+			]);
+
+			expect(mappedFilters.length).toEqual(3);
+			expect(mappedFilters[1].value).toEqual('examination');
+			expect(mappedFilters[1].count).toEqual(9);
 		});
 	});
 });

--- a/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
@@ -181,7 +181,7 @@ describe('document mapper functions', () => {
 					}
 				];
 				const mappedFilters = mapFilters(filter);
-				const lowerCaseValue =
+				const expectedFilterValue =
 					Number.isInteger(filterValue) || filterName === 'category'
 						? filterValue
 						: filterValue.toLowerCase();
@@ -189,7 +189,7 @@ describe('document mapper functions', () => {
 				expect(mappedFilters[0]).toEqual(
 					expect.objectContaining({
 						name: filterName,
-						value: lowerCaseValue,
+						value: expectedFilterValue,
 						label: expectedLabel,
 						type: [
 							{

--- a/packages/applications-service-api/src/utils/document.mapper.js
+++ b/packages/applications-service-api/src/utils/document.mapper.js
@@ -88,7 +88,11 @@ const mapBackOfficeDocuments = (documents) =>
 
 const mapFilters = (input) => {
 	const appendFilter = (filterGroup, filter, filterName) => {
-		const filterValue = filter[filterName];
+		const filterValue =
+			Number.isInteger(filter[filterName]) || filterName === 'category'
+				? filter[filterName]
+				: filter[filterName].toLowerCase();
+
 		if (!filterGroup[filterValue]) {
 			filterGroup[filterValue] = {
 				name: filterName,


### PR DESCRIPTION
## Describe your changes


   https://pins-ds.atlassian.net/browse/ASB-2150

Fix issue where stages with uppercase/lowercase values are displaying multiple stages for the same stage, eg Acceptance:
https://applications-service-test.planninginspectorate.gov.uk/projects/BC0110001/documents

- The change converts the filter value to lowercase so that each different case stage, eg acceptance, Acceptance are grouped together.
- This excludes the 'category' filter as this is handled separately and with BO it will be replaced by "Developer's Application" as a stage rather than category.

 
## Useful information to review or test

- Will be interesting to test filters work, in dev/test where the issue is currently happening.
- Will also be good to check the filters returned:
[/api/v3/documents](https://pins-app-applications-service-applications-api-dev-ukw-001.azurewebsites.net/api-docs/#/Documents/post_api_v3_documents)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
