### PR TITLE
fix: assign Sequelize mocks to db object

### DIFF
--- a/packages/applications-service-api/src/models/index.js
+++ b/packages/applications-service-api/src/models/index.js
@@ -21,12 +21,14 @@ const modelsToMock = [
 let db = {};
 
 // Training env will only use BO and cannot connect to NI, so we use a mock DB to avoid connection errors
-const shouldMockDB = () => getAllApplications === 'BO';
-if (shouldMockDB()) {
+if (getAllApplications === 'BO') {
 	console.log('Training environment - using mock DB for NI');
 	db = new SequelizeMock();
 
-	modelsToMock.forEach((name) => db.define(name, {}));
+	modelsToMock.forEach((name) => {
+		const modelMock = db.define(name, {});
+		db[name] = modelMock;
+	});
 } else {
 	const sequelize = new Sequelize(config.database, config.username, config.password, config);
 	fs.readdirSync(__dirname)


### PR DESCRIPTION
## Describe your changes

[APPLICS-630](https://pins-ds.atlassian.net/browse/APPLICS-630)

Assign the generated Sequelize mock to the `db` object.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-630]: https://pins-ds.atlassian.net/browse/APPLICS-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ