### PR TITLE
fix: document sorting by datePublished

### DIFF
--- a/packages/applications-service-api/__tests__/unit/repositories/document.backoffice.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/document.backoffice.repository.test.js
@@ -96,7 +96,7 @@ describe('document repository', () => {
 			});
 
 			expect(mockFindFirst).toHaveBeenCalledWith({
-				orderBy: { createdAt: 'desc' },
+				orderBy: { datePublished: 'desc' },
 				take: 1,
 				where: { caseRef: 'mock case ref', documentType: 'mock type' }
 			});

--- a/packages/applications-service-api/src/repositories/document.backoffice.repository.js
+++ b/packages/applications-service-api/src/repositories/document.backoffice.repository.js
@@ -78,7 +78,7 @@ const getDocumentsByType = async (queryData) =>
 			documentType: queryData.type
 		},
 		orderBy: {
-			createdAt: 'desc'
+			datePublished: 'desc'
 		},
 		take: 1
 	});


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/ASB-2353

Previously was sorting by `createdAt` but should be using `datePublished`. This PR changes the sort filter for BO document repository.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
