### PR TITLE
fix(web): order project stage filters on project search page (applics-1444)

### DIFF
--- a/packages/forms-web-app/src/pages/project-search/utils/filters/get-filters-view-model.js
+++ b/packages/forms-web-app/src/pages/project-search/utils/filters/get-filters-view-model.js
@@ -63,6 +63,45 @@ const filterGroupViewModel = (i18n, { name }) => {
 const hasFilterGroup = (filterGroups, filter) =>
 	filterGroups.find((filterGroup) => filterGroup.name === filter.name);
 
+// north to south order
+const locationOrder = [
+	'north_west',
+	'north_east',
+	'yorkshire_and_the_humber',
+	'west_midlands',
+	'east_midlands',
+	'eastern',
+	'south_west',
+	'south_east',
+	'london',
+	'wales'
+];
+
+// order of completion
+const stageOrder = [
+	'pre_application',
+	'acceptance',
+	'pre_examination',
+	'examination',
+	'recommendation',
+	'decision',
+	'post_decision',
+	'withdrawn'
+];
+
+const orderFilterItems = (items, orderItems) => {
+	const orderedItems = [];
+	orderItems.forEach((orderItem) => {
+		const itemIndex = items.findIndex((item) => item.value === orderItem);
+
+		if (itemIndex >= 0) {
+			const itemElement = items[itemIndex];
+			orderedItems.push(itemElement);
+		}
+	});
+	return orderedItems;
+};
+
 const getFiltersViewModel = (i18n, filters) => {
 	const filterGroups = [];
 
@@ -78,36 +117,19 @@ const getFiltersViewModel = (i18n, filters) => {
 	const locationIndex = filterGroups.findIndex((filterGroup) => filterGroup.name === 'region');
 
 	if (locationIndex >= 0) {
-		filterGroups[locationIndex].items = orderLocationItems(filterGroups[locationIndex]?.items);
+		filterGroups[locationIndex].items = orderFilterItems(
+			filterGroups[locationIndex]?.items,
+			locationOrder
+		);
+	}
+
+	const stageIndex = filterGroups.findIndex((filterGroup) => filterGroup.name === 'stage');
+
+	if (stageIndex >= 0) {
+		filterGroups[stageIndex].items = orderFilterItems(filterGroups[stageIndex]?.items, stageOrder);
 	}
 
 	return orderFilterGroups(filterGroups);
-};
-
-const orderLocationItems = (items) => {
-	// north to south order
-	const locationOrder = [
-		'north_west',
-		'north_east',
-		'yorkshire_and_the_humber',
-		'west_midlands',
-		'east_midlands',
-		'eastern',
-		'south_west',
-		'south_east',
-		'london',
-		'wales'
-	];
-	const orderedItems = [];
-	locationOrder.forEach((region) => {
-		const regionIndex = items.findIndex((item) => item.value === region);
-
-		if (regionIndex >= 0) {
-			const regionElement = items[regionIndex];
-			orderedItems.push(regionElement);
-		}
-	});
-	return orderedItems;
 };
 
 module.exports = { getFiltersViewModel };

--- a/packages/forms-web-app/src/pages/project-search/utils/filters/get-filters.component.test.js
+++ b/packages/forms-web-app/src/pages/project-search/utils/filters/get-filters.component.test.js
@@ -41,14 +41,14 @@ describe('project-search/utils/filters/get-filters', () => {
 					},
 					{
 						name: 'stage',
-						value: 'mock_value_5',
-						label: 'mock label 5',
+						value: 'pre_application',
+						label: 'Pre-application',
 						count: 5
 					},
 					{
 						name: 'stage',
-						value: 'mock_value_6',
-						label: 'mock label 6',
+						value: 'acceptance',
+						label: 'Acceptance',
 						count: 6
 					}
 				];
@@ -115,15 +115,15 @@ describe('project-search/utils/filters/get-filters', () => {
 								items: [
 									{
 										checked: false,
-										label: 'mock label 5',
-										text: 'mock label 5 (5)',
-										value: 'mock_value_5'
+										label: 'Pre-application',
+										text: 'Pre-application (5)',
+										value: 'pre_application'
 									},
 									{
 										checked: false,
-										label: 'mock label 6',
-										text: 'mock label 6 (6)',
-										value: 'mock_value_6'
+										label: 'Acceptance',
+										text: 'Acceptance (6)',
+										value: 'acceptance'
 									}
 								],
 								label: 'Stage',
@@ -145,7 +145,7 @@ describe('project-search/utils/filters/get-filters', () => {
 						{
 							region: 'north_west',
 							sector: ['mock_value_3', 'mock_value_4'],
-							stage: 'mock_value_6'
+							stage: 'acceptance'
 						},
 						mockFilters
 					);
@@ -158,7 +158,7 @@ describe('project-search/utils/filters/get-filters', () => {
 								tags: [
 									{
 										icon: 'close',
-										link: '?sector=mock_value_3&sector=mock_value_4&stage=mock_value_6',
+										link: '?sector=mock_value_3&sector=mock_value_4&stage=acceptance',
 										textHtml:
 											'<span class="govuk-visually-hidden">Remove</span> North West <span class="govuk-visually-hidden">filter</span>'
 									}
@@ -169,13 +169,13 @@ describe('project-search/utils/filters/get-filters', () => {
 								tags: [
 									{
 										icon: 'close',
-										link: '?region=north_west&sector=mock_value_4&stage=mock_value_6',
+										link: '?region=north_west&sector=mock_value_4&stage=acceptance',
 										textHtml:
 											'<span class="govuk-visually-hidden">Remove</span> mock label 3 <span class="govuk-visually-hidden">filter</span>'
 									},
 									{
 										icon: 'close',
-										link: '?region=north_west&sector=mock_value_3&stage=mock_value_6',
+										link: '?region=north_west&sector=mock_value_3&stage=acceptance',
 										textHtml:
 											'<span class="govuk-visually-hidden">Remove</span> mock label 4 <span class="govuk-visually-hidden">filter</span>'
 									}
@@ -188,7 +188,7 @@ describe('project-search/utils/filters/get-filters', () => {
 										icon: 'close',
 										link: '?region=north_west&sector=mock_value_3&sector=mock_value_4',
 										textHtml:
-											'<span class="govuk-visually-hidden">Remove</span> mock label 6 <span class="govuk-visually-hidden">filter</span>'
+											'<span class="govuk-visually-hidden">Remove</span> Acceptance <span class="govuk-visually-hidden">filter</span>'
 									}
 								]
 							}
@@ -244,15 +244,15 @@ describe('project-search/utils/filters/get-filters', () => {
 								items: [
 									{
 										checked: false,
-										label: 'mock label 5',
-										text: 'mock label 5 (5)',
-										value: 'mock_value_5'
+										label: 'Pre-application',
+										text: 'Pre-application (5)',
+										value: 'pre_application'
 									},
 									{
 										checked: true,
-										label: 'mock label 6',
-										text: 'mock label 6 (6)',
-										value: 'mock_value_6'
+										label: 'Acceptance',
+										text: 'Acceptance (6)',
+										value: 'acceptance'
 									}
 								],
 								label: 'Stage',


### PR DESCRIPTION
## Describe your changes
[APPLICS 1444](https://pins-ds.atlassian.net/browse/APPLICS-1444): FO Project search - Filtering by stage

The order that project stage filters are displayed on the project search page is not consistent in Production. This PR adapts an existing function that orders location filters so that it can be reused to order the project stage filters. They are now displayed in the order that the corresponding NSIP processes are completed. The corresponding unit test has been updated.

## Useful information to review or test
The order that the project stage filters is displayed on the project search page was found to be correct in the Dev and Test environments. The issue has only been observed on the live site.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
