### PR TITLE
fix(tooling): updating appURL for deploy API in  deploy-release pipeline

### DIFF
--- a/azure-pipelines-deploy-release.yml
+++ b/azure-pipelines-deploy-release.yml
@@ -161,7 +161,7 @@ extends:
               - template: ../steps/azure_web_app_verify_git_hash.yml
                 parameters:
                   appName: Application service API
-                  appUrl: $(deploySlotOutputs.slotUrl)/health
+                  appUrl: https://pins-app-applications-service-$(appName)-$(ENVIRONMENT)-$(REGION_SHORT)-001.azurewebsites.net/health
                   buildCommit: $(resources.pipeline.build.sourceCommit)
           - name: Deploy Web
             condition: eq(${{ parameters.deployWeb }}, 'true')


### PR DESCRIPTION
## Describe your changes

Variable '$(deploySlotOutputs.slotUrl)' works well for stage Web/API but fails in Deploy Api/web.
Following error is found in the failed pipeline logs:
`/agent/_work/_temp/c5a69a5d-6a09-4609-be62-04cd72ae588e.sh: line 71: deploySlotOutputs.slotUrl: command not found`
 Hence I have updated the appURL to https://pins-app-applications-service-$(appName)-$(ENVIRONMENT)-$(REGION_SHORT)-001.azurewebsites.net/health


Part of ticket: https://pins-ds.atlassian.net/browse/DEV-356

<!--
    Issue ticket number and link
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
