### PR TITLE
fix: always display English name, summary and location for English cases

### DIFF
--- a/packages/forms-web-app/src/pages/projects/_utils/get-application-data.js
+++ b/packages/forms-web-app/src/pages/projects/_utils/get-application-data.js
@@ -19,22 +19,20 @@ const getApplicationData = async (case_ref, lang = 'en') => {
 
 	const DateOfDCOSubmission = badDateToNull(data.DateOfDCOSubmission);
 
-	const projectName = (() => {
-		if (data.ProjectNameWelsh && isLangWelsh(lang)) {
-			return data.ProjectNameWelsh;
+	const translatedField = (englishField, welshField) => {
+		if (data.Region === 'Wales' && isLangWelsh(lang) && data[welshField]) {
+			return data[welshField];
 		}
 
-		return data.ProjectName;
-	})();
+		return data[englishField];
+	};
 
 	return {
-		projectName,
+		projectName: translatedField('ProjectName', 'ProjectNameWelsh'),
 		promoterName: data.PromoterName,
 		caseRef: data.CaseReference,
 		proposal: data.Proposal,
-		summary: preserveLinebreaks(
-			isLangWelsh(lang) && data.SummaryWelsh ? data.SummaryWelsh : data.Summary
-		),
+		summary: preserveLinebreaks(translatedField('Summary', 'SummaryWelsh')),
 		confirmedDateOfDecision: badDateToNull(data.ConfirmedDateOfDecision),
 		webAddress: data.WebAddress,
 		dateOfNonAcceptance: badDateToNull(data.dateOfNonAcceptance),
@@ -60,10 +58,7 @@ const getApplicationData = async (case_ref, lang = 'en') => {
 		stage5ExtensionToDecisionDeadline: badDateToNull(data.Stage5ExtensiontoDecisionDeadline),
 		longLat: data.LongLat,
 		mapZoomLevel: data.MapZoomLevel,
-		projectLocation:
-			isLangWelsh(lang) && data.ProjectLocationWelsh
-				? data.ProjectLocationWelsh
-				: data.ProjectLocation,
+		projectLocation: translatedField('ProjectLocation', 'ProjectLocationWelsh'),
 		isMaterialChange: data.isMaterialChange
 	};
 };


### PR DESCRIPTION
## Describe your changes

[APPLICS-912](https://pins-ds.atlassian.net.mcas.ms/browse/APPLICS-912)

Always display English name, summary and location for English cases, even when in Welsh mode.

## Useful information to review or test

AC:
Given the user has created an english case in BO 
And the project has been published
When the user navigates to Project page for the case
And select the welsh toggle
Then the project page is visible in welsh
And the project name, description and location appear in English (As there is no Welsh)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-912]: https://pins-ds.atlassian.net/browse/APPLICS-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ