### PR TITLE
fix(document.backoffice.repository.js): fix document filters issue for BO cases

### DIFF
--- a/packages/applications-service-api/src/repositories/document.backoffice.repository.js
+++ b/packages/applications-service-api/src/repositories/document.backoffice.repository.js
@@ -9,7 +9,6 @@ const getFilters = (caseReference) => {
 		WHERE caseRef = ${caseReference}
 			AND (stage is not null and stage <> 'draft' and stage <> '0')
 			AND filter1 is not null
-			AND filter1Welsh is not null
 		GROUP BY stage, filter1, filter1Welsh`;
 
 	return prismaClient.$queryRaw(sql);


### PR DESCRIPTION
## Describe your changes

https://pins-ds.atlassian.net/browse/APPLICS-667

Fix for BO cases where the documents page is not showing filters.
This is because the filters where clause has a condition of welsh filter field not being null.
This is going to be null for the non-welsh cases so the condition has been removed


## Useful information to review or test

This has been tested locally and will be validated in dev against projects that are affected by this issue:
BC0110003
BC0110005

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [n/a] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [n/a] I have included unit tests to cover any testable code changes
