### PR TITLE
fix(web): trim encodede spaces in URLs

### DIFF
--- a/packages/forms-web-app/__tests__/unit/middleware/handle-encoded-spaces.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/handle-encoded-spaces.test.js
@@ -1,0 +1,35 @@
+const { handleEncodedSpacesInUrl } = require('../../../src/middleware/handle-encoded-spaces');
+
+describe('#handleEncodedSpacesInUrl', () => {
+	let req;
+	let res;
+	let next;
+
+	beforeEach(() => {
+		req = {
+			url: ''
+		};
+		res = {
+			redirect: jest.fn()
+		};
+		next = jest.fn();
+	});
+
+	it('should call next if the URL does not change', () => {
+		req.url = '/mock/url';
+
+		handleEncodedSpacesInUrl(req, res, next);
+
+		expect(next).toHaveBeenCalled();
+		expect(res.redirect).not.toHaveBeenCalled();
+	});
+
+	it('should trim all URL segments and redirect to new URL', () => {
+		req.url = '/mock/%20url/%20test';
+
+		handleEncodedSpacesInUrl(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalledWith(301, '/mock/url/test');
+		expect(next).not.toHaveBeenCalled();
+	});
+});

--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -12,6 +12,7 @@ const flashMessageToNunjucks = require('./middleware/flash-message-to-nunjucks')
 const removeUnwantedCookiesMiddelware = require('./middleware/remove-unwanted-cookies');
 const formSanitisationMiddleware = require('./middleware/form-sanitisation');
 const { plannedOutage } = require('./middleware/planned-outage');
+const { handleEncodedSpacesInUrl } = require('./middleware/handle-encoded-spaces');
 const {
 	setLocalslDisplayCookieBannerValue
 } = require('./middleware/set-locals-display-cookie-banner-value');
@@ -68,6 +69,7 @@ app.use(session(sessionStoreConfig));
 app.use(removeUnwantedCookiesMiddelware);
 app.use(formSanitisationMiddleware());
 app.use(setLocalslDisplayCookieBannerValue);
+app.use(handleEncodedSpacesInUrl);
 
 const staticOptions = {
 	maxAge: config.cacheControl.maxAge

--- a/packages/forms-web-app/src/middleware/handle-encoded-spaces.js
+++ b/packages/forms-web-app/src/middleware/handle-encoded-spaces.js
@@ -1,0 +1,17 @@
+const handleEncodedSpacesInUrl = (req, res, next) => {
+	const url = req.url;
+	const trimmedUrl = url
+		.split('/')
+		.map((segment) => decodeURIComponent(segment).trim())
+		.join('/');
+
+	if (url !== trimmedUrl) {
+		return res.redirect(301, trimmedUrl);
+	}
+
+	next();
+};
+
+module.exports = {
+	handleEncodedSpacesInUrl
+};


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1263

Users were able to continue journeys with an encoded space (%20) in the url, however it would fail the submission with an API error. 

-fixed by trimming encoded spaces in URL segments

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
