### PR TITLE
fix: applics-1357: refactor chevron card macro to dynamically change …

### DIFF
--- a/packages/forms-web-app/src/pages/detailed-information/view.njk
+++ b/packages/forms-web-app/src/pages/detailed-information/view.njk
@@ -23,11 +23,12 @@
 
 	<div class="full-width-line full-width-line--bg-blue"></div>
 
-	<section class="page-section full-width-section full-width-section--bg-lightgrey">
+	<section class="page-section full-width-section full-width-section--bg-lightgrey-no-h2-border">
 		<div class="page-section__content">
 			<div class="govuk-grid-row">
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle1'),
 						detailedInformationUrls.processGuide,
 						t('detailedInformation.linkParagraph1')
@@ -36,6 +37,7 @@
 
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle2'),
 						detailedInformationUrls.haveYourSayGuide,
 						t('detailedInformation.linkParagraph2')
@@ -44,6 +46,7 @@
 
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle3'),
 						detailedInformationUrls.developmentConsentUrl,
 						t('detailedInformation.linkParagraph3')
@@ -54,6 +57,7 @@
 			<div class="govuk-grid-row">
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle4'),
 						detailedInformationUrls.developmentConsentAndAdviceUrl,
 						t('detailedInformation.linkParagraph4')
@@ -62,6 +66,7 @@
 
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle5'),
 						detailedInformationUrls.planningGuidanceUrl,
 						t('detailedInformation.linkParagraph5')
@@ -70,6 +75,7 @@
 
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle6'),
 						detailedInformationUrls.advicePagesUrl,
 						t('detailedInformation.linkParagraph6')
@@ -80,6 +86,7 @@
 			<div class="govuk-grid-row">
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle7'),
 						detailedInformationUrls.nationalPolicyStatementsUrl,
 						t('detailedInformation.linkParagraph7')
@@ -88,6 +95,7 @@
 
 				<div class="govuk-grid-column-one-third">
 					{{ chevronCard(
+						'2',
 						t('detailedInformation.linkTitle8'),
 						detailedInformationUrls.registerOfAdviceIndexURL,
 						t('detailedInformation.linkParagraph8')

--- a/packages/forms-web-app/src/pages/index/_includes/members-of-public.njk
+++ b/packages/forms-web-app/src/pages/index/_includes/members-of-public.njk
@@ -7,18 +7,20 @@
 		<div class="govuk-grid-row">
 			<div class="govuk-grid-column-one-half">
 				{{ chevronCard(
-						t('index.linkTitle1'),
-						homePageUrls.processGuideURL,
-						t('index.linkParagraph1')
-					) }}
+					'3',
+					t('index.linkTitle1'),
+					homePageUrls.processGuideURL,
+					t('index.linkParagraph1')
+				) }}
 			</div>
 
 			<div class="govuk-grid-column-one-half">
 				{{ chevronCard(
-						t('index.linkTitle2'),
-						homePageUrls.haveYourSayGuideURL,
-						t('index.linkParagraph2')
-					) }}
+					'3',
+					t('index.linkTitle2'),
+					homePageUrls.haveYourSayGuideURL,
+					t('index.linkParagraph2')
+				) }}
 			</div>
 		</div>
 	</div>

--- a/packages/forms-web-app/src/pages/index/_includes/professional-users.njk
+++ b/packages/forms-web-app/src/pages/index/_includes/professional-users.njk
@@ -7,18 +7,20 @@
 		<div class="govuk-grid-row">
 			<div class="govuk-grid-column-one-half">
 				{{ chevronCard(
-          t('index.linkTitle3'),
-          homePageUrls.detailedInformationURL,
-          t('index.linkParagraph3')
-        ) }}
+					'3',
+					t('index.linkTitle3'),
+					homePageUrls.detailedInformationURL,
+					t('index.linkParagraph3')
+        		) }}
 			</div>
 
 			<div class="govuk-grid-column-one-half">
 				{{ chevronCard(
-          t('index.linkTitle4'),
-          homePageUrls.developmentConsentURL, 
-          t('index.linkParagraph4')
-        ) }}
+					'3',
+					t('index.linkTitle4'),
+					homePageUrls.developmentConsentURL, 
+					t('index.linkParagraph4')
+        		) }}
 			</div>
 		</div>
 	</div>

--- a/packages/forms-web-app/src/pages/index/_includes/updates-and-contacts.njk
+++ b/packages/forms-web-app/src/pages/index/_includes/updates-and-contacts.njk
@@ -7,6 +7,7 @@
 		<div class="govuk-grid-row">
 			<div class="govuk-grid-column-one-half">
 				{{ chevronCard(
+					'3',
 					t('index.linkTitle5'),
 					homePageUrls.contactURL,
 					t('index.linkParagraph5')
@@ -14,6 +15,7 @@
 			</div>
 			<div class="govuk-grid-column-one-half">
 				{{ chevronCard(
+					'3',
 					t('index.linkTitle6'),
 					homePageUrls.nsipNewsURL,
 					t('index.linkParagraph6')

--- a/packages/forms-web-app/src/sass/components/section/full-width-section.scss
+++ b/packages/forms-web-app/src/sass/components/section/full-width-section.scss
@@ -16,7 +16,13 @@
                 padding-bottom: 5px;
                 margin-bottom: 25px;
             }
-            
+            &-no-h2-border {
+                h2 {
+                    border-bottom: none;
+                    padding-bottom: 5px;
+                    margin-bottom: 25px;
+                }
+            }
         }
     }
 }

--- a/packages/forms-web-app/src/views/components/ui/chevron-card.njk
+++ b/packages/forms-web-app/src/views/components/ui/chevron-card.njk
@@ -1,9 +1,11 @@
-{% macro chevronCard(headerText, headerUrl, contentText) %}
+{% macro chevronCard(hTagSize, headerText, headerUrl, contentText) %}
+    {% set openTag = '<h' + hTagSize + ' class="pins-chevron-card__heading govuk-heading-s" >' %}
+    {% set closeTag = '</h' + hTagSize + '>'%}
     <div class="pins-chevron-card">
         <div class="pins-chevron-card__wrapper">
-            <h3 class="pins-chevron-card__heading govuk-heading-s">
+            {{ openTag | safe }}
                 <a class="govuk-link pins-chevron-card__link"  href="{{ headerUrl }}">{{ headerText }}</a>
-            </h3>
+            {{ closeTag | safe }}
             <p class="govuk-body pins-chevron-card__description">{{ contentText }}</p>
         </div>
     </div>


### PR DESCRIPTION
…heading size

## Describe your changes

This PR refactors the chevronCard macro so it can be utilised on different pages with different heading sizes. It updates the usage of the macro to define the size on the pages it is used on. It adds some new styling to ensure the new h2 heading of the cards on the detailed information page appears the same as it was.

<!--
    Issue ticket number and link
-->

https://pins-ds.atlassian.net/jira/software/c/projects/APPLICS/boards/269?selectedIssue=APPLICS-1357

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
