### PR TITLE
feat: use personalName for documents

### DIFF
--- a/packages/applications-service-api/__tests__/__data__/representation.js
+++ b/packages/applications-service-api/__tests__/__data__/representation.js
@@ -85,6 +85,7 @@ const REPRESENTATION_BACKOFFICE_RESPONSE = {
 			representative: '',
 			docReference: null,
 			author: null,
+			personalName: null,
 			lastModified: '2023-06-19 10:50:31.8860000',
 			dateCreated: '2023-06-19 10:50:31.8860000'
 		}

--- a/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/document.mapper.test.js
@@ -146,6 +146,7 @@ describe('document mapper functions', () => {
 					representative: 'somerep',
 					docReference: 'someref',
 					author: 'someone',
+					personalName: 'someone',
 					authorWelsh: 'author welsh',
 					lastModified: '2023-06-19T10:50:31.957Z',
 					dateCreated: '2023-06-19T10:50:31.957Z'

--- a/packages/applications-service-api/src/utils/document.mapper.js
+++ b/packages/applications-service-api/src/utils/document.mapper.js
@@ -95,8 +95,7 @@ const mapBackOfficeDocuments = (documents, isMaterialChange) =>
 		path: document.publishedDocumentURI,
 		// status: 'Published', // should always be Published, so not needed in API response?
 		datePublished: document.datePublished,
-		// deadlineDate: "", // no equivalent in BO schema
-		// personalName: '', // no equivalent in BO schema
+		personalName: document.author,
 		representative: document.representative,
 		// whoFrom: null, // no equivalent in BO schema
 		docReference: document.documentReference,


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-1137

Update to set author as personalName. Then FE will use personalName for display name if description does not exist, 

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
