### PR TITLE
fix: bo migrated cases document display names

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/get-file-name-from-url.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/get-file-name-from-url.test.js
@@ -11,7 +11,6 @@ describe('forms-web-app/src/lib/get-file-name-from-url.js', () => {
 		});
 		it('should return null if function fails to extract file name', () => {
 			expect(getFileNameFromDocumentUrl('')).toEqual(null);
-			expect(getFileNameFromDocumentUrl('https://www.google.com/no-file')).toEqual(null);
 			expect(
 				getFileNameFromDocumentUrl(
 					'https://nitestaz.planninginspectorate.gov.uk/wp-content/ipc/uploads/wrong_file_name_format.doc'
@@ -35,5 +34,22 @@ describe('forms-web-app/src/lib/get-file-name-from-url.js', () => {
 				)
 			).toEqual('Acceptance of Application');
 		});
+		it('should return correctly when there is no format suffix (Back Office / Migrated cases URIs)', () => {
+			expect(
+				getFileNameFromDocumentUrl(
+					'https://back-office-applications-docs-test.planninginspectorate.gov.uk/published-documents/TR010012-000032-Scoping Opinion'
+				)
+			).toEqual('Scoping Opinion');
+		});
+		expect(
+			getFileNameFromDocumentUrl(
+				'https://back-office-applications-docs-test.planninginspectorate.gov.uk/published-documents/TR010012-000003-130619_TR010012_Letter to relevant stakeholders re consultation'
+			)
+		).toEqual('130619 TR010012 Letter to relevant stakeholders re consultation');
+		expect(
+			getFileNameFromDocumentUrl(
+				'https://back-office-applications-docs-test.planninginspectorate.gov.uk/published-documents/TR010012-000036-Elmbridge Transport Scheme Scoping Report'
+			)
+		).toEqual('Elmbridge Transport Scheme Scoping Report');
 	});
 });

--- a/packages/forms-web-app/src/lib/get-file-name-from-url.js
+++ b/packages/forms-web-app/src/lib/get-file-name-from-url.js
@@ -1,11 +1,19 @@
 const getFileNameFromDocumentUrl = (url = '') => {
 	if (typeof url !== 'string') return null;
 
-	const lastUrlSegment = url.split('/').filter(Boolean).pop() || '';
-	const regex = /(?<=-)[^-]*(?=\.[^.]*$)/;
-	const fileName = lastUrlSegment.match(regex);
+	const lastUrlSegment = url.split('/').filter(Boolean).pop();
 
-	return fileName ? fileName[0].replaceAll('_', ' ') : null;
+	if (!lastUrlSegment) return null;
+
+	const regexWithExtension = /(?<=-)[^-]*(?=\.[^.]*$)/;
+	const regexWithoutExtension = /(?<=-)[^-]*$/;
+
+	let match =
+		lastUrlSegment.match(regexWithExtension) || lastUrlSegment.match(regexWithoutExtension);
+
+	if (!match) return null;
+
+	return match[0].replaceAll('_', ' ');
 };
 
 module.exports = { getFileNameFromDocumentUrl };


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-1137

BO migrated cases have a slightly different path (published URI). This change ensures its formatted correctly on the FO FE instead of being blank. This change should not impact what currently works.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
