### PR TITLE
fix(api): handle error caused by querying ni projects table with utf chars

### DIFF
--- a/packages/applications-service-api/src/routes/applications.js
+++ b/packages/applications-service-api/src/routes/applications.js
@@ -30,7 +30,7 @@ router.get(
 	parseBooleanQueryParams(['excludeNullDateOfSubmission']),
 	normaliseArrayQueryParams(['stage', 'region', 'sector']),
 	validateRequestWithOpenAPI,
-	applicationsController.getAllApplications
+	asyncRoute(applicationsController.getAllApplications)
 );
 
 module.exports = router;


### PR DESCRIPTION
## Describe your changes

APPLICS-1284 

The NI `wp_ipc_projects` table uses `latin1` encoding which means queries cannot include non-latin1 characters, and when doing so the database throws an errors, which the API does not handle and crashes.

This PR updates the NI project repository to return an empty result rather than throwing an error if a query with unsupported characters is received.

The `asyncRoute` middleware has also been added to the router/controller, so in the future any uncaught errors are caught at the router level rather than crashing the whole application.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
