### PR TITLE
feat(web): group examination deadline form elements correctly (applics-1355)

### DIFF
--- a/packages/forms-web-app/src/pages/examination/add-another-deadline-item/view.njk
+++ b/packages/forms-web-app/src/pages/examination/add-another-deadline-item/view.njk
@@ -8,7 +8,6 @@
 
 {% set backLinkUrl = backLinkUrl %}
 {% set pageTitle = t("examination.addAnotherDeadlineItem.title") %}
-{% set hintHtml = '<legend class="govuk-fieldset__legend govuk-fieldset__legend govuk-fieldset__legend--m">' + t("examination.addAnotherDeadlineItem.hintText1") + '</legend>' %}
 
 {% block pageTitle %}
 	{% if errors %}
@@ -94,13 +93,10 @@
 							},
 							fieldset: {
 								legend: {
-									text: '',
+									text: t("examination.addAnotherDeadlineItem.hintText1"),
 									isPageHeading: true,
 									classes: "govuk-fieldset__legend--m"
 								}
-							},
-							hint: {
-								html: hintHtml
 							},
 							items: options
 						}) }}


### PR DESCRIPTION
## Describe your changes
[APPLICS-1355](https://pins-ds.atlassian.net/browse/APPLICS-1355): Related Form Elements Not Grouped Correctly

Following accessibility testing by Zoonou, it was observed that in the Have Your Say form on the "Your response to deadline" page, "the checkbox fields are grouped within a fieldset where the legend is not a direct child of the fieldset and is instead nested within a div element." 

This PR removes the additional div element, which contained hint text, and sets this text as the legend directly inside the fieldset.

## Useful information to review or test
On inspecting the page in the browser, the legend element should be directly nested inside the fieldset element.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1355]: https://pins-ds.atlassian.net/browse/APPLICS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ