### PR TITLE
Fix/applics 831 rejectonnotfound

### DIFF
--- a/packages/back-office-subscribers/nsip-exam-timetable/__tests__/index.test.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable/__tests__/index.test.js
@@ -139,7 +139,6 @@ describe('nsip-exam-timetable', () => {
 			where: {
 				caseReference: mockMessage.caseReference
 			},
-			rejectOnNotFound: false,
 			take: 1
 		});
 	});

--- a/packages/back-office-subscribers/nsip-exam-timetable/index.js
+++ b/packages/back-office-subscribers/nsip-exam-timetable/index.js
@@ -17,7 +17,6 @@ module.exports = async (context, message) => {
 			where: {
 				caseReference
 			},
-			rejectOnNotFound: false,
 			take: 1
 		});
 


### PR DESCRIPTION
## Describe your changes

In Prisma v5, "rejectOnNotFound: false" is no longer supported and results in an error.  My understanding is that "rejectOnNotFound: false", pre v5, is an instruction to the query to return null if no records were found.  This is also the default behaviour if "rejectOnNotFound: false" is omitted.  So the fix to this issue was to simply remove it from the query.

I've tested this locally using the API and Postman and it tested ok.  Data was appearing in the database and I was no longer seeing the error.

[https://pins-ds.atlassian.net/browse/APPLICS-831](https://pins-ds.atlassian.net/browse/APPLICS-831)

## Useful information to review or test

Test instructions can be found in the ticket.

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes
