### PR TITLE
Fix/applics 907 regions

### DIFF
--- a/packages/applications-service-api/__tests__/unit/utils/application.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/application.mapper.test.js
@@ -7,7 +7,8 @@ const {
 	mapBackOfficeApplicationToApi,
 	addMapZoomLevelAndLongLat,
 	mapBackOfficeApplicationsToApi,
-	mapNIApplicationsToApi
+	mapNIApplicationsToApi,
+	mergeFilters
 } = require('../../../src/utils/application.mapper');
 const {
 	APPLICATIONS_NI_FILTER_COLUMNS,
@@ -598,6 +599,77 @@ describe('application.mapper', () => {
 					]);
 				}
 			);
+		});
+	});
+	describe('mergeFilters', () => {
+		it('Should accept two lists of filters with non-overlapping names and simply concatenate them', () => {
+			const aFilters = [
+				{
+					name: 'name-a',
+					value: 'value',
+					label: 'Label',
+					count: 1,
+					label_cy: 'Label Cy'
+				}
+			];
+
+			const bFilters = [
+				{
+					name: 'name-b',
+					value: 'value',
+					label: 'Label',
+					count: 1,
+					label_cy: 'Label Cy'
+				}
+			];
+
+			expect(mergeFilters(aFilters, bFilters)).toEqual([...aFilters, ...bFilters]);
+		});
+
+		it('Should accept two lists of filters with non-overlapping values and simply concatenate them', () => {
+			const aFilters = [
+				{
+					name: 'name',
+					value: 'value-a',
+					label: 'Label',
+					count: 1,
+					label_cy: 'Label Cy'
+				}
+			];
+
+			const bFilters = [
+				{
+					name: 'name',
+					value: 'value-b',
+					label: 'Label',
+					count: 1,
+					label_cy: 'Label Cy'
+				}
+			];
+
+			expect(mergeFilters(aFilters, bFilters)).toEqual([...aFilters, ...bFilters]);
+		});
+
+		it('Should combine the counts of any items with matching name AND value', () => {
+			const filters = [
+				{
+					name: 'region',
+					value: 'wales',
+					label: 'Wales',
+					count: 1,
+					label_cy: 'Cymru'
+				}
+			];
+
+			expect(mergeFilters(filters, filters)).toEqual([
+				{
+					name: 'region',
+					value: 'wales',
+					label: 'Wales',
+					count: 2,
+					label_cy: 'Cymru'
+				}
+			]);
 		});
 	});
 });

--- a/packages/applications-service-api/src/utils/application.mapper.js
+++ b/packages/applications-service-api/src/utils/application.mapper.js
@@ -151,6 +151,32 @@ const buildApplicationsFiltersFromBOApplications = (applications) => {
 };
 
 /**
+ * Takes two lists of Applications API filters and merges them,
+ * combining counts when duplicates are encountered.
+ *
+ * @typedef {{name: string, value: string, count: number}} MergeFiltersItem
+ *
+ * @param {MergeFiltersItem[]} filtersA
+ * @param {MergeFiltersItem[]} filtersB
+ * @returns {MergeFiltersItem[]}
+ * */
+const mergeFilters = (filtersA, filtersB) => {
+	let merged = structuredClone(filtersA);
+
+	for (const f of filtersB) {
+		const idx = merged.findIndex((e) => e.name === f.name && e.value === f.value);
+		if (idx === -1) {
+			merged.push(f);
+			continue;
+		}
+
+		merged[idx].count += f.count;
+	}
+
+	return merged;
+};
+
+/**
  * Map API filters back to values for querying against NI database
  * @param {{ stage?: string[], region?: string[], sector?: string[] }} query
  * @returns {{ stage?: string[], region?: string[], sector?: string[] }}
@@ -421,5 +447,6 @@ module.exports = {
 	buildApplicationsFiltersFromBOApplications,
 	mapNIApplicationsToApi,
 	mapColumnLabelToApi: mapColumnLabelToApiEn,
-	mapColumnLabelToApiCy
+	mapColumnLabelToApiCy,
+	mergeFilters
 };

--- a/packages/applications-service-api/src/utils/application.mapper.js
+++ b/packages/applications-service-api/src/utils/application.mapper.js
@@ -296,10 +296,11 @@ const mapBackOfficeApplicationToApi = (application) => {
  * Map Applications array from Back Office to legacy API format
  * @param applications
  */
-const mapBackOfficeApplicationsToApi = (applications) => {
-	const mappedToApi = applications.map(mapBackOfficeApplicationToApi);
-	return mappedToApi.map(mapResponseBackToNILegacyFormat);
-};
+const mapBackOfficeApplicationsToApi = (applications) =>
+	applications.map((application) => {
+		const mappedToApi = mapBackOfficeApplicationToApi(application);
+		return mapResponseBackToNILegacyFormat(mappedToApi);
+	});
 
 /**
  * Adds MapZoomLevel and LongLat properties to NI Application


### PR DESCRIPTION
## Describe your changes

[APPLICS-907](https://pins-ds.atlassian.net/browse/APPLICS-907)

* refactor: change mapBackOfficeApplicationsToApi to run in one pass
* fix: use BO-specific filter-building function and then merge with NI

## Useful information to review or test

The problem was that we were converting the list of Back Office application results into the NI format and using the `buildApiFiltersFromNIApplications` to build filters for them. This doesn't work because while `buildApiFiltersFromNIApplications` checks for the case where the `Region` property is an array, we have actually turned it into a comma-separated string.

There is another `buildApplicationsFiltersFromBOApplications` function that we should be using to construct filters for the BO results. This means we end up with two lists of filters, one for NI and one for BO. The new `mergeFilters` function combines these into a single list.

Tested working locally, added unit tests.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[APPLICS-907]: https://pins-ds.atlassian.net/browse/APPLICS-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ