### PR TITLE
fix: advice organisation name trim whitespace

### DIFF
--- a/packages/forms-web-app/src/pages/projects/section-51/index/_utils/advice-helpers.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/_utils/advice-helpers.js
@@ -8,7 +8,7 @@ const {
 
 const getAdviceName = ({ organisation, firstName, lastName }) => {
 	let name = 'Anonymous';
-	if (organisation) name = organisation;
+	if (organisation?.trim()) name = organisation.trim();
 	else if (firstName && lastName) name = `${firstName} ${lastName}`;
 	return name;
 };


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-444

When organisation name `from` came as ` ` (space), we wouldn't default to `firstName + lastName` or `Anonymous` and display the empty space instead. This change trims the organisation field to ensure if its empty, we default to the name or Anonymous.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
