### PR TITLE
fix(web): add page title to register of advice page (applics-1358)

### DIFF
--- a/packages/forms-web-app/src/pages/register-of-advice/index/view.njk
+++ b/packages/forms-web-app/src/pages/register-of-advice/index/view.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/default.njk" %}
 
+{% block pageTitle %}
+	{{ t('registerOfAdvice.pageHeading') }}
+{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Describe your changes
[APPLICS-1358](https://pins-ds.atlassian.net/browse/APPLICS-1358): FO Zoonou testing - 5/10 - Page Title is Not Descriptive

Added page title to register of advice page following Zoonou accessibility audit.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1358]: https://pins-ds.atlassian.net/browse/APPLICS-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ