### PR TITLE
fix: added null check to advice function attachmentIds

### DIFF
--- a/packages/back-office-subscribers/nsip-advice/index.js
+++ b/packages/back-office-subscribers/nsip-advice/index.js
@@ -25,7 +25,7 @@ module.exports = async (context, message) => {
 			let advice = pick(message, advicePropertiesFromMessage);
 			advice = {
 				...advice,
-				attachmentIds: advice?.attachmentIds.join(','),
+				attachmentIds: advice?.attachmentIds?.join(','),
 				modifiedAt: new Date()
 			};
 			await tx.advice.upsert({


### PR DESCRIPTION
## Describe your changes

Hotfix as BO advice function was throwing an error when attachmentIds did not exist due to missing null check.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
