### PR TITLE
chore(tooling): set node alpine to node:20-alpine3.20

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 6379:6379
 
   applications-service-api:
-    image: node:20-alpine
+    image: node:20-alpine3.20
     user: node
     container_name: applications-service-api
     environment:
@@ -82,7 +82,7 @@ services:
     command: npm run start:dev --workspace=packages/applications-service-api
 
   applications-web-app:
-    image: node:20-alpine
+    image: node:20-alpine3.20
     user: node
     container_name: applications-web-app
     environment:

--- a/packages/applications-service-api/Dockerfile
+++ b/packages/applications-service-api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine3.20 AS build
 
 # TODO: Remove this once these get fixed:
 # - https://github.com/vercel/turborepo/issues/1097

--- a/packages/forms-web-app/Dockerfile
+++ b/packages/forms-web-app/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine3.20 AS build
 
 # TODO: Remove this once these get fixed:
 # - https://github.com/vercel/turborepo/issues/1097


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1189

we don't specify an alpine version in our dockerfiles and things have broken specifically for prisma.
node alpine has been updated, and openssl path has changed, setting node alpine to node:20-alpine3.20
## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
