### PR TITLE
fix: fallback to general advice case ref if project case ref is not available

### DIFF
--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/controller.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/controller.js
@@ -1,5 +1,6 @@
 const logger = require('../../../../lib/logger');
 const { getAdviceDetailData } = require('../../../../services/advice.service');
+const { registerOfAdviceCaseRef } = require('../../../register-of-advice/index/config');
 const { getPageViewModel } = require('./_utils/get-page-view-model');
 const { getView } = require('./_utils/get-view');
 
@@ -8,7 +9,9 @@ const getSection51AdviceDetailController = async (req, res, next) => {
 		const { params, path } = req;
 		const { case_ref, id } = params;
 
-		const adviceDetailData = await getAdviceDetailData(id, case_ref);
+		const caseRef = case_ref || registerOfAdviceCaseRef;
+
+		const adviceDetailData = await getAdviceDetailData(id, caseRef);
 
 		const view = getView(path, id);
 


### PR DESCRIPTION
## Describe your changes

Issue with general advice attachments not appearing on the page. Fix to fallback to the general advice case reference in the Section 51 advice detail controller when there isn't a project case reference available.

Original ticket: https://pins-ds.atlassian.net/browse/ASB-2310?atlOrigin=eyJpIjoiMTBkMjQ2Y2MzYTBlNDJmMDhmZWY0MjI2N2E0YTFlZmIiLCJwIjoiaiJ9

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
