### PR TITLE
fix(web): move outage page middleware to be  after i18n init

### DIFF
--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -70,14 +70,15 @@ app.use('/sw.script.js', express.static(path.join(__dirname, 'public/scripts/sw.
 // View Engine
 app.set('view engine', 'njk');
 
-if (config.plannedServiceOutage.showOutagePage) app.use(plannedOutage);
-
 app.use(i18nRedirect);
 
 configureI18n(app);
 
 app.use(flashMessageCleanupMiddleware);
 app.use(flashMessageToNunjucks(nunjucksEnv));
+
+// Outage page blocking access to the site when active
+if (config.plannedServiceOutage.showOutagePage) app.use(plannedOutage);
 
 // Routes
 app.use('/', routes);


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-586

to test, set `ACTIVATE_PLANNED_OUTAGE` to true

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
