### PR TITLE
feat: hide pagination controls for merged applications

### DIFF
--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -64,7 +64,8 @@ module.exports = {
 		),
 		generalisedFormSanitisation:
 			process.env.FEATURE_ENABLE_GENERALISED_FORM_SANITISATION === 'true',
-		useApplicationInsights: process.env.FEATURE_APPLICATION_INSIGHTS === 'true'
+		useApplicationInsights: process.env.FEATURE_APPLICATION_INSIGHTS === 'true',
+		allowApplicationsPagination: process.env.BACK_OFFICE_INTEGRATION_GET_APPLICATIONS !== 'MERGE'
 	},
 	featureHideLink: {
 		hideAllExaminationDocumentsLink: true

--- a/packages/forms-web-app/src/pages/project-search/view.njk
+++ b/packages/forms-web-app/src/pages/project-search/view.njk
@@ -40,11 +40,15 @@
 
 				{% if applications | length %}
 
-					{% include "./includes/results-per-page.njk" %}
+					{% if featureFlag.allowApplicationsPagination == true %}
+					    {% include "./includes/results-per-page.njk" %}
+                	{% endif %}
 
 					{% include "./includes/projects.njk" %}
 
-					{% include "./includes/pagination.njk" %}
+					{% if featureFlag.allowApplicationsPagination == true %}
+					    {% include "./includes/pagination.njk" %}
+                	{% endif %}
 
 				{% else %}
 

--- a/packages/forms-web-app/src/pages/register-of-applications/view.njk
+++ b/packages/forms-web-app/src/pages/register-of-applications/view.njk
@@ -21,9 +21,17 @@
 		{% include "./includes/search.njk" %}
 
 		{% if applications | length %}
-			{% include "./includes/results-per-page.njk" %}
+
+            {% if featureFlag.allowApplicationsPagination == true %}
+                {% include "./includes/results-per-page.njk" %}
+            {% endif %}
+
 			{% include "./includes/applications-table.njk" %}
-			{% include "./includes/pagination.njk" %}
+
+            {% if featureFlag.allowApplicationsPagination == true %}
+                {% include "./includes/pagination.njk" %}
+            {% endif %}
+
 		{% else %}
 			{% include "./includes/no-matching-results.njk" %}
 		{% endif %}


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-2284

PR hides pagination and items per page controls when showing merged applications (checked via feature flag)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
