### PR TITLE
fix(nsip-exam-timetable): handle missing deadline start time

### DIFF
--- a/packages/back-office-subscribers/nsip-exam-timetable/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable/__tests__/index.test.js
@@ -36,7 +36,6 @@ const mockMessage = {
 			type: 'Preliminary Meeting',
 			eventTitle: 'Example Preliminary Meeting',
 			description: 'A preliminary meeting will be held to discuss the examination process.',
-			eventDeadlineStartDate: '2023-06-10',
 			date: '2023-06-10',
 			eventLineItems: [
 				{
@@ -76,7 +75,9 @@ const assertEventsCreated = (message) => {
 				type: event.type,
 				eventTitle: event.eventTitle,
 				description: event.description,
-				eventDeadlineStartDate: new Date(event.eventDeadlineStartDate),
+				...(event.eventDeadlineStartDate && {
+					eventDeadlineStartDate: new Date(event.eventDeadlineStartDate)
+				}),
 				date: new Date(event.date),
 				eventId: event.eventId,
 				eventLineItems: {

--- a/packages/back-office-subscribers/nsip-exam-timetable/index.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable/index.js
@@ -46,7 +46,9 @@ module.exports = async (context, message) => {
 						type: event.type,
 						eventTitle: event.eventTitle,
 						description: event.description,
-						eventDeadlineStartDate: new Date(event.eventDeadlineStartDate),
+						...(event.eventDeadlineStartDate && {
+							eventDeadlineStartDate: new Date(event.eventDeadlineStartDate)
+						}),
 						date: new Date(event.date),
 						eventId: event.eventId,
 						eventLineItems: {


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/ASB-2214

Handle case where deadlineStartDate does not exist. This will only be set on events of type deadline, change will set based on availability.

This is causing the function to fail at the moment for any messages which include non-deadline events.
Will be tested/validated once deployed via message bus.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
