### PR TITLE
feat(web): additional attributes to file upload component to improve accessibility(applics-1360)

### DIFF
--- a/packages/forms-web-app/src/pages/examination/select-file/view.njk
+++ b/packages/forms-web-app/src/pages/examination/select-file/view.njk
@@ -144,7 +144,11 @@
 						name: "documents",
 						label: {
 							text: t("common.uploadAFile"),
-							classes: 'govuk-label--m'
+							classes: 'govuk-label--m',
+							attributes: {
+								role: "link",
+								tabindex: "0"
+							}
 						},
 						attributes: { multiple: 'multiple', accept: ".pdf,.doc,.docx,.jpg,.jpeg,.png,.tif,.tiff,.xls,.xlsx", type: "file" },
 						errorMessage: errorMessage
@@ -186,6 +190,8 @@
 						<label
 							for="file-upload"
 							class="govuk-button govuk-button--secondary ui-file-upload__label"
+							role="link"
+							tabindex="0"
 						>
 							{{ t("common.selectFiles") }}
 						</label>


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1360


This is a workaround solution allowing Dragon Naturally Speaking users to target the upload feature using voice commands such as “click link” or saying the linked label for the input.

https://github.com/alphagov/reported-bugs/issues/35

## Describe your changes

<!--
    Issue ticket number and link
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
