### PR TITLE
feat: APPLICS-892 - Examination journey - redirect if examination session is not found

### DIFF
--- a/packages/forms-web-app/src/pages/examination/_middleware/examination.middleware.js
+++ b/packages/forms-web-app/src/pages/examination/_middleware/examination.middleware.js
@@ -1,0 +1,29 @@
+const { buildQueryString } = require('../../_utils/build-query-string');
+const { hasExaminationSession } = require('../_session/examination-session');
+const {
+	routesConfig: {
+		examination: {
+			baseDirectory,
+			pages: { haveYourSay }
+		}
+	}
+} = require('../../../routes/config');
+const { getProjectsURL } = require('../../projects/_utils/get-projects-url');
+
+const examinationMiddleware = (req, res, next) => {
+	const { params, path, query, session } = req;
+	const { case_ref } = params;
+
+	if (path.replace('/', '') === haveYourSay.route) return next();
+	else if (!hasExaminationSession(session)) {
+		const projectsURL = getProjectsURL(case_ref);
+		const url = `${projectsURL}/${baseDirectory}/${haveYourSay.route}`;
+		const queryString = Object.keys(query).length ? buildQueryString(query) : '';
+
+		return res.redirect(`${url}${queryString}`);
+	}
+
+	next();
+};
+
+module.exports = { examinationMiddleware };

--- a/packages/forms-web-app/src/pages/examination/_middleware/examination.middleware.test.js
+++ b/packages/forms-web-app/src/pages/examination/_middleware/examination.middleware.test.js
@@ -2,7 +2,7 @@ const { examinationMiddleware } = require('./examination.middleware');
 
 describe('pages/examination/_middleware/examination.middleware', () => {
 	describe('#examinationMiddleware', () => {
-		describe('When user is viewing the have your say page', () => {
+		describe('When the user is viewing the have your say page', () => {
 			const req = {
 				path: '/have-your-say-during-examination',
 				params: {
@@ -21,28 +21,58 @@ describe('pages/examination/_middleware/examination.middleware', () => {
 			});
 		});
 
-		describe('When user does not have an examination session', () => {
-			const req = {
-				path: '/have-an-interested-party-number',
-				params: {
-					case_ref: 'ABC-123'
-				},
-				query: {},
-				session: {}
-			};
-			const res = {
-				redirect: jest.fn()
-			};
-			const next = jest.fn();
+		describe('When the user does not have an examination session', () => {
+			describe('and there is no query values present', () => {
+				const req = {
+					path: '/have-an-interested-party-number',
+					params: {
+						case_ref: 'ABC-123'
+					},
+					query: {},
+					session: {}
+				};
+				const res = {
+					redirect: jest.fn()
+				};
+				const next = jest.fn();
 
-			beforeEach(() => {
-				examinationMiddleware(req, res, next);
+				beforeEach(() => {
+					examinationMiddleware(req, res, next);
+				});
+
+				it('should redirect to the have your say page', () => {
+					expect(res.redirect).toHaveBeenCalledWith(
+						'/projects/ABC-123/examination/have-your-say-during-examination'
+					);
+				});
 			});
 
-			it('should go to the next middleware', () => {
-				expect(res.redirect).toHaveBeenCalledWith(
-					'/projects/ABC-123/examination/have-your-say-during-examination'
-				);
+			describe('and there are query values present', () => {
+				const req = {
+					path: '/have-an-interested-party-number',
+					params: {
+						case_ref: 'ABC-123'
+					},
+					query: {
+						mockQueryOne: 'mock-value-1',
+						mockQueryTwo: 'mock-value-2'
+					},
+					session: {}
+				};
+				const res = {
+					redirect: jest.fn()
+				};
+				const next = jest.fn();
+
+				beforeEach(() => {
+					examinationMiddleware(req, res, next);
+				});
+
+				it('should redirect to the have your say page and maintain the query string', () => {
+					expect(res.redirect).toHaveBeenCalledWith(
+						'/projects/ABC-123/examination/have-your-say-during-examination?mockQueryOne=mock-value-1&mockQueryTwo=mock-value-2'
+					);
+				});
 			});
 		});
 

--- a/packages/forms-web-app/src/pages/examination/_middleware/examination.middleware.test.js
+++ b/packages/forms-web-app/src/pages/examination/_middleware/examination.middleware.test.js
@@ -1,0 +1,74 @@
+const { examinationMiddleware } = require('./examination.middleware');
+
+describe('pages/examination/_middleware/examination.middleware', () => {
+	describe('#examinationMiddleware', () => {
+		describe('When user is viewing the have your say page', () => {
+			const req = {
+				path: '/have-your-say-during-examination',
+				params: {
+					case_ref: 'ABC-123'
+				}
+			};
+			const res = {};
+			const next = jest.fn();
+
+			beforeEach(() => {
+				examinationMiddleware(req, res, next);
+			});
+
+			it('should go to the next middleware', () => {
+				expect(next).toHaveBeenCalled();
+			});
+		});
+
+		describe('When user does not have an examination session', () => {
+			const req = {
+				path: '/have-an-interested-party-number',
+				params: {
+					case_ref: 'ABC-123'
+				},
+				query: {},
+				session: {}
+			};
+			const res = {
+				redirect: jest.fn()
+			};
+			const next = jest.fn();
+
+			beforeEach(() => {
+				examinationMiddleware(req, res, next);
+			});
+
+			it('should go to the next middleware', () => {
+				expect(res.redirect).toHaveBeenCalledWith(
+					'/projects/ABC-123/examination/have-your-say-during-examination'
+				);
+			});
+		});
+
+		describe('When the user is viewing a examination journey page and does have an examination session', () => {
+			const req = {
+				path: '/have-an-interested-party-number',
+				params: {
+					case_ref: 'ABC-123'
+				},
+				query: {},
+				session: {
+					examination: {}
+				}
+			};
+			const res = {
+				redirect: jest.fn()
+			};
+			const next = jest.fn();
+
+			beforeEach(() => {
+				examinationMiddleware(req, res, next);
+			});
+
+			it('should go to the next middleware', () => {
+				expect(next).toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/src/routes/index.js
+++ b/packages/forms-web-app/src/routes/index.js
@@ -16,6 +16,9 @@ const { haveYourSayGuideRouter } = require('../pages/have-your-say-guide/router'
 const { accessibilityStatementRouter } = require('../pages/accessibility-statement/router');
 
 const { addGlobalMiddleware } = require('../pages/_middleware/add-global-middleware');
+const {
+	examinationMiddleware
+} = require('../pages/examination/_middleware/examination.middleware');
 
 router.use(addGlobalMiddleware);
 
@@ -25,6 +28,7 @@ router.use(accessibilityStatementRouter);
 
 router.use(
 	`/projects/:case_ref/${routesConfig.examination.baseDirectory}`,
+	examinationMiddleware,
 	isProcessingSubmission,
 	examinationRouter
 );


### PR DESCRIPTION
## Describe your changes

- Middleware added to examination journey pages to redirect the user back to the examination start page if no examination session is present.

https://pins-ds.atlassian.net/browse/APPLICS-892?atlOrigin=eyJpIjoiNjM3Y2QxOWJiNWI3NDA5ZjljZWY4NjljYmQxYWIxYTkiLCJwIjoiaiJ9

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
