### PR TITLE
fix(api): update back office field mapping for acceptance date

### DIFF
--- a/packages/applications-service-api/__tests__/integration/applications.test.js
+++ b/packages/applications-service-api/__tests__/integration/applications.test.js
@@ -66,7 +66,6 @@ describe('/api/v1/applications', () => {
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual({
 				...APPLICATION_API_V1,
-				DateOfDCOAcceptance_NonAcceptance: null,
 				sourceSystem: 'ODT'
 			});
 		});
@@ -293,8 +292,7 @@ describe('/api/v1/applications', () => {
 					applications: [
 						{
 							...APPLICATION_API_V1,
-							sourceSystem: 'ODT',
-							DateOfDCOAcceptance_NonAcceptance: null
+							sourceSystem: 'ODT'
 						}
 					],
 					currentPage: 1,
@@ -470,7 +468,6 @@ describe('/api/v1/applications', () => {
 		describe('when getAllApplications is MERGE', () => {
 			const BOApplication = {
 				...APPLICATION_API_V1,
-				DateOfDCOAcceptance_NonAcceptance: null,
 				sourceSystem: 'ODT'
 			};
 			const NIApplications = mapNIApplicationsToApi(APPLICATIONS_NI_DB);

--- a/packages/applications-service-api/__tests__/unit/controllers/applications.v2.test.js
+++ b/packages/applications-service-api/__tests__/unit/controllers/applications.v2.test.js
@@ -35,7 +35,6 @@ describe('applications v2 controller', () => {
 
 				expect(responseBody).toEqual({
 					...APPLICATION_API_V1,
-					DateOfDCOAcceptance_NonAcceptance: null,
 					sourceSystem: 'ODT'
 				});
 			});

--- a/packages/applications-service-api/__tests__/unit/services/application.merge.service.test.js
+++ b/packages/applications-service-api/__tests__/unit/services/application.merge.service.test.js
@@ -26,7 +26,6 @@ describe('application.merge.service', () => {
 	describe('getAllMergedApplications', () => {
 		const BOApplication = {
 			...APPLICATION_API_V1,
-			DateOfDCOAcceptance_NonAcceptance: null,
 			sourceSystem: 'ODT'
 		};
 		const NIApplications = mapNIApplicationsToApi(APPLICATIONS_NI_DB);
@@ -131,7 +130,6 @@ describe('application.merge.service', () => {
 			});
 			const BOApplication = {
 				...APPLICATION_API_V1,
-				DateOfDCOAcceptance_NonAcceptance: null,
 				sourceSystem: 'ODT'
 			};
 			const NIApplications = mapNIApplicationsToApi(APPLICATIONS_NI_DB);

--- a/packages/applications-service-api/__tests__/unit/utils/application.mapper.test.js
+++ b/packages/applications-service-api/__tests__/unit/utils/application.mapper.test.js
@@ -433,7 +433,6 @@ describe('application.mapper', () => {
 			expect(mapNIApplicationToApi(APPLICATION_FO)).toEqual(
 				expect.objectContaining({
 					...APPLICATION_API,
-					dateOfDCOAcceptance: null,
 					deadlineForAcceptanceDecision: null,
 					sourceSystem: 'HORIZON'
 				})
@@ -453,7 +452,6 @@ describe('application.mapper', () => {
 					...APPLICATION_API,
 					longLat: ['-0.7123', '53.6123'],
 					mapZoomLevel: 6,
-					dateOfDCOAcceptance: null,
 					deadlineForAcceptanceDecision: null,
 					sourceSystem: 'HORIZON'
 				})
@@ -553,7 +551,6 @@ describe('application.mapper', () => {
 			expect(mapBackOfficeApplicationsToApi([APPLICATION_DB])).toEqual([
 				{
 					...APPLICATION_API_V1,
-					DateOfDCOAcceptance_NonAcceptance: null,
 					sourceSystem: 'ODT'
 				}
 			]);

--- a/packages/applications-service-api/src/utils/application.mapper.js
+++ b/packages/applications-service-api/src/utils/application.mapper.js
@@ -227,7 +227,7 @@ const mapNIApplicationToApi = (application) => {
 		anticipatedSubmissionDateNonSpecific: application.AnticipatedSubmissionDateNonSpecific,
 		confirmedDateOfDecision: application.ConfirmedDateOfDecision,
 		confirmedStartOfExamination: application.ConfirmedStartOfExamination,
-		dateOfDCOAcceptance: null, // field is in NI but we don't include it in query
+		dateOfDCOAcceptance: application.DateOfDCOAcceptance_NonAcceptance,
 		dateOfDCOSubmission: application.DateOfDCOSubmission,
 		dateOfNonAcceptance: application.dateOfNonAcceptance,
 		dateOfRecommendations: application.DateOfRecommendations,
@@ -366,7 +366,7 @@ const mapResponseBackToNILegacyFormat = (application) => {
 		AnticipatedDateOfSubmission: application.anticipatedDateOfSubmission,
 		AnticipatedSubmissionDateNonSpecific: application.anticipatedSubmissionDateNonSpecific,
 		DateOfDCOSubmission: getValidDateInStringOrNull(application.dateOfDCOSubmission),
-		DateOfDCOAcceptance_NonAcceptance: null, // attribute not present in Back Office schema
+		DateOfDCOAcceptance_NonAcceptance: application.dateOfDCOAcceptance,
 		DateOfPreliminaryMeeting: application.preliminaryMeetingStartDate,
 		ConfirmedStartOfExamination: application.confirmedStartOfExamination,
 		DateTimeExaminationEnds: application.dateTimeExaminationEnds,


### PR DESCRIPTION
## Describe your changes

APPLICS-1259

- Updates field mapping for cases originating from CBOS, which were missing the 'Date of acceptance' field in the CSV download

## Useful information to review or test

- `dateOfAcceptance` is the name of the field in CBOS and the Front Office database
- `DateOfDCOAcceptance_NonAcceptance` is the name of the field in NI (the field is used for two purposes)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
