### PR TITLE
feat(back-office-subscribers): add exam timetable unpublish function

### DIFF
--- a/e2e-tests/cypress/e2e/examination-of-the-application.feature
+++ b/e2e-tests/cypress/e2e/examination-of-the-application.feature
@@ -13,11 +13,13 @@ Feature: Examination page
     Scenario: verify page title, heading and contents
         Then I am on the "examination" page
         And I verify below links present on Examination page
-            | Links                                                   |
-            | About the examination stage                             |
-            | What happens at the examination stage                   |
-            | What you can do if you have registered to have your say |
-            | If you have missed the deadline to register             |
-            | More detailed advice                                    |
+            | Links                                                                     |
+            | About the examination stage                                               |
+            | What happens at the examination stage                                     |
+            | When you have registered to have your say you can                         |
+            | If you have missed the deadline to register                               |
+            | If you have recently gained an interest in land affected by a development |
+            | More information                                                          |
+
         And I click on "Find out what you can do at this stage and check our detailed guides" link
         Then I am on the "Pre-application" page

--- a/packages/back-office-subscribers/nsip-exam-timetable-unpublish/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable-unpublish/__tests__/index.test.js
@@ -1,0 +1,47 @@
+const sendMessage = require('../index');
+
+const mockDeleteMany = jest.fn();
+
+jest.mock('../../lib/prisma', () => ({
+	prismaClient: {
+		examinationTimetable: {
+			deleteMany: (query) => mockDeleteMany(query)
+		}
+	}
+}));
+
+const mockContext = {
+	log: jest.fn(),
+	bindingData: {
+		enqueuedTimeUtc: '2023-01-01T09:00:00.000Z',
+		deliveryCount: 1,
+		messageId: 123
+	}
+};
+
+const mockMessage = {
+	caseReference: 'mock-case-ref'
+};
+
+describe('nsip-exam-timetable-unpublish', () => {
+	it('logs message', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockContext.log).toHaveBeenCalledWith('invoking nsip-exam-timetable-unpublish');
+	});
+
+	it('throws an error if caseReference is missing', async () => {
+		await expect(sendMessage(mockContext, {})).rejects.toThrow('caseReference is required');
+	});
+
+	it('unpublishes exam time table', async () => {
+		await sendMessage(mockContext, mockMessage);
+		expect(mockDeleteMany).toHaveBeenCalledWith({
+			where: {
+				caseReference: mockMessage.caseReference
+			}
+		});
+		expect(mockContext.log).toHaveBeenCalledWith(
+			`unpublished ExaminationTimetable with caseReference: ${mockMessage.caseReference}`
+		);
+	});
+});

--- a/packages/back-office-subscribers/nsip-exam-timetable-unpublish/function.json
+++ b/packages/back-office-subscribers/nsip-exam-timetable-unpublish/function.json
@@ -1,0 +1,14 @@
+{
+	"bindings": [
+		{
+			"type": "serviceBusTrigger",
+			"direction": "in",
+			"name": "message",
+			"topicName": "nsip-exam-timetable",
+			"subscriptionName": "applications-nsip-exam-timetable-unpublish",
+			"connection": "ServiceBusConnection",
+			"accessRights": "listen"
+		}
+	],
+	"disabled": false
+}

--- a/packages/back-office-subscribers/nsip-exam-timetable-unpublish/index.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable-unpublish/index.js
@@ -1,0 +1,19 @@
+const { prismaClient } = require('../lib/prisma');
+
+module.exports = async (context, message) => {
+	context.log(`invoking nsip-exam-timetable-unpublish`);
+	const caseReference = message.caseReference;
+
+	if (!caseReference) {
+		throw new Error('caseReference is required');
+	}
+
+	// we use deleteMany to avoid the need to check if the project exists
+	await prismaClient.examinationTimetable.deleteMany({
+		where: {
+			caseReference
+		}
+	});
+
+	context.log(`unpublished ExaminationTimetable with caseReference: ${caseReference}`);
+};

--- a/packages/back-office-subscribers/nsip-exam-timetable-unpublish/index.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable-unpublish/index.js
@@ -8,7 +8,7 @@ module.exports = async (context, message) => {
 		throw new Error('caseReference is required');
 	}
 
-	// we use deleteMany to avoid the need to check if the project exists
+	// we use deleteMany to avoid the need to check if the timetable exists
 	await prismaClient.examinationTimetable.deleteMany({
 		where: {
 			caseReference


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-2286

Infra PR:

## Useful information to review or test

1. Follow the readme on the back-office subscribers function to set it up
2. Run azurite `npx azurite` and this function `npx func start --functions nsip-exam-timetable-unpublish`
3. Make a POST request to `http://localhost:7071/admin/functions/nsip-exam-timetable-unpublish` with this body:
```
{
    "input": "{\"caseReference\":\"mock-id\"}"
}
```

to test that the error is thrown when case reference is missing:

```
{
    "input": "{\"notCaseReference\":\"mock-id\"}"
}
```


## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
