### PR TITLE
fix: explicitly define mock models for sequelize-mock

### DIFF
--- a/packages/applications-service-api/src/models/index.js
+++ b/packages/applications-service-api/src/models/index.js
@@ -6,18 +6,29 @@ const {
 } = require('../lib/config');
 const basename = path.basename(__filename);
 const config = require(`../database/config/config`);
-const db = {};
 const SequelizeMock = require('sequelize-mock');
 
-let sequelize;
+const modelsToMock = [
+	'Advice',
+	'Document',
+	'InterestedParty',
+	'Project',
+	'Representation',
+	'Submission',
+	'Timetable'
+];
+
+let db = {};
 
 // Training env will only use BO and cannot connect to NI, so we use a mock DB to avoid connection errors
 const shouldMockDB = () => getAllApplications === 'BO';
 if (shouldMockDB()) {
 	console.log('Training environment - using mock DB for NI');
-	sequelize = new SequelizeMock();
+	db = new SequelizeMock();
+
+	modelsToMock.forEach((name) => db.define(name, {}));
 } else {
-	sequelize = new Sequelize(config.database, config.username, config.password, config);
+	const sequelize = new Sequelize(config.database, config.username, config.password, config);
 	fs.readdirSync(__dirname)
 		.filter((file) => {
 			return file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js';
@@ -32,9 +43,10 @@ if (shouldMockDB()) {
 			db[modelName].associate(db);
 		}
 	});
+
+	db.sequelize = sequelize;
 }
 
-db.sequelize = sequelize;
 db.Sequelize = Sequelize;
 
 module.exports = db;


### PR DESCRIPTION
## Describe your changes

[APPLICS-630](https://pins-ds.atlassian.net/browse/APPLICS-630)

Explicitly define mock models for sequelize-mock.

Will need to test this in dev by setting `BACK_OFFICE_INTEGRATION_GET_APPLICATIONS` to "BO".

## Useful information to review or test

This might be enough to fix the error, but a follow-up PR might be needed to include mock data.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-630]: https://pins-ds.atlassian.net/browse/APPLICS-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ