### PR TITLE
fix(applics-1353): change html bold tags to use strong

### DIFF
--- a/packages/forms-web-app/src/pages/examination/have-your-say/view.njk
+++ b/packages/forms-web-app/src/pages/examination/have-your-say/view.njk
@@ -24,7 +24,7 @@
 	<h2 class="govuk-heading-m">{{ t('examination.haveYourSay.deadlinesOpen.heading1') }}</h2>
 
 	<p>
-		<b>{{ t('examination.haveYourSay.deadlinesOpen.paragraph2') }}</b>
+		<strong>{{ t('examination.haveYourSay.deadlinesOpen.paragraph2') }}</strong>
 	</p>
 
 	<p>{{ t('examination.haveYourSay.deadlinesOpen.paragraph3') }}</p>
@@ -40,7 +40,7 @@
 	<p>{{ t('examination.haveYourSay.deadlinesOpen.paragraph4') }}</p>
 
 	<p>
-		<b>{{ t('examination.haveYourSay.deadlinesOpen.paragraph5') }}</b>
+		<strong>{{ t('examination.haveYourSay.deadlinesOpen.paragraph5') }}</strong>
 	</p>
 
 	<p>{{ t('examination.haveYourSay.deadlinesOpen.paragraph6') }}</p>

--- a/packages/forms-web-app/src/views/macros/pagination-bar.njk
+++ b/packages/forms-web-app/src/views/macros/pagination-bar.njk
@@ -29,7 +29,7 @@
               {% endif %}
             {% endfor %}
           </ul>
-          <p class="moj-pagination__results">{{ t('common.paginationShowing', { from: '<b>' + paginationData.fromRange + '</b>', to: '<b>' + paginationData.toRange + '</b>', total: '<b>' + paginationData.totalItems + '</b>' }) | safe }}</p>
+          <p class="moj-pagination__results">{{ t('common.paginationShowing', { from: '<strong>' + paginationData.fromRange + '</strong>', to: '<strong>' + paginationData.toRange + '</strong>', total: '<strong>' + paginationData.totalItems + '</strong>' }) | safe }}</p>
         </nav>
     {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
## Describe your changes

This PR removes the bold `<b>` tags in nunjucks templates and replaces them with `<strong>` tags for better use with screen readers as per accessibility testing.

<!--
    Issue ticket number and link
-->
https://pins-ds.atlassian.net/browse/APPLICS-1353

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->



<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
