### PR TITLE
fix(document.backoffice.repository.js): do not return attachments in …

### DIFF
--- a/packages/applications-service-api/src/repositories/document.backoffice.repository.js
+++ b/packages/applications-service-api/src/repositories/document.backoffice.repository.js
@@ -6,7 +6,7 @@ const getFilters = (caseReference) => {
 		SELECT DISTINCT(stage), filter1, count(id) as total
 		FROM Document
 		WHERE caseRef = ${caseReference}
-			AND (stage is not null and stage <> 'draft')
+			AND (stage is not null and stage <> 'draft' and stage <> '0')
 			AND filter1 is not null
 		GROUP BY stage, filter1`;
 
@@ -18,7 +18,11 @@ const getDocuments = async (query) => {
 		AND: [
 			{ caseRef: query.caseReference },
 			{
-				AND: [{ stage: { not: { equals: null } } }, { stage: { not: { equals: 'draft' } } }]
+				AND: [
+					{ stage: { not: { equals: null } } },
+					{ stage: { not: { equals: 'draft' } } },
+					{ stage: { not: { equals: '0' } } }
+				]
 			}
 		]
 	};


### PR DESCRIPTION
…documents search endpoint

## Describe your changes

Fix to filter out attachments from document search endpoint, these will have stage = '0' indicating they are an attachment.
This logic already exists in the NI DB repository.

    [Issue ticket number and link](https://pins-ds.atlassian.net/browse/ASB-2295)

## Useful information to review or test

Tested locally with documents marked as '0'

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
