### PR TITLE
fix(api): add debian 1.1 to prisma targets (applics-1595)

### DIFF
--- a/packages/applications-service-api/prisma/schema.prisma
+++ b/packages/applications-service-api/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "darwin", "darwin-arm64", "linux-musl", "linux-musl-arm64-openssl-1.1.x", "linux-musl-arm64-openssl-3.0.x", "linux-musl-openssl-3.0.x", "windows"]
+  binaryTargets = ["native", "darwin", "darwin-arm64", "linux-musl", "linux-musl-arm64-openssl-1.1.x", "linux-musl-arm64-openssl-3.0.x", "linux-musl-openssl-3.0.x", "windows", "debian-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Describe your changes
[APPLICS 1595](https://pins-ds.atlassian.net/browse/APPLICS-1595): Publishing to FO failing in dev and test environments

The Front Office is failing to get any service bus updates, the Invocations report this error: PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "debian-openssl-1.1.x". This happened because Prisma Client was generated for "debian-openssl-3.0.x", but the actual deployment required "debian-openssl-1.1.x"

This PR adds debian 1.1 to the Prisma targets as advised in the above error message.

## Useful information to review or test


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
