### PR TITLE
feat(web): add welsh advice link to detailed information page (applics-1497)

### DIFF
--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -90,6 +90,8 @@ module.exports = {
 			'https://www.gov.uk/search/all?keywords=accessible%20document%20policy',
 		advicePages:
 			'https://www.gov.uk/government/collections/national-infrastructure-planning-advice-notes',
+		advicePagesWelsh:
+			'https://www.gov.uk/government/collections/prosiectau-seilwaith-o-arwyddocad-cenedlaethol-tudalennau-cyngor',
 		administrativeCourtURL: 'https://www.gov.uk/courts-tribunals/administrative-court',
 		crownCopyright:
 			'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/',

--- a/packages/forms-web-app/src/pages/_utils/get-govuk-urls.js
+++ b/packages/forms-web-app/src/pages/_utils/get-govuk-urls.js
@@ -9,7 +9,8 @@ const getGovUkUrls = (locale = 'en') => {
 		nationalPolicyStatements,
 		nationalPolicyStatementsWelsh,
 		planningGuidance,
-		advicePages
+		advicePages,
+		advicePagesWelsh
 	} = config.govUK;
 
 	return {
@@ -20,7 +21,7 @@ const getGovUkUrls = (locale = 'en') => {
 			developmentConsentAndAdviceWelsh
 		),
 		planningGuidanceUrl: planningGuidance,
-		advicePagesUrl: advicePages,
+		advicePagesUrl: getGovUkUrl(locale, advicePages, advicePagesWelsh),
 		nationalPolicyStatementsUrl: getGovUkUrl(
 			locale,
 			nationalPolicyStatements,

--- a/packages/forms-web-app/src/pages/_utils/get-govuk-urls.test.js
+++ b/packages/forms-web-app/src/pages/_utils/get-govuk-urls.test.js
@@ -9,6 +9,7 @@ jest.mock('../../../src/config', () => {
 			developmentConsentAndAdviceWelsh: 'Welsh URL 2',
 			planningGuidance: 'URL 3',
 			advicePages: 'URL 4',
+			advicePagesWelsh: 'Welsh URL 4',
 			nationalPolicyStatements: 'URL 5',
 			nationalPolicyStatementsWelsh: 'Welsh URL 5'
 		}
@@ -30,7 +31,7 @@ describe('pages/_utils/get-govuk-urls', () => {
 				developmentConsentUrl: 'Welsh URL 1',
 				developmentConsentAndAdviceUrl: 'Welsh URL 2',
 				planningGuidanceUrl: 'URL 3',
-				advicePagesUrl: 'URL 4',
+				advicePagesUrl: 'Welsh URL 4',
 				nationalPolicyStatementsUrl: 'Welsh URL 5'
 			});
 		});


### PR DESCRIPTION
## Describe your changes
[APPLICS 1497](https://pins-ds.atlassian.net/browse/APPLICS-1497): FO Welsh Advice pages

This PR adds the URL for the Welsh advice pages to the existing config to be utilised on the Detailed Information page when the locale is equal to 'cy'. The relevant unit test has been updated.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
