### PR TITLE
fix: fall back to English document fields if Welsh aren't available

### DIFF
--- a/packages/forms-web-app/src/pages/projects/_utils/get-application-data.js
+++ b/packages/forms-web-app/src/pages/projects/_utils/get-application-data.js
@@ -19,8 +19,16 @@ const getApplicationData = async (case_ref, lang = 'en') => {
 
 	const DateOfDCOSubmission = badDateToNull(data.DateOfDCOSubmission);
 
+	const projectName = (() => {
+		if (data.ProjectNameWelsh && isLangWelsh(lang)) {
+			return data.ProjectNameWelsh;
+		}
+
+		return data.ProjectName;
+	})();
+
 	return {
-		projectName: isLangWelsh(lang) ? data.ProjectNameWelsh : data.ProjectName,
+		projectName,
 		promoterName: data.PromoterName,
 		caseRef: data.CaseReference,
 		proposal: data.Proposal,

--- a/packages/forms-web-app/src/views/components/section/results.njk
+++ b/packages/forms-web-app/src/views/components/section/results.njk
@@ -19,7 +19,7 @@
         >
           <strong>
             {{ getFileName(
-              result.description_welsh if langIsWelsh else result.description,
+              result.description_welsh if langIsWelsh and result.description_welsh else result.description,
               result.personal_name,
               result.path
             ) }}
@@ -61,7 +61,7 @@
 
           <div class="section-results__result-meta-data-item">
             <span class="section-results__result-meta-data-item-text" data-cy="published-title">
-              {{ result.filter_1_welsh if langIsWelsh else result.filter_1 }}
+              {{ result.filter_1_welsh if langIsWelsh and result.filter_1_welsh else result.filter_1 }}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Describe your changes

[APPLICS-193](https://pins-ds.atlassian.net/browse/APPLICS-193)

Fall back to English document fields if Welsh aren't available

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-193]: https://pins-ds.atlassian.net/browse/APPLICS-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ