### PR TITLE
fix(web): add session affinity cookie to allow list (applics-1455)

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/remove-unwanted-cookies.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/remove-unwanted-cookies.test.js
@@ -13,7 +13,13 @@ jest.mock('../../../src/lib/extract-root-domain-name-from-full-domain-name');
 describe('lib/remove-unwanted-cookies', () => {
 	describe('defaultKeepMeCookies', () => {
 		it('should have the expected cookie names', () => {
-			expect(defaultKeepMeCookies).toEqual(['connect.sid', cookieConfig.COOKIE_POLICY_KEY, 'lang']);
+			expect(defaultKeepMeCookies).toEqual([
+				'connect.sid',
+				cookieConfig.COOKIE_POLICY_KEY,
+				'lang',
+				'ARRAffinity',
+				'ARRAffinitySameSite'
+			]);
 		});
 	});
 

--- a/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
+++ b/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
@@ -5,7 +5,13 @@ const {
 	extractRootDomainNameFromHostnameAndSubdomains
 } = require('./extract-root-domain-name-from-full-domain-name');
 
-const defaultKeepMeCookies = ['connect.sid', cookieConfig.COOKIE_POLICY_KEY, localesQueryCookieID];
+const defaultKeepMeCookies = [
+	'connect.sid',
+	cookieConfig.COOKIE_POLICY_KEY,
+	localesQueryCookieID,
+	'ARRAffinity',
+	'ARRAffinitySameSite'
+];
 
 /**
  * This is a brute force attempt at removing any unwanted cookies.


### PR DESCRIPTION
## Describe your changes
[APPLICS-1455](https://pins-ds.atlassian.net/browse/APPLICS-1455): Add session affinity cookie to allow list

## Useful information to review or test
To confirm the change is working, once deployed, the cookies values should remain static when browsing the website (check request headers and responses).

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[APPLICS-1455]: https://pins-ds.atlassian.net/browse/APPLICS-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ