### PR TITLE
fix(azure-pipelines-release.yml): add timeout parameter to release jobs

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -27,6 +27,7 @@ extends:
         deploymentJobs:
           - name: Stage API
             condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.apiRelease'], 'true')
+            timeoutInMinutes: 30
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:
@@ -46,6 +47,7 @@ extends:
                 value: $[ stageDependencies.semantic_release.run_semantic_release.outputs['versions.apiVersion'] ]
           - name: Stage Web
             condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.webRelease'], 'true')
+            timeoutInMinutes: 30
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:
@@ -68,6 +70,7 @@ extends:
           - Stage
         deploymentJobs:
           - name: Deploy API
+            timeoutInMinutes: 30
             steps:
               - template: ../steps/azure_web_app_slot_swap.yml
                 parameters:
@@ -87,6 +90,7 @@ extends:
       - name: Semantic Release
         jobs:
           - name: Run Semantic Release
+            timeoutInMinutes: 30
             steps:
               - checkout: self
                 clean: true


### PR DESCRIPTION
## Describe your changes

Fix to release pipeline due to the upgrade to node 20, this has caused release pipeline to fail.
It appears the wrapper template upgrade requires the timeoutInMinutes to be set in version refs/tags/release/3.16.1.

This is going to have to be tested by running it.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
