### PR TITLE
chore(web): set redis pingInterval to stop Azure redis idle timeouts

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/session.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/session.test.js
@@ -47,7 +47,8 @@ describe('lib/session', () => {
 					tls: false
 				},
 				password: 'some_password',
-				legacyMode: true
+				legacyMode: true,
+				pingInterval: 300000
 			});
 			expect(mockCreateClientOnFn).toBeCalledWith('connect', expect.any(Function));
 			expect(mockCreateClientOnFn).toBeCalledWith('ready', expect.any(Function));

--- a/packages/forms-web-app/src/lib/session.js
+++ b/packages/forms-web-app/src/lib/session.js
@@ -38,7 +38,8 @@ const configureRedisStore = (session) => {
 			tls: redisConfig.ssl
 		},
 		password: redisConfig.password,
-		legacyMode: true
+		legacyMode: true,
+		pingInterval: 1000 * 60 * 5 // 5 minutes; to stop Azure Redis 10 minutes idle timeout
 	});
 
 	redisClient.on('connect', () => logger.info('Initiating connection to redis server...'));


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1154

-set redis pingInterval to 5 mins to stop Azure Redis 10min idle timeouts

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
