### PR TITLE
fix: s51 advice welsh bugs

### DIFF
--- a/packages/forms-web-app/src/pages/projects/section-51/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/section-51/_translations/cy.json
@@ -1,4 +1,5 @@
 {
+	"heading": "Cyngor Adran 51",
 	"anonymous": "Dienw",
 	"dateOfMeeting": "Dyddiad y cyfarfod",
 	"dateAdviceGiven": "Y dyddiad y rhoddwyd y cyngor",
@@ -8,5 +9,13 @@
 	"enquiryType": "Math o ymholiad",
 	"from": "Oddiwrth",
 	"viewMeetingWith": "Gweld cyfarfod gyda",
-	"viewAdviceTo": "Gweld cyngor i"
+	"viewAdviceTo": "Gweld cyngor i",
+	"details": {
+		"adviceInDetail": "Cyngor mewn manylder",
+		"backToList": "Yn ôl i'r rhestr",
+		"enquiry": "Ymholiad",
+		"adviceGiven": "Cyngor a roddwyd",
+		"attachments": "Atodiadau",
+		"viewAdvice": "Gweld y cyngor"
+	}
 }

--- a/packages/forms-web-app/src/pages/projects/section-51/_translations/cy.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/_translations/cy.test.js
@@ -3,6 +3,7 @@ const section51Translations__CY = require('./cy.json');
 describe('pages/projects/section-51/_translations/cy', () => {
 	it('should return the welsh projects translations', () => {
 		expect(section51Translations__CY).toEqual({
+			heading: 'Cyngor Adran 51',
 			adviceTo: 'Cyngor i',
 			anonymous: 'Dienw',
 			dateAdviceGiven: 'Y dyddiad y rhoddwyd y cyngor',
@@ -12,7 +13,15 @@ describe('pages/projects/section-51/_translations/cy', () => {
 			from: 'Oddiwrth',
 			meetingWith: 'Cyfarfod gyda',
 			viewAdviceTo: 'Gweld cyngor i',
-			viewMeetingWith: 'Gweld cyfarfod gyda'
+			viewMeetingWith: 'Gweld cyfarfod gyda',
+			details: {
+				adviceInDetail: 'Cyngor mewn manylder',
+				backToList: "Yn ôl i'r rhestr",
+				enquiry: 'Ymholiad',
+				adviceGiven: 'Cyngor a roddwyd',
+				attachments: 'Atodiadau',
+				viewAdvice: 'Gweld y cyngor'
+			}
 		});
 	});
 });

--- a/packages/forms-web-app/src/pages/projects/section-51/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/section-51/_translations/en.json
@@ -1,4 +1,5 @@
 {
+	"heading": "Section 51 advice",
 	"anonymous": "Anonymous",
 	"dateOfMeeting": "Date of meeting",
 	"dateAdviceGiven": "Date advice given",
@@ -8,5 +9,13 @@
 	"enquiryType": "Enquiry type",
 	"from": "From",
 	"viewMeetingWith": "View meeting with",
-	"viewAdviceTo": "View advice to"
+	"viewAdviceTo": "View advice to",
+	"details": {
+		"adviceInDetail": "Advice in detail",
+		"backToList": "Back to list",
+		"enquiry": "Enquiry",
+		"adviceGiven": "Advice given",
+		"attachments": "Attachments",
+		"viewAdvice": "View advice"
+	}
 }

--- a/packages/forms-web-app/src/pages/projects/section-51/_translations/en.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/_translations/en.test.js
@@ -3,6 +3,7 @@ const section51Translations__EN = require('./en.json');
 describe('pages/projects/section-51/_translations/en', () => {
 	it('should return the english projects translations', () => {
 		expect(section51Translations__EN).toEqual({
+			heading: 'Section 51 advice',
 			adviceTo: 'Advice to',
 			anonymous: 'Anonymous',
 			dateAdviceGiven: 'Date advice given',
@@ -12,7 +13,15 @@ describe('pages/projects/section-51/_translations/en', () => {
 			from: 'From',
 			meetingWith: 'Meeting with',
 			viewAdviceTo: 'View advice to',
-			viewMeetingWith: 'View meeting with'
+			viewMeetingWith: 'View meeting with',
+			details: {
+				adviceInDetail: 'Advice in detail',
+				backToList: 'Back to list',
+				enquiry: 'Enquiry',
+				adviceGiven: 'Advice given',
+				attachments: 'Attachments',
+				viewAdvice: 'View advice'
+			}
 		});
 	});
 });

--- a/packages/forms-web-app/src/pages/projects/section-51/_translations/translations.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/_translations/translations.test.js
@@ -2,6 +2,7 @@ const enTranslation = require('./en.json');
 const cyTranslation = require('./cy.json');
 
 const expectedTranslationKeys = [
+	'heading',
 	'anonymous',
 	'dateOfMeeting',
 	'dateAdviceGiven',
@@ -11,7 +12,8 @@ const expectedTranslationKeys = [
 	'enquiryType',
 	'from',
 	'viewMeetingWith',
-	'viewAdviceTo'
+	'viewAdviceTo',
+	'details'
 ].sort();
 
 describe('pages/projects/section-51/_translations', () => {

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_includes/page.njk
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_includes/page.njk
@@ -4,12 +4,12 @@
 {{ govukBackLink({
   classes: 'govuk-!-margin-top-0',
   href: backToListUrl,
-  text: 'Back to list'
+  text: t('section51.details.backToList')
 }) }}
 
 {% if enquirySummaryList or enquiryText %}
   <h2 class="govuk-heading-m">
-    Enquiry
+    {{ t('section51.details.enquiry') }}
   </h2>
 
   {% if enquirySummaryList %}
@@ -27,7 +27,7 @@
 
 {% if adviceGiven %}
   <h2 class="govuk-heading-m">
-    Advice given
+   {{ t('section51.details.adviceGiven') }}
   </h2>
 
   <div class="pins-rte">
@@ -37,7 +37,7 @@
 
 {% if attachments.length %}
   <h2 class="govuk-heading-m">
-    Attachments
+    {{ t('section51.details.attachments') }}
   </h2>
 
   {% for attachment in attachments %}

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-attachments.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-attachments.js
@@ -1,8 +1,8 @@
 const fileTypeDisplayHelper = require('../../../../../lib/file-type-display-helper');
 
-const getAttachments = (attachments) =>
+const getAttachments = (attachments, i18n) =>
 	attachments.map((attachment) => ({
-		text: `View advice (${fileTypeDisplayHelper(attachment.mime)})`,
+		text: `${i18n.t('section51.details.viewAdvice')} (${fileTypeDisplayHelper(attachment.mime)})`,
 		url: attachment.documentURI
 	}));
 

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items.js
@@ -3,12 +3,15 @@ const {
 	isRegisterOfAdviceDetailURL
 } = require('../../../../register-of-advice/detail/_utils/is-register-of-advice-detail-url');
 
-const getBreadcrumbsItems = (path, caseRef, id) =>
+const getBreadcrumbsItems = (path, caseRef, id, i18n) =>
 	isRegisterOfAdviceDetailURL(path, id)
 		? null
 		: [
-				{ href: getSection51IndexURL(caseRef), text: 'Section 51 advice' },
-				{ text: 'Advice in detail' }
+				{
+					href: getSection51IndexURL(caseRef),
+					text: i18n.t('section51.heading')
+				},
+				{ text: i18n.t('section51.details.adviceInDetail') }
 		  ];
 
 module.exports = { getBreadcrumbsItems };

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items.test.js
@@ -1,5 +1,5 @@
 const { getBreadcrumbsItems } = require('./get-breadcrumbs-items');
-
+const { mockI18n } = require('../../../../_mocks/i18n');
 describe('pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items', () => {
 	describe('#getBreadcrumbsItems', () => {
 		describe('When getting the breadcrumbs items', () => {
@@ -11,7 +11,7 @@ describe('pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items',
 				const id = 'mock-id';
 
 				beforeEach(() => {
-					breadcrumbsItems = getBreadcrumbsItems(path, caseRef, id);
+					breadcrumbsItems = getBreadcrumbsItems(path, caseRef, id, mockI18n({}));
 				});
 				it('should return null', () => {
 					expect(breadcrumbsItems).toEqual(null);
@@ -26,7 +26,19 @@ describe('pages/projects/section-51/advice-detail/_utils/get-breadcrumbs-items',
 				const id = 'mock-id';
 
 				beforeEach(() => {
-					breadcrumbsItems = getBreadcrumbsItems(path, caseRef, id);
+					breadcrumbsItems = getBreadcrumbsItems(
+						path,
+						caseRef,
+						id,
+						mockI18n({
+							section51: {
+								heading: 'Section 51 advice',
+								details: {
+									adviceInDetail: 'Advice in detail'
+								}
+							}
+						})
+					);
 				});
 				it('should return the breadcrumbs for the section 51 advice detail page', () => {
 					expect(breadcrumbsItems).toEqual([

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-enquiry-summary-list.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-enquiry-summary-list.js
@@ -14,6 +14,25 @@ const getEnquirySummaryListItemViewModel = (keyText, valueText) => ({
 	}
 });
 
+const getEnquiryTypeText = {
+	phone: {
+		en: 'phone',
+		cy: 'ffôn'
+	},
+	email: {
+		en: 'email',
+		cy: 'e-bost'
+	},
+	post: {
+		en: 'post',
+		cy: 'post'
+	},
+	meeting: {
+		en: 'meeting',
+		cy: 'cyfarfod'
+	}
+};
+
 const getEnquirySummaryList = (pageData, i18n) => [
 	getEnquirySummaryListItemViewModel(
 		getAdviceEnquiryText(pageData.enquiryMethod, i18n),
@@ -21,9 +40,14 @@ const getEnquirySummaryList = (pageData, i18n) => [
 	),
 	getEnquirySummaryListItemViewModel(
 		getAdviceDateText(pageData.enquiryMethod, i18n),
-		formatDate(pageData.dateAdviceGiven)
+		formatDate(pageData.dateAdviceGiven, i18n.language)
 	),
-	getEnquirySummaryListItemViewModel(i18n.t('section51.enquiryType'), pageData.enquiryMethod)
+	getEnquirySummaryListItemViewModel(
+		i18n.t('section51.enquiryType'),
+		getEnquiryTypeText[pageData.enquiryMethod]
+			? getEnquiryTypeText[pageData.enquiryMethod?.toLowerCase()][i18n.language]
+			: pageData.enquiryMethod
+	)
 ];
 
 module.exports = { getEnquirySummaryList };

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-page-view-model.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/_utils/get-page-view-model.js
@@ -11,13 +11,17 @@ const parseText = (text) => (text ? marked.parse(text).trim() : '');
 
 const handleAdviceDetails = (adviceDetails, i18n) => {
 	const langIsWelsh = isLangWelsh(i18n.language);
-	const adviceGiven = langIsWelsh ? adviceDetails.adviceGivenWelsh : adviceDetails.adviceGiven;
-	const enquiryDetail = langIsWelsh
-		? adviceDetails.enquiryDetailWelsh
-		: adviceDetails.enquiryDetail;
+	const adviceGiven =
+		langIsWelsh && adviceDetails.adviceGivenWelsh
+			? adviceDetails.adviceGivenWelsh
+			: adviceDetails.adviceGiven;
+	const enquiryDetail =
+		langIsWelsh && adviceDetails.enquiryDetailWelsh
+			? adviceDetails.enquiryDetailWelsh
+			: adviceDetails.enquiryDetail;
 	return {
 		adviceGiven: parseText(adviceGiven),
-		attachments: getAttachments(adviceDetails.attachments),
+		attachments: getAttachments(adviceDetails.attachments, i18n),
 		enquirySummaryList: getEnquirySummaryList(adviceDetails, i18n),
 		enquiryText: parseText(enquiryDetail),
 		pageTitle: enquiryDetail,
@@ -28,7 +32,7 @@ const handleAdviceDetails = (adviceDetails, i18n) => {
 const getPageViewModel = async (refURL, path, caseRef, id, adviceDetails, i18n) => ({
 	activeId: 'section-51',
 	backToListUrl: getBackToListURL(refURL, path, caseRef, id),
-	breadcrumbsItems: getBreadcrumbsItems(path, caseRef, id),
+	breadcrumbsItems: getBreadcrumbsItems(path, caseRef, id, i18n),
 	...handleAdviceDetails(adviceDetails, i18n)
 });
 

--- a/packages/forms-web-app/src/pages/projects/section-51/advice-detail/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/advice-detail/controller.test.js
@@ -103,8 +103,8 @@ describe('pages/projects/section-51/advice-detail/controller', () => {
 							activeId: 'section-51',
 							adviceGiven: '<p>mock advice given in Welsh</p>',
 							attachments: [
-								{ text: 'View advice (PDF)', url: 'mock document URI 1' },
-								{ text: 'View advice (Word)', url: 'mock document URI 2' }
+								{ text: 'Gweld y cyngor (PDF)', url: 'mock document URI 1' },
+								{ text: 'Gweld y cyngor (Word)', url: 'mock document URI 2' }
 							],
 							backToListUrl: '/register-of-advice',
 							breadcrumbsItems: null,
@@ -112,7 +112,7 @@ describe('pages/projects/section-51/advice-detail/controller', () => {
 								{ key: { text: 'Oddiwrth' }, value: { text: 'mock organisation' } },
 								{
 									key: { text: 'Y dyddiad y rhoddwyd y cyngor' },
-									value: { text: '1 January 2023' }
+									value: { text: '1 Ionawr 2023' }
 								},
 								{ key: { text: 'Math o ymholiad' }, value: { text: 'Email' } }
 							],

--- a/packages/forms-web-app/src/pages/projects/section-51/index/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/_translations/cy.json
@@ -1,5 +1,4 @@
 {
-	"heading1": "Cyngor Adran 51",
 	"paragraph1": "Mae'r rhestr isod yn cynnwys cofnod o gyngor a roddwyd gennym ar gyfer y prosiect hwn.",
 	"paragraph2": "Mae dyletswydd statudol, o dan {{-link}}, ynglŷn â chais neu ddarpar gais. Mae hyn yn cynnwys cofnodi enw'r unigolyn a ofynnodd am y cyngor a'r cyngor a roddwyd. Mae'n rhaid i'r wybodaeth hon gael ei chyhoeddi.",
 	"paragraph2LinkText1": "adran 51 Deddf Cynllunio 2008",

--- a/packages/forms-web-app/src/pages/projects/section-51/index/_translations/cy.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/_translations/cy.test.js
@@ -3,7 +3,6 @@ const cySection51IndexTranslations = require('./cy.json');
 describe('pages/projects/section-51/index/_translations/cy.json', () => {
 	it('should return the Welsh section 51 index page translations', () => {
 		expect(cySection51IndexTranslations).toEqual({
-			heading1: 'Cyngor Adran 51',
 			paragraph1:
 				"Mae'r rhestr isod yn cynnwys cofnod o gyngor a roddwyd gennym ar gyfer y prosiect hwn.",
 			paragraph2:

--- a/packages/forms-web-app/src/pages/projects/section-51/index/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/_translations/en.json
@@ -1,5 +1,4 @@
 {
-	"heading1": "Section 51 advice",
 	"paragraph1": "The list below includes a record of advice we have provided for this project.",
 	"paragraph2": "There is a statutory duty, under {{-link}}, around an application or potential application. This includes recording the name of the person who requested advice and the advice given. This information has to be made publicly available.",
 	"paragraph2LinkText1": "section 51 of the Planning Act 2008",

--- a/packages/forms-web-app/src/pages/projects/section-51/index/_translations/en.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/_translations/en.test.js
@@ -3,7 +3,6 @@ const enSection51IndexTranslations = require('./en.json');
 describe('pages/projects/section-51/index/_translations/en.json', () => {
 	it('should return the English section 51 index page translations', () => {
 		expect(enSection51IndexTranslations).toEqual({
-			heading1: 'Section 51 advice',
 			paragraph1: 'The list below includes a record of advice we have provided for this project.',
 			paragraph2:
 				'There is a statutory duty, under {{-link}}, around an application or potential application. This includes recording the name of the person who requested advice and the advice given. This information has to be made publicly available.',

--- a/packages/forms-web-app/src/pages/projects/section-51/index/view.njk
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/view.njk
@@ -10,7 +10,7 @@
 {% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
 {% from "projects/section-51/index/_components/results.njk" import sectionResults %}
 
-{% set pageTitle = t('section51Index.heading1') %}
+{% set pageTitle = t('section51.heading') %}
 
 {% block content %}
 	<form>
@@ -27,7 +27,7 @@
 				</span>
 
 				<h1 class="govuk-heading-xl">
-					{{ t('section51Index.heading1') }}
+					{{ t('section51.heading') }}
 				</h1>
 
 				{% if adviceExists or (not adviceExists and searchAttempted) %}

--- a/packages/forms-web-app/src/pages/projects/section-51/index/view.njk
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/view.njk
@@ -72,7 +72,7 @@
 						{{ t('section51Index.phrase4') }}
 					</p>
 
-					{{ uiResultsPerPage(resultsPerPage) }}
+					{{ uiResultsPerPage(resultsPerPage, t('common.resultsPerPage')) }}
 
 					{{ sectionResults(adviceViewModel) }}
 

--- a/packages/forms-web-app/src/pages/projects/section-51/router.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/router.js
@@ -36,6 +36,7 @@ section51Router.get(
 
 section51Router.get(
 	section51AdviceDetailURL,
+	addCommonTranslationsMiddleware,
 	projectsMiddleware,
 	getSection51AdviceDetailController
 );

--- a/packages/forms-web-app/src/pages/projects/section-51/router.test.js
+++ b/packages/forms-web-app/src/pages/projects/section-51/router.test.js
@@ -38,6 +38,7 @@ describe('pages/projects/section-51/router', () => {
 
 			expect(get).toHaveBeenCalledWith(
 				'/projects/:case_ref/s51advice/:id',
+				addCommonTranslationsMiddleware,
 				projectsMiddleware,
 				getSection51AdviceDetailController
 			);


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-686

Fixes the bugs: 
- On the main cy page the date and the results per page are shown in english
- On the cy detail page the breadcrumbs, the H2s, type description and  attachment link description are shown in english
- On the cy detail page the query field and the Advice given heading and content are missing
- On the cy detail page the date is not translated to Welsh

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
