### PR TITLE
feat(api): add search term split for documents page (applics-1215)

### DIFF
--- a/packages/applications-service-api/__tests__/unit/repositories/document.backoffice.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/document.backoffice.repository.test.js
@@ -38,17 +38,17 @@ describe('document repository', () => {
 			expect(mockCount.mock.calls[0][0].where.AND[0]).toEqual({ caseRef: caseReference });
 		});
 
-		it('calls findMany and count with searchTerm if provided', async () => {
+		it('calls findMany and count with split and filtered searchTerm if provided', async () => {
 			await getDocuments({
 				caseReference: caseReference,
-				searchTerm: 'someterm'
+				searchTerm: 'a search term'
 			});
 
-			expect(mockFindMany.mock.calls[0][0].where.AND[2].OR[0].description.contains).toEqual(
-				'someterm'
+			expect(mockFindMany.mock.calls[0][0].where.AND[2].OR[0].AND[0].description.contains).toEqual(
+				'search'
 			);
-			expect(mockCount.mock.calls[0][0].where.AND[2].OR[0].description.contains).toEqual(
-				'someterm'
+			expect(mockCount.mock.calls[0][0].where.AND[2].OR[0].AND[0].description.contains).toEqual(
+				'search'
 			);
 		});
 

--- a/packages/applications-service-api/__tests__/unit/repositories/document.ni.repository.test.js
+++ b/packages/applications-service-api/__tests__/unit/repositories/document.ni.repository.test.js
@@ -93,12 +93,12 @@ describe('documentV3 service', () => {
 			});
 		});
 
-		it('calls query api with searchTerm if it is specified', async () => {
+		it('calls query api with a split and filtered searchTerm if it is specified', async () => {
 			await fetchDocuments({
 				caseReference: 'EN010085',
 				page: 1,
 				itemsPerPage: 25,
-				searchTerm: 'foo'
+				searchTerm: 'a search term'
 			});
 
 			expect(mockFindAndCountAll).toBeCalledWith({
@@ -109,10 +109,27 @@ describe('documentV3 service', () => {
 						STAGE_NOT_EMPTY_OR_0_STATEMENT,
 						{
 							[Op.or]: [
-								{ description: { [Op.like]: '%foo%' } },
-								{ personal_name: { [Op.like]: '%foo%' } },
-								{ representative: { [Op.like]: '%foo%' } },
-								{ mime: { [Op.like]: '%foo%' } }
+								{
+									[Op.and]: [
+										{ description: { [Op.like]: '%search%' } },
+										{ description: { [Op.like]: '%term%' } }
+									]
+								},
+								{
+									[Op.and]: [
+										{ personal_name: { [Op.like]: '%search%' } },
+										{ personal_name: { [Op.like]: '%term%' } }
+									]
+								},
+								{
+									[Op.and]: [
+										{ representative: { [Op.like]: '%search%' } },
+										{ representative: { [Op.like]: '%term%' } }
+									]
+								},
+								{
+									[Op.and]: [{ mime: { [Op.like]: '%search%' } }, { mime: { [Op.like]: '%term%' } }]
+								}
 							]
 						}
 					]
@@ -193,12 +210,12 @@ describe('documentV3 service', () => {
 			});
 		});
 
-		it('calls query api with searchTerm and stage filter when they are specified', async () => {
+		it('calls query api with a split and filtered searchTerm and stage filter when they are specified', async () => {
 			await fetchDocuments({
 				caseReference: 'EN010085',
 				page: 1,
 				itemsPerPage: 25,
-				searchTerm: 'foo',
+				searchTerm: 'a search term',
 				filters: [
 					{
 						name: 'stage',
@@ -216,10 +233,27 @@ describe('documentV3 service', () => {
 						STAGE_NOT_EMPTY_OR_0_STATEMENT,
 						{
 							[Op.or]: [
-								{ description: { [Op.like]: '%foo%' } },
-								{ personal_name: { [Op.like]: '%foo%' } },
-								{ representative: { [Op.like]: '%foo%' } },
-								{ mime: { [Op.like]: '%foo%' } }
+								{
+									[Op.and]: [
+										{ description: { [Op.like]: '%search%' } },
+										{ description: { [Op.like]: '%term%' } }
+									]
+								},
+								{
+									[Op.and]: [
+										{ personal_name: { [Op.like]: '%search%' } },
+										{ personal_name: { [Op.like]: '%term%' } }
+									]
+								},
+								{
+									[Op.and]: [
+										{ representative: { [Op.like]: '%search%' } },
+										{ representative: { [Op.like]: '%term%' } }
+									]
+								},
+								{
+									[Op.and]: [{ mime: { [Op.like]: '%search%' } }, { mime: { [Op.like]: '%term%' } }]
+								}
 							]
 						},
 						{

--- a/packages/applications-service-api/src/repositories/document.backoffice.repository.js
+++ b/packages/applications-service-api/src/repositories/document.backoffice.repository.js
@@ -1,5 +1,7 @@
 const { Prisma } = require('@prisma/client');
 const { prismaClient } = require('../lib/prisma');
+const stopWords = require('../utils/stopwords');
+const stopWordList = stopWords.english;
 
 const getFilters = (caseReference) => {
 	const sql = Prisma.sql`
@@ -28,13 +30,37 @@ const getDocuments = async (query) => {
 	};
 
 	if (query.searchTerm) {
+		const terms = query.searchTerm
+			.split(' ')
+			.filter((term) => !stopWordList.includes(term.toLowerCase()));
+
 		whereClause['AND'].push({
 			OR: [
-				{ description: { contains: query.searchTerm } },
-				{ descriptionWelsh: { contains: query.searchTerm } },
-				{ author: { contains: query.searchTerm } },
-				{ authorWelsh: { contains: query.searchTerm } },
-				{ representative: { contains: query.searchTerm } }
+				{
+					AND: terms.map((term) => ({
+						description: { contains: term }
+					}))
+				},
+				{
+					AND: terms.map((term) => ({
+						descriptionWelsh: { contains: term }
+					}))
+				},
+				{
+					AND: terms.map((term) => ({
+						author: { contains: term }
+					}))
+				},
+				{
+					AND: terms.map((term) => ({
+						authorWelsh: { contains: term }
+					}))
+				},
+				{
+					AND: terms.map((term) => ({
+						representative: { contains: term }
+					}))
+				}
 			]
 		});
 	}


### PR DESCRIPTION
## Describe your changes
[APPLICS 1215](https://pins-ds.atlassian.net/browse/APPLICS-1215): Documents page - Search term split

NI and back-office:
- Split the search term string into an array of terms and filtered out stop words such as 'and' or 'or'.
- Updated the where clause in each database query to iterate through this array for each field to check if each term is present.
- Updated the unit tests for each repository.

## Useful information to review or test
Covered by the project-application-documents e2e test.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
