### PR TITLE
ci: use git commit hash for deployments

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -25,7 +25,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.16.1
+      ref: refs/tags/release/3.20.0
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -32,7 +32,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.18.2
+      ref: refs/tags/release/3.20.0
   pipelines:
     - pipeline: build
       source: Applications Service Build
@@ -74,12 +74,13 @@ extends:
                 displayName: Set app name
                 env:
                   ENVIRONMENT: $(ENVIRONMENT)
-              - template: ../steps/azure_web_app_deploy.yml
+              - template: ../steps/azure_web_app_deploy_slot.yml
                 parameters:
                   appName: pins-app-applications-service-$(appName)-$(ENVIRONMENT)-$(REGION_SHORT)-001
                   appResourceGroup: $(resourceGroup)
                   azurecrName: $(azurecrName)
                   repository: applications-service/applications-service-api
+                  slot: default
               - script: |
                   echo "Verifying API Version (using git hash)..."
                   bash ./verify_commit_hash.sh "API" "https://pins-app-applications-service-$(appName)-$(ENVIRONMENT)-$(REGION_SHORT)-001.azurewebsites.net/health" "$(resources.pipeline.build.sourceCommit)" 3
@@ -101,12 +102,13 @@ extends:
                 displayName: Set app name
                 env:
                   ENVIRONMENT: $(ENVIRONMENT)
-              - template: ../steps/azure_web_app_deploy.yml
+              - template: ../steps/azure_web_app_deploy_slot.yml
                 parameters:
                   appName: pins-app-applications-service-$(appName)-$(ENVIRONMENT)-$(REGION_SHORT)-001
                   appResourceGroup: $(resourceGroup)
                   azurecrName: $(azurecrName)
                   repository: applications-service/forms-web-app
+                  slot: default
               - script: |
                   echo "Verifying Web Version (using git hash)..."
                   if [ "$(ENVIRONMENT)" == "prod" ]; then


### PR DESCRIPTION
# Describe your changes
Switch to newer versions of the Build & Deploy pipelines, to use git commit hash for docker image tags
NOTE: this does not change the release pipeline

More [docs here](https://pins-ds.atlassian.net/wiki/spaces/CS/pages/1719861253/App+Service+Deployments)

# Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/DEV-337)