### PR TITLE
fix: post decision doc case stage (applics-1193)

### DIFF
--- a/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
@@ -172,7 +172,7 @@ describe('document mapper functions', () => {
 			['stage', 'examination', { cy: 'Archwiliad', en: 'Examination' }],
 			['stage', 'recommendation', { cy: 'Argymhelliad', en: 'Recommendation' }],
 			['stage', 'decision', { cy: 'Penderfyniad', en: 'Decision' }],
-			['stage', 'post-decision', { cy: 'Ôl-benderfyniad', en: 'Post-decision' }],
+			['stage', 'post_decision', { cy: 'Ôl-benderfyniad', en: 'Post-decision' }],
 			[
 				'stage',
 				'developers_application',

--- a/packages/applications-service-api/src/utils/document.mapper.js
+++ b/packages/applications-service-api/src/utils/document.mapper.js
@@ -32,7 +32,7 @@ const GET_LABEL_MAPPING = (isMaterialChange = false) => ({
 		examination: mappedLabel('Archwiliad', 'Examination'),
 		recommendation: mappedLabel('Argymhelliad', 'Recommendation'),
 		decision: mappedLabel('Penderfyniad', 'Decision'),
-		'post-decision': mappedLabel('Ôl-benderfyniad', 'Post-decision'),
+		post_decision: mappedLabel('Ôl-benderfyniad', 'Post-decision'),
 		developers_application: mappedLabel('Cais y datblygwr', `Developer's application`)
 	},
 	category: {


### PR DESCRIPTION
## Describe your changes

CBOS / Service Bus model value for document case stage is "post_decision" with an underscore, not a hyphen (post-decision).  Amended CBOS mapper to handle this correctly.

## APPLICS-1193 Document case stages not mapping correctly to schema - POST DECISION
https://pins-ds.atlassian.net/browse/APPLICS-1193

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
