### PR TITLE
fix(nsip-service-user): throw exception when no service user id present

### DIFF
--- a/packages/back-office-subscribers/nsip-service-user/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-service-user/__tests__/index.test.js
@@ -40,9 +40,9 @@ describe('nsip-service-user', () => {
 		await sendMessage(mockContext, mockApplicantMessage);
 		expect(mockContext.log).toHaveBeenCalledWith('invoking nsip-service-user function');
 	});
-	it('skips update if serviceUserId is missing', async () => {
-		await sendMessage(mockContext, {});
-		expect(mockContext.log).toHaveBeenCalledWith('skipping update as serviceUserId is missing');
+
+	it('throws error if serviceUserId is missing', async () => {
+		await expect(sendMessage(mockContext, {})).rejects.toThrow(`serviceUserId is required`);
 		expect(mockExecuteRawUnsafe).not.toHaveBeenCalled();
 	});
 
@@ -54,31 +54,56 @@ describe('nsip-service-user', () => {
 	});
 
 	describe('when service user is valid', () => {
-		const sqlDateTime = new Date(mockEnqueueDateTime).toISOString().slice(0, 19).replace('T', ' ');
 		it('runs query to match upsert RepresentationContact', async () => {
 			await sendMessage(mockContext, mockRepresentationContactMessage);
-			const expectedStatement = `MERGE INTO [serviceUser] AS Target
-			USING (SELECT @P1, @P2, @P3, @P4, @P5, @P6, @P7) AS Source ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [modifiedAt])
-			ON Target.[serviceUserId] = Source.[serviceUserId]
-			WHEN MATCHED 
-			AND '${sqlDateTime}' >= DATEADD(MINUTE, -1, Target.[modifiedAt])
-			THEN UPDATE SET Target.[firstName] = Source.[firstName], Target.[lastName] = Source.[lastName], Target.[organisationName] = Source.[organisationName], Target.[caseReference] = Source.[caseReference], Target.[serviceUserType] = Source.[serviceUserType], Target.[modifiedAt] = Source.[modifiedAt]
-			WHEN NOT MATCHED THEN INSERT ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [modifiedAt]) VALUES (@P1, @P2, @P3, @P4, @P5, @P6, @P7);`;
+			const [receivedStatement, ...receivedParameters] = mockExecuteRawUnsafe.mock.calls[0];
+			const statements = receivedStatement.split('\n');
+			expect(statements[0].trim()).toBe('MERGE INTO [serviceUser] AS Target');
+			expect(statements[1].trim()).toBe(
+				'USING (SELECT @P1, @P2, @P3, @P4, @P5, @P6, @P7) AS Source ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [modifiedAt])'
+			);
+			expect(statements[2].trim()).toBe('ON Target.[serviceUserId] = Source.[serviceUserId]');
+			expect(statements[3].trim()).toBe('WHEN MATCHED');
+			expect(statements[4].trim()).toBe(
+				`AND '2023-01-01 09:00:00' >= DATEADD(MINUTE, -1, Target.[modifiedAt])`
+			);
+			expect(statements[5].trim()).toBe(
+				'THEN UPDATE SET Target.[firstName] = Source.[firstName], Target.[lastName] = Source.[lastName], Target.[organisationName] = Source.[organisationName], Target.[caseReference] = Source.[caseReference], Target.[serviceUserType] = Source.[serviceUserType], Target.[modifiedAt] = Source.[modifiedAt]'
+			);
+			expect(statements[6].trim()).toBe(
+				'WHEN NOT MATCHED THEN INSERT ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [modifiedAt]) VALUES (@P1, @P2, @P3, @P4, @P5, @P6, @P7);'
+			);
 			const expectedParameters = Object.values(mockRepresentationContactServiceUser);
-			expect(mockExecuteRawUnsafe).toHaveBeenCalledWith(expectedStatement, ...expectedParameters);
+			expect(receivedParameters.length).toBe(expectedParameters.length);
+			expect(receivedParameters).toEqual(expect.arrayContaining(expectedParameters));
+			expect(mockContext.log).toHaveBeenCalledWith(
+				`updated serviceUser with serviceUserId ${mockRepresentationContactServiceUser.serviceUserId}`
+			);
 		});
 
-		it('runs query to match upsert Applicant', async () => {
+		it('runs query to match upsert Applicant2', async () => {
 			await sendMessage(mockContext, mockApplicantMessage);
-			const expectedStatement = `MERGE INTO [serviceUser] AS Target
-			USING (SELECT @P1, @P2, @P3, @P4, @P5, @P6, @P7, @P8, @P9, @P10) AS Source ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [email], [webAddress], [phoneNumber], [modifiedAt])
-			ON Target.[serviceUserId] = Source.[serviceUserId]
-			WHEN MATCHED 
-			AND '${sqlDateTime}' >= DATEADD(MINUTE, -1, Target.[modifiedAt])
-			THEN UPDATE SET Target.[firstName] = Source.[firstName], Target.[lastName] = Source.[lastName], Target.[organisationName] = Source.[organisationName], Target.[caseReference] = Source.[caseReference], Target.[serviceUserType] = Source.[serviceUserType], Target.[email] = Source.[email], Target.[webAddress] = Source.[webAddress], Target.[phoneNumber] = Source.[phoneNumber], Target.[modifiedAt] = Source.[modifiedAt]
-			WHEN NOT MATCHED THEN INSERT ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [email], [webAddress], [phoneNumber], [modifiedAt]) VALUES (@P1, @P2, @P3, @P4, @P5, @P6, @P7, @P8, @P9, @P10);`;
+
+			const [receivedStatement, ...receivedParameters] = mockExecuteRawUnsafe.mock.calls[0];
+			const statements = receivedStatement.split('\n');
+			expect(statements[0].trim()).toBe('MERGE INTO [serviceUser] AS Target');
+			expect(statements[1].trim()).toBe(
+				'USING (SELECT @P1, @P2, @P3, @P4, @P5, @P6, @P7, @P8, @P9, @P10) AS Source ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [email], [webAddress], [phoneNumber], [modifiedAt])'
+			);
+			expect(statements[2].trim()).toBe('ON Target.[serviceUserId] = Source.[serviceUserId]');
+			expect(statements[3].trim()).toBe('WHEN MATCHED');
+			expect(statements[4].trim()).toBe(
+				`AND '2023-01-01 09:00:00' >= DATEADD(MINUTE, -1, Target.[modifiedAt])`
+			);
+			expect(statements[5].trim()).toBe(
+				'THEN UPDATE SET Target.[firstName] = Source.[firstName], Target.[lastName] = Source.[lastName], Target.[organisationName] = Source.[organisationName], Target.[caseReference] = Source.[caseReference], Target.[serviceUserType] = Source.[serviceUserType], Target.[email] = Source.[email], Target.[webAddress] = Source.[webAddress], Target.[phoneNumber] = Source.[phoneNumber], Target.[modifiedAt] = Source.[modifiedAt]'
+			);
+			expect(statements[6].trim()).toBe(
+				'WHEN NOT MATCHED THEN INSERT ([serviceUserId], [firstName], [lastName], [organisationName], [caseReference], [serviceUserType], [email], [webAddress], [phoneNumber], [modifiedAt]) VALUES (@P1, @P2, @P3, @P4, @P5, @P6, @P7, @P8, @P9, @P10);'
+			);
 			const expectedParameters = Object.values(mockApplicantServiceUser);
-			expect(mockExecuteRawUnsafe).toHaveBeenCalledWith(expectedStatement, ...expectedParameters);
+			expect(receivedParameters.length).toBe(expectedParameters.length);
+			expect(receivedParameters).toEqual(expect.arrayContaining(expectedParameters));
 			expect(mockContext.log).toHaveBeenCalledWith(
 				`updated serviceUser with serviceUserId ${mockApplicantServiceUser.serviceUserId}`
 			);

--- a/packages/back-office-subscribers/nsip-service-user/index.js
+++ b/packages/back-office-subscribers/nsip-service-user/index.js
@@ -6,8 +6,7 @@ module.exports = async (context, message) => {
 	const serviceUserId = message.id;
 
 	if (!serviceUserId) {
-		context.log(`skipping update as serviceUserId is missing`);
-		return;
+		throw new Error(`serviceUserId is required`);
 	}
 
 	const serviceUser = mapMessageToServiceUser(message);


### PR DESCRIPTION
## Describe your changes

https://pins-ds.atlassian.net/browse/ASB-2388

Update function to follow existing pattern of throwing exception on missing id.
Merge query was already being used, however tests had to be re-written to follow pattern in order to pass.

## Useful information to review or test

The only change is the check for missing Id which throws an exception.
Unit test had to be updated.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [n/a] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
