### PR TITLE
fix: add English update data if Welsh update data missing

### DIFF
--- a/packages/forms-web-app/src/pages/projects/_utils/format-project-update.js
+++ b/packages/forms-web-app/src/pages/projects/_utils/format-project-update.js
@@ -3,7 +3,7 @@ const { isLangWelsh } = require('../../_utils/is-lang-welsh');
 
 const formatProjectUpdate = (projectUpdate, lang = 'en') => ({
 	content: isLangWelsh(lang)
-		? projectUpdate.updateContentWelsh
+		? projectUpdate.updateContentWelsh || projectUpdate.updateContentEnglish
 		: projectUpdate.updateContentEnglish,
 	date: formatDate(projectUpdate.updateDate, lang)
 });

--- a/packages/forms-web-app/src/pages/projects/_utils/format-project.update.test.js
+++ b/packages/forms-web-app/src/pages/projects/_utils/format-project.update.test.js
@@ -1,0 +1,45 @@
+const { formatProjectUpdate } = require('./format-project-update');
+
+describe('pages/projects/_utils/format-project-update', () => {
+	it('returns English update content and date if language is English (default)', () => {
+		const projectUpdate = {
+			updateContentEnglish: 'some content in English',
+			updateContentWelsh: 'some content in Welsh',
+			updateDate: '2023-08-04'
+		};
+
+		const expectedOutput = {
+			content: 'some content in English',
+			date: '4 August 2023'
+		};
+
+		expect(formatProjectUpdate(projectUpdate)).toEqual(expectedOutput);
+	}),
+		it('returns Welsh update data and date if language is Welsh and Welsh update content exists', () => {
+			const projectUpdate = {
+				updateContentEnglish: 'some content in English',
+				updateContentWelsh: 'some content in Welsh',
+				updateDate: '2024-09-05'
+			};
+
+			const expectedOutput = {
+				content: 'some content in Welsh',
+				date: '5 Medi 2024'
+			};
+
+			expect(formatProjectUpdate(projectUpdate, 'cy')).toEqual(expectedOutput);
+		}),
+		it('returns English update data and Welsh date when language is Welsh and Welsh update content does not exist', () => {
+			const projectUpdate = {
+				updateContentEnglish: 'some content in English',
+				updateDate: '2024-03-23'
+			};
+
+			const expectedOutput = {
+				content: 'some content in English',
+				date: '23 Mawrth 2024'
+			};
+
+			expect(formatProjectUpdate(projectUpdate, 'cy')).toEqual(expectedOutput);
+		});
+});


### PR DESCRIPTION
## Describe your changes

* display English project update content is language is Welsh and Welsh project update content is missing

https://pins-ds.atlassian.net.mcas.ms/jira/software/c/projects/APPLICS/boards/242?selectedIssue=APPLICS-1013

<!--
    Issue ticket number and link
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
