### PR TITLE
Fix/windows common package erroAdded new common volume package to docker-compose to correct build issue on Windows machinesr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - ./node_modules:/opt/app/node_modules
       - ./packages/common:/opt/app/packages/common
       - ./packages/applications-service-api:/opt/app/packages/applications-service-api
+      - ./packages/common:/opt/app/node_modules/@pins/common
       - ./uploads:/opt/app/uploads
     #    command: npm run start:dev:debug --workspace=packages/applications-service-api
     command: npm run start:dev --workspace=packages/applications-service-api
@@ -116,6 +117,7 @@ services:
       - ./node_modules:/opt/app/node_modules
       - ./packages/common:/opt/app/packages/common
       - ./packages/forms-web-app:/opt/app/packages/forms-web-app
+      - ./packages/common:/opt/app/node_modules/@pins/common
       - ./uploads:/opt/app/uploads
     # if enabling debug, be sure to uncomment / expose the debug port below.
     command: npm run start:dev --workspace=packages/forms-web-app


### PR DESCRIPTION
## Added new common volume package to docker-compose to correct build issue on Windows machines

Update to docker-compose.yml to include new file reference

## Useful information to review or test

Prior to this change the application service solution build would fail with a "Cannot find module '@pins/common/src/utils/redis'" error when attempting to do a "npm run dev". Including a reference to the module in docker-compose corrected this error. The fix has been confirmed by myself and Ben Jacobs. There is nothing to test on the front end for this fix. There is no ticket for this issue.

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
