### PR TITLE
fix(web): correctly open timetable based on two name versions of procedural deadline event type

### DIFF
--- a/packages/forms-web-app/src/utils/timetables/check-timetable-state.js
+++ b/packages/forms-web-app/src/utils/timetables/check-timetable-state.js
@@ -5,15 +5,23 @@ const {
 	isNullSQLDate
 } = require('../date-utils');
 
-//event list triggering open timetable
-const openTimetableEventList = ['deadline', 'procedural deadline'].map((event) =>
-	event.toLowerCase()
-);
+const eventTypeTriggers = {
+	deadline: 'deadline',
+	proceduralDeadline: 'procedural deadline'
+};
+
+const isEventOfTypeDeadline = (event) => event === eventTypeTriggers.deadline;
+
+const isEventOfTypeProceduralDeadline = (event) =>
+	event.includes(eventTypeTriggers.proceduralDeadline);
 
 const isTimetableTypeOfEventActionable = (typeOfEvent) => {
 	const typeOfEventLowerCase = typeOfEvent?.toLowerCase();
 
-	return openTimetableEventList.includes(typeOfEventLowerCase);
+	return (
+		isEventOfTypeDeadline(typeOfEventLowerCase) ||
+		isEventOfTypeProceduralDeadline(typeOfEventLowerCase)
+	);
 };
 
 const isTimetableDateOfEventPast = (dateOfEvent) => setTimeToEndOfDay(dateOfEvent) < getDateNow();

--- a/packages/forms-web-app/src/utils/timetables/check-timetable-state.unit.test.js
+++ b/packages/forms-web-app/src/utils/timetables/check-timetable-state.unit.test.js
@@ -85,8 +85,16 @@ describe('utils/check-timetable-state', () => {
 					expect(result).toEqual(true);
 				});
 			});
-			describe('and the type of event is "procedural deadline"', () => {
+			describe('and the type of event is "procedural deadline" [source: NI]', () => {
 				mockTypeOfEvent = 'Procedural DEADLINE';
+				const result = isTimetableTypeOfEventActionable(mockTypeOfEvent);
+				it('should return true', () => {
+					expect(result).toEqual(true);
+				});
+			});
+
+			describe('and the type of event is "procedural deadline (pre-examination)" [source: BO]', () => {
+				mockTypeOfEvent = 'Procedural DEADLINE (pre-examination)';
 				const result = isTimetableTypeOfEventActionable(mockTypeOfEvent);
 				it('should return true', () => {
 					expect(result).toEqual(true);


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/ASB-2359

Fix to the above ticket. When first introducing the `procedural deadline` event type, it was not considering the fact that BO version of the event is called `procedural deadline (pre-examination)` and only opened NI cases where the event type is just `procedural deadline`
<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
