### PR TITLE
fix(web): localise CBOS exam timetable dates

### DIFF
--- a/packages/forms-web-app/src/pages/projects/examination-timetable/_utils/events/get-events.js
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/_utils/events/get-events.js
@@ -23,7 +23,11 @@ const getEvents = async (appData, i18n) => {
 			return {
 				...timetable,
 				dateOfEvent: localiseDate(timetable.dateOfEvent),
-				dateTimeDeadlineStart: localiseDate(timetable.dateTimeDeadlineStart)
+				//some deadline start dates have null values, which the exam date logic happens to handle as it is being fed to js date object and turned into the default 1970-01-01T00:00:00.000
+				//we will need to check if the date is null before localising it, but we should have a more graceful way of handling that
+				dateTimeDeadlineStart: timetable.dateTimeDeadlineStart
+					? localiseDate(timetable.dateTimeDeadlineStart)
+					: null
 			};
 		}
 		return timetable;

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/_utils/events/get-events.js
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/_utils/events/get-events.js
@@ -6,18 +6,35 @@ const {
 	getOpenEventDeadlineTimetables
 } = require('../../../../../utils/timetables/get-timetables-state');
 const { getPastTimetables } = require('../../../../../utils/timetables/get-timetables-state');
+const { localiseDate } = require('../../../../../utils/date-utils');
 
 const getEvents = async (appData, i18n) => {
 	const { data } = await getTimetables(getProjectCaseRef(appData));
 
 	const timetables = data?.timetables || [];
 
+	//(APPLICS-1508)Due to timetable data coming from two sources (NI and CBOS; and NI dates being saved in local time, while CBOS dates are saved in UTC),
+	//we will need to localise the CBOS dates here, where we can still differentiate between the two sources (by sourceSystem), before it is being passed deeper
+	//TODO: When the migration is completed, we should remove this and probably only localise the dates in the views, and keep the date logic in UTC
+
+	//go over the timetables and localise the CBOS dates
+	const localisedTimetableData = timetables.map((timetable) => {
+		if (timetable.sourceSystem === 'BACK_OFFICE') {
+			return {
+				...timetable,
+				dateOfEvent: localiseDate(timetable.dateOfEvent),
+				dateTimeDeadlineStart: localiseDate(timetable.dateTimeDeadlineStart)
+			};
+		}
+		return timetable;
+	});
+
 	const sortedTimetables = {
-		past: getPastTimetables(timetables),
-		upcoming: getUpcomingTimetables(timetables)
+		past: getPastTimetables(localisedTimetableData),
+		upcoming: getUpcomingTimetables(localisedTimetableData)
 	};
 
-	const hasOpenTimetables = getOpenEventDeadlineTimetables(timetables).length > 0;
+	const hasOpenTimetables = getOpenEventDeadlineTimetables(localisedTimetableData).length > 0;
 
 	return { ...eventsViewModel(sortedTimetables, i18n), hasOpenTimetables };
 };

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/controller.js
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/controller.js
@@ -26,6 +26,7 @@ const getProjectsExaminationTimetableController = async (req, res) => {
 		const examinationTimetableData = data;
 		const projectName = examinationTimetableData?.ProjectName;
 		const pageData = getPageData(case_ref, projectName, examinationTimetableData, i18n);
+
 		return res.render(view, {
 			...pageData,
 			events: await getEvents(examinationTimetableData, i18n)

--- a/packages/forms-web-app/src/utils/date-utils.js
+++ b/packages/forms-web-app/src/utils/date-utils.js
@@ -1,4 +1,10 @@
-const moment = require('moment');
+const moment = require('moment'); //TODO: remove this and use dayjs or date-fns to handle dates rather than js date objects
+const dayjs = require('dayjs');
+const dayjsUtcPlugin = require('dayjs/plugin/utc');
+const dayjsTimezonePlugin = require('dayjs/plugin/timezone');
+
+dayjs.extend(dayjsUtcPlugin);
+dayjs.extend(dayjsTimezonePlugin);
 
 const buildDateSting = (year, month, day) => `${year}-${month}-${day}`;
 
@@ -32,12 +38,21 @@ const setTimeToStartOfDay = (date) => new Date(date).setHours(0, 0, 0, 0);
 
 const setTimeToEndOfDay = (date) => new Date(date).setHours(23, 59, 59, 999);
 
+const localiseDate = (date, format = 'YYYY-MM-DD HH:mm:ss.SSS', timezone = 'Europe/London') => {
+	if (!date || !dayjs(date).isValid()) {
+		throw new Error(`Valid date is required: ${date}`);
+	}
+
+	return dayjs(date).tz(timezone).format(format);
+};
+
 module.exports = {
 	buildDateSting,
 	getDate,
 	getDateNow,
 	getYearNow,
 	formatDate,
+	localiseDate,
 	isNullSQLDate,
 	setTimeToStartOfDay,
 	setTimeToEndOfDay


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1508

Issue is caused by the FO not handling dates correctly. 
CBOS is saving dates in UTC. In a situation when a timetable event (eg meeting or hearing) is created without the end time, as they usually are, a default time is set eg `2025-04-24 00:00:00.000` then prisma correctly saves the date in UTC and during summer time, subtracts an hour, saving the date in the db as 
`2025-04-23 23:00:00.000`. 
Not only does FO currently not handle timezones/DST at all and simply displays given values, it also ignores the time on the deadlines/meetings, and sets the time to end of day by default on all timetable dates. Changing CBOS date into `2025-04-23 23:59:59.000`.  Which in this situation makes the event timetable items display as a day early.

This fix simply adjusts the date before it is passed to the date handling logic, but only for the CBOS cases. 
Ideally, after the migration, we would remove this and keep the date logic using UCT, and format the display date only in the views.


<!--
    Issue ticket number and link
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
