### PR TITLE
Feature/applics 710 welsh translation related guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,19 @@ Or:
 We use the logger [Pino](http://getpino.io), and [express-pino-logger](https://github.com/pinojs/express-pino-logger). Import the logger and use `logger.info`, `logger.error`, etc rather than `console.log` as this will ensure logs are formatted in a way that Azure can collect.
 
 Please see [Confluence](https://pins-ds.atlassian.net/wiki/spaces/AAPDS/pages/edit-v2/554205478) for further information
+
+### Tests
+
+Run unit tests from the /applications-service/packages/forms-web-app folder with:
+
+```shell
+npm run test
+```
+
+If snapshots need to be updated, from the /applications-service/packages/forms-web-app folder run:
+
+```shell
+npm run test:update
+```
+
+

--- a/packages/forms-web-app/src/pages/projects/_components/project-pages-template.njk
+++ b/packages/forms-web-app/src/pages/projects/_components/project-pages-template.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 
 {% if h1Style %}
 

--- a/packages/forms-web-app/src/pages/projects/_components/vertical-tabs-wrapper.njk
+++ b/packages/forms-web-app/src/pages/projects/_components/vertical-tabs-wrapper.njk
@@ -1,6 +1,6 @@
 {% from "components/layout/slots.njk" import layoutSlots %}
 {% from "components/ui/vertical-tabs.njk" import uiVerticalTabs %}
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 {% from "components/ui/checkbox-accordion.njk" import uiCheckboxAccordion %}
 {% from "components/ui/checkboxes.njk" import uiCheckboxes %}
 

--- a/packages/forms-web-app/src/pages/projects/_components/vertical-tabs-wrapper.njk
+++ b/packages/forms-web-app/src/pages/projects/_components/vertical-tabs-wrapper.njk
@@ -4,7 +4,7 @@
 {% from "components/ui/checkbox-accordion.njk" import uiCheckboxAccordion %}
 {% from "components/ui/checkboxes.njk" import uiCheckboxes %}
 
-{% set slots = [uiVerticalTabs(null, activeId, verticalTabs, "Project navigation")] %}
+{% set slots = [uiVerticalTabs(null, activeId, verticalTabs, t('projects.navigation.projectNavigation'))] %}
 
 {% if displayFilters %}
 	{% set slots = (slots.push(uiCheckboxAccordion(

--- a/packages/forms-web-app/src/pages/projects/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/projects/_translations/__snapshots__/translations.test.js.snap
@@ -12,12 +12,12 @@ exports[`pages/projects/_translations should return the correct English translat
     "representations": "Relevant representations (registration comments)",
     "section51": "Section 51 advice",
   },
-	"relatedGuides": {
-		"heading": "Related guides",
-		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs)",
-		"haveYourSay": "Have your say about a national infrastructure project",
-		"navigationLabel": "Related guides navigation"
-	}
+  "relatedGuides": {
+    "haveYourSay": "Have your say about a national infrastructure project",
+    "heading": "Related guides",
+    "navigationLabel": "Related guides navigation",
+    "process": "The process for Nationally Significant Infrastructure Projects (NSIPs)",
+  },
 }
 `;
 
@@ -33,11 +33,11 @@ exports[`pages/projects/_translations should return the correct Welsh translatio
     "representations": "Sylwadau perthnasol (sylwadau cofrestru)",
     "section51": "Cyngor Adran 51",
   },
-	"relatedGuides": {
-		"heading": "Related guides ** Needs welsh translation",
-		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs) ** Needs welsh translation",
-		"haveYourSay": "Have your say about a national infrastructure project ** Needs welsh translation",
-		"navigationLabel": "Related guides navigation ** Needs welsh translation"
-	}
+  "relatedGuides": {
+    "haveYourSay": "Have your say about a national infrastructure project ** Needs welsh translation",
+    "heading": "Related guides ** Needs welsh translation",
+    "navigationLabel": "Related guides navigation ** Needs welsh translation",
+    "process": "The process for Nationally Significant Infrastructure Projects (NSIPs) ** Needs welsh translation",
+  },
 }
 `;

--- a/packages/forms-web-app/src/pages/projects/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/projects/_translations/__snapshots__/translations.test.js.snap
@@ -8,6 +8,7 @@ exports[`pages/projects/_translations should return the correct English translat
     "getUpdates": "Get updates",
     "haveYourSay": "Have your say",
     "index": "Project information",
+    "projectNavigation": "Project navigation",
     "register": "Register to have your say",
     "representations": "Relevant representations (registration comments)",
     "section51": "Section 51 advice",
@@ -29,15 +30,16 @@ exports[`pages/projects/_translations should return the correct Welsh translatio
     "getUpdates": "Cael diweddariadau",
     "haveYourSay": "Dweud eich dweud",
     "index": "Gwybodaeth am y prosiect",
+    "projectNavigation": "Cyfeiri prosiect",
     "register": "Cofrestru i leisio'ch barn",
     "representations": "Sylwadau perthnasol (sylwadau cofrestru)",
     "section51": "Cyngor Adran 51",
   },
   "relatedGuides": {
-    "haveYourSay": "Have your say about a national infrastructure project ** Needs welsh translation",
-    "heading": "Related guides ** Needs welsh translation",
-    "navigationLabel": "Related guides navigation ** Needs welsh translation",
-    "process": "The process for Nationally Significant Infrastructure Projects (NSIPs) ** Needs welsh translation",
+    "haveYourSay": "LLeisio'ch barn am brosiect seilwaith cenedlaethol",
+    "heading": "Canllawiau cysylltiedig",
+    "navigationLabel": "Cyfeiri canllawiau cysylltiedig",
+    "process": "Y broses ar gyfer Prosiectau Seilwaith o Arwyddocâd Cenedlaethol (NSIPau)",
   },
 }
 `;

--- a/packages/forms-web-app/src/pages/projects/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/projects/_translations/__snapshots__/translations.test.js.snap
@@ -12,6 +12,12 @@ exports[`pages/projects/_translations should return the correct English translat
     "representations": "Relevant representations (registration comments)",
     "section51": "Section 51 advice",
   },
+	"relatedGuides": {
+		"heading": "Related guides",
+		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs)",
+		"haveYourSay": "Have your say about a national infrastructure project",
+		"navigationLabel": "Related guides navigation"
+	}
 }
 `;
 
@@ -27,5 +33,11 @@ exports[`pages/projects/_translations should return the correct Welsh translatio
     "representations": "Sylwadau perthnasol (sylwadau cofrestru)",
     "section51": "Cyngor Adran 51",
   },
+	"relatedGuides": {
+		"heading": "Related guides ** Needs welsh translation",
+		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs) ** Needs welsh translation",
+		"haveYourSay": "Have your say about a national infrastructure project ** Needs welsh translation",
+		"navigationLabel": "Related guides navigation ** Needs welsh translation"
+	}
 }
 `;

--- a/packages/forms-web-app/src/pages/projects/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/_translations/cy.json
@@ -8,5 +8,11 @@
 		"haveYourSay": "Dweud eich dweud",
 		"getUpdates": "Cael diweddariadau",
 		"section51": "Cyngor Adran 51"
+	},
+	"relatedGuides": {
+		"heading": "Related guides ** Needs welsh translation",
+		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs) ** Needs welsh translation",
+		"haveYourSay": "Have your say about a national infrastructure project ** Needs welsh translation",
+		"navigationLabel": "Related guides navigation ** Needs welsh translation"
 	}
 }

--- a/packages/forms-web-app/src/pages/projects/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/_translations/cy.json
@@ -7,12 +7,13 @@
 		"examinationTimetable": "Amserlen yr archwiliad",
 		"haveYourSay": "Dweud eich dweud",
 		"getUpdates": "Cael diweddariadau",
-		"section51": "Cyngor Adran 51"
+		"section51": "Cyngor Adran 51",
+		"projectNavigation": "Cyfeiri prosiect"
 	},
 	"relatedGuides": {
-		"heading": "Related guides ** Needs welsh translation",
-		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs) ** Needs welsh translation",
-		"haveYourSay": "Have your say about a national infrastructure project ** Needs welsh translation",
-		"navigationLabel": "Related guides navigation ** Needs welsh translation"
+		"heading": "Canllawiau cysylltiedig",
+		"process": "Y broses ar gyfer Prosiectau Seilwaith o Arwyddocâd Cenedlaethol (NSIPau)",
+		"haveYourSay": "LLeisio'ch barn am brosiect seilwaith cenedlaethol",
+		"navigationLabel": "Cyfeiri canllawiau cysylltiedig"
 	}
 }

--- a/packages/forms-web-app/src/pages/projects/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/_translations/en.json
@@ -7,7 +7,8 @@
 		"examinationTimetable": "Examination timetable",
 		"haveYourSay": "Have your say",
 		"getUpdates": "Get updates",
-		"section51": "Section 51 advice"
+		"section51": "Section 51 advice",
+		"projectNavigation": "Project navigation"
 	},
 	"relatedGuides": {
 		"heading": "Related guides",

--- a/packages/forms-web-app/src/pages/projects/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/_translations/en.json
@@ -8,5 +8,11 @@
 		"haveYourSay": "Have your say",
 		"getUpdates": "Get updates",
 		"section51": "Section 51 advice"
+	},
+	"relatedGuides": {
+		"heading": "Related guides",
+		"process": "The process for Nationally Significant Infrastructure Projects (NSIPs)",
+		"haveYourSay": "Have your say about a national infrastructure project",
+		"navigationLabel": "Related guides navigation"
 	}
 }

--- a/packages/forms-web-app/src/pages/projects/documents/view.njk
+++ b/packages/forms-web-app/src/pages/projects/documents/view.njk
@@ -9,7 +9,7 @@
 {% from "components/ui/tag-link-list.njk" import uiTagLinkList %}
 {% from "components/ui/results-per-page.njk" import uiResultsPerPage %}
 {% from "macros/pagination-bar.njk" import paginationBar %}
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 
 {% set section = 'project-documents' %}
 {% set pageTitle = '' + t('projectsDocuments.heading1') + ' | ' + projectName + '' %}

--- a/packages/forms-web-app/src/pages/projects/get-updates/index/view.njk
+++ b/packages/forms-web-app/src/pages/projects/get-updates/index/view.njk
@@ -1,5 +1,5 @@
 {% extends "layouts/default.njk" %}
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 
 {% set pageTitle = '' + t('getUpdatesIndex.title1') + ' | ' + projectName + '' %}
 

--- a/packages/forms-web-app/src/pages/projects/index/view.njk
+++ b/packages/forms-web-app/src/pages/projects/index/view.njk
@@ -4,7 +4,7 @@
 
 {% from "./_components/latest-update.njk" import getLatestUpdate %}
 {% from "./_components/stage-progress-tag.njk" import stageProgressTag %}
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 
 {% set activeId = "project-information" %}
 

--- a/packages/forms-web-app/src/pages/projects/representations/index/view.njk
+++ b/packages/forms-web-app/src/pages/projects/representations/index/view.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/default.njk" %}
 
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 
 {% set pageTitle = t('representationsIndex.pageTitle1') + " | "  + projectName %}
 

--- a/packages/forms-web-app/src/pages/projects/representations/representation/view.njk
+++ b/packages/forms-web-app/src/pages/projects/representations/representation/view.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 
 {% block content %}
 	<div class="govuk-grid-row">

--- a/packages/forms-web-app/src/pages/projects/section-51/index/view.njk
+++ b/packages/forms-web-app/src/pages/projects/section-51/index/view.njk
@@ -7,7 +7,7 @@
 {% from "components/ui/tag-link-list.njk" import uiTagLinkList %}
 {% from "components/ui/results-per-page.njk" import uiResultsPerPage %}
 {% from "macros/pagination-bar.njk" import paginationBar %}
-{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper %}
+{% from "components/wrappers/related-guides-wrapper.njk" import relatedGuidesWrapper with context %}
 {% from "projects/section-51/index/_components/results.njk" import sectionResults %}
 
 {% set pageTitle = t('section51.heading') %}

--- a/packages/forms-web-app/src/views/components/wrappers/related-guides-wrapper.njk
+++ b/packages/forms-web-app/src/views/components/wrappers/related-guides-wrapper.njk
@@ -3,19 +3,19 @@
 {% macro relatedGuidesWrapper(featureHideLink, styles) %}
 	<div class="{{ styles }}">
 		{{ uiVerticalTabs(
-			"Related guides",
+			t('projects.relatedGuides.heading'),
 			null,
 			[
 				{
-					name: "The process for Nationally Significant Infrastructure Projects (NSIPs)",
+					name: t('projects.relatedGuides.process'),
 					url:"/decision-making-process-guide"
 				},
 				{
-					name: "Have your say about a national infrastructure project",
+					name: t('projects.relatedGuides.haveYourSay'),
 					url:"/having-your-say-guide"
 				}
 			],
-			"Related guides navigation",
+			t('projects.relatedGuides.navigationLabel'),
 			"h2"
 		) }}
 	</div>


### PR DESCRIPTION
## Added translations to related guide section on project pages 

APPLICS-710 - https://pins-ds.atlassian.net/browse/APPLICS-710

Added "with context" to relatedGuidesWrapper imports
Updated English and Welsh translation json files
Referenced the new translated terms in the relatedGuidesWrapper template
Updated tests

## Useful information to review or test

Switching between English and Welsh languages should now display the correct English and Welsh terms in the Related Guides section of project pages. 

Page example - https://national-infrastructure-consenting.planninginspectorate.gov.uk/projects/WW010003

## Type of change 🧩

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes
