### PR TITLE
fix: bypass ni sequelize connection on training env

### DIFF
--- a/packages/applications-service-api/__tests__/unit/controllers/representations.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/representations.test.js
@@ -86,6 +86,7 @@ const returnData = {
 };
 
 jest.mock('../../../src/lib/config.js', () => ({
+	...jest.requireActual('../../../src/lib/config.js'),
 	logger: {
 		level: process.env.LOGGER_LEVEL || 'info'
 	}

--- a/packages/applications-service-api/src/models/index.js
+++ b/packages/applications-service-api/src/models/index.js
@@ -1,27 +1,38 @@
 const fs = require('fs');
 const path = require('path');
 const Sequelize = require('sequelize');
-
+const {
+	backOfficeIntegration: { getAllApplications }
+} = require('../lib/config');
 const basename = path.basename(__filename);
 const config = require(`../database/config/config`);
 const db = {};
+const SequelizeMock = require('sequelize-mock');
 
-const sequelize = new Sequelize(config.database, config.username, config.password, config);
+let sequelize;
 
-fs.readdirSync(__dirname)
-	.filter((file) => {
-		return file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js';
-	})
-	.forEach((file) => {
-		const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
-		db[model.name] = model;
+// Training env will only use BO and cannot connect to NI, so we use a mock DB to avoid connection errors
+const shouldMockDB = getAllApplications === 'BO';
+if (shouldMockDB) {
+	console.log('Training environment - using mock DB for NI');
+	sequelize = new SequelizeMock();
+} else {
+	sequelize = new Sequelize(config.database, config.username, config.password, config);
+	fs.readdirSync(__dirname)
+		.filter((file) => {
+			return file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js';
+		})
+		.forEach((file) => {
+			const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+			db[model.name] = model;
+		});
+
+	Object.keys(db).forEach((modelName) => {
+		if (db[modelName].associate) {
+			db[modelName].associate(db);
+		}
 	});
-
-Object.keys(db).forEach((modelName) => {
-	if (db[modelName].associate) {
-		db[modelName].associate(db);
-	}
-});
+}
 
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-479

PR uses a mock sequelize connection if using training environment (determined by BACK_OFFICE_INTEGRATION_GET_APPLICATIONS  feature flag being set as 'BO'), which would bypass the NI connection errors that occurred because training environment cannot access NI. This approach was chosen over a memory DB as it requires no new dependancies or more memory, whilst still ensuring everything is built correctly

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
