### PR TITLE
fix: replace hard coded name of submission comments pdf with the submission type

### DIFF
--- a/packages/applications-service-api/__tests__/integration/submission.test.js
+++ b/packages/applications-service-api/__tests__/integration/submission.test.js
@@ -108,7 +108,7 @@ describe('/api/v1/submissions', () => {
 			let response;
 
 			describe('submission with written representation', () => {
-				const generatedPDFFileName = `Joe-Bloggs-Written-Representation-${mockSubmissionId}.pdf`;
+				const generatedPDFFileName = `Joe-Bloggs-Comments-on-LIRs-${mockSubmissionId}.pdf`;
 
 				describe('request with submissionId provided', () => {
 					beforeEach(async () => {

--- a/packages/applications-service-api/src/services/submission.service.js
+++ b/packages/applications-service-api/src/services/submission.service.js
@@ -40,7 +40,9 @@ const createBackOfficeSubmission = async (submission) => {
 };
 
 const buildRepresentationFileName = (metadata) =>
-	`${metadata.name.replace(/\s+/g, '-')}-Written-Representation-${metadata.submissionId}.pdf`;
+	`${metadata.name.replace(/\s+/g, '-')}-${metadata.submissionType.replace(/\s+/g, '-')}-${
+		metadata.submissionId
+	}.pdf`;
 
 const completeBackOfficeSubmission = async (submissionDetails) => {
 	const { submissionId, caseReference, email } = submissionDetails;


### PR DESCRIPTION
## Describe your changes

APPLICS-909- https://pins-ds.atlassian.net/browse/APPLICS-909

- Updated naming of a written representation pdf so that the filename includes the submission type.
- Update unit tests to match above

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
