### PR TITLE
Fix/applics 884 representation

### DIFF
--- a/packages/forms-web-app/src/pages/projects/representations/representation/controller.js
+++ b/packages/forms-web-app/src/pages/projects/representations/representation/controller.js
@@ -1,4 +1,5 @@
 const logger = require('../../../../lib/logger');
+const { NotFoundError } = require('../../../../lib/errors');
 const { getRepresentationById } = require('../../../../lib/application-api-wrapper');
 const { getRepresentationsURL } = require('../_utils/get-representations-url');
 const { getRepresentationViewModel } = require('../index/_utils/get-representations-view-model');
@@ -15,7 +16,10 @@ const getRepresentationController = async (req, res, next) => {
 		const { case_ref, id } = params;
 		const { projectName } = res.locals.applicationData;
 
-		const { data: representation } = await getRepresentationById(id, case_ref);
+		const { data: representation, resp_code } = await getRepresentationById(id, case_ref);
+		if (resp_code === 404) {
+			throw new NotFoundError(`Representation with ID ${id}`);
+		}
 
 		return res.render(view, {
 			representation: getRepresentationViewModel(representation, i18n.language),

--- a/packages/forms-web-app/src/pages/projects/representations/representation/controller.js
+++ b/packages/forms-web-app/src/pages/projects/representations/representation/controller.js
@@ -1,8 +1,5 @@
 const logger = require('../../../../lib/logger');
-const {
-	getProjectData,
-	getRepresentationById
-} = require('../../../../lib/application-api-wrapper');
+const { getRepresentationById } = require('../../../../lib/application-api-wrapper');
 const { getRepresentationsURL } = require('../_utils/get-representations-url');
 const { getRepresentationViewModel } = require('../index/_utils/get-representations-view-model');
 const {
@@ -16,17 +13,14 @@ const getRepresentationController = async (req, res, next) => {
 	try {
 		const { params, i18n } = req;
 		const { case_ref, id } = params;
-
-		const { data: applicationData } = await getProjectData(case_ref);
-		const { ProjectName, ProjectNameWelsh } = applicationData;
+		const { projectName } = res.locals.applicationData;
 
 		const { data: representation } = await getRepresentationById(id, case_ref);
 
 		return res.render(view, {
 			representation: getRepresentationViewModel(representation, i18n.language),
 			backToListUrl: getRepresentationsURL(case_ref),
-			projectName: ProjectName,
-			projectNameWelsh: ProjectNameWelsh,
+			projectName,
 			allowProjectInformation,
 			langIsWelsh: isLangWelsh(i18n.language)
 		});

--- a/packages/forms-web-app/src/pages/projects/representations/representation/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects/representations/representation/controller.test.js
@@ -1,9 +1,6 @@
 const { getRepresentationController } = require('./controller');
 
-const {
-	getProjectData,
-	getRepresentationById
-} = require('../../../../lib/application-api-wrapper');
+const { getRepresentationById } = require('../../../../lib/application-api-wrapper');
 
 jest.mock('../../../../lib/application-api-wrapper');
 
@@ -29,7 +26,7 @@ describe('pages/projects/representations/representation/controller', () => {
 		res = {
 			locals: {
 				applicationData: {
-					projectName: 'mock project name'
+					projectName: 'ABC'
 				}
 			},
 			render: jest.fn()
@@ -73,12 +70,6 @@ describe('pages/projects/representations/representation/controller', () => {
 		describe('When getting the representation page', () => {
 			describe('and there are no issues', () => {
 				beforeEach(async () => {
-					getProjectData.mockImplementation((applicationCaseRef) =>
-						Promise.resolve({
-							resp_code: 200,
-							data: { CaseReference: applicationCaseRef, ProjectName: 'ABC' }
-						})
-					);
 					getRepresentationById.mockImplementation(() =>
 						Promise.resolve({
 							data: { ...representations[0] }
@@ -94,7 +85,6 @@ describe('pages/projects/representations/representation/controller', () => {
 							allowProjectInformation: true,
 							backToListUrl: '/projects/EN010009/representations',
 							projectName: 'ABC',
-							projectNameWelsh: undefined,
 							representation: {
 								URL: '/projects/:case_ref/representations/2',
 								attachments: [],

--- a/packages/forms-web-app/src/pages/projects/representations/representation/view.njk
+++ b/packages/forms-web-app/src/pages/projects/representations/representation/view.njk
@@ -29,7 +29,7 @@
 			</a>
 
 			<span class="govuk-caption-l">
-				{{ projectNameWelsh if langIsWelsh and projectNameWelsh else projectName }} 
+        {{ projectName }}
 			</span>
 
 			<h1 class="govuk-heading-l">


### PR DESCRIPTION
## Describe your changes

Ensure a 404 is returned when a requested representation is not found.

[APPLICS-884](https://pins-ds.atlassian.net/browse/APPLICS-884)

* refactor: use applicationData from res.locals instead of fetching again
Toggling between English and Welsh is handled by a middleware earlier in
the stack.
* fix: throw a NotFoundError when a representation is not found
test: update unit tests for representation controller

Tested locally.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[APPLICS-884]: https://pins-ds.atlassian.net/browse/APPLICS-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ