### PR TITLE
fix: @pins/common filepath was incorrect after package consolidation (#0db5899)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@azure/storage-blob": "^12.16.0",
 				"@godaddy/terminus": "^4.7.1",
 				"@ministryofjustice/frontend": "^2.2.0",
-				"@pins/common": "file:../common",
+				"@pins/common": "file:./packages/common",
 				"@planning-inspectorate/pins-components": "^2.2.6",
 				"@planning-inspectorate/pins-notify": "^1.0.2",
 				"@prisma/client": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@azure/storage-blob": "^12.16.0",
 		"@godaddy/terminus": "^4.7.1",
 		"@ministryofjustice/frontend": "^2.2.0",
-		"@pins/common": "file:../common",
+		"@pins/common": "file:./packages/common",
 		"@planning-inspectorate/pins-components": "^2.2.6",
 		"@planning-inspectorate/pins-notify": "^1.0.2",
 		"@prisma/client": "^5.17.0",


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/DEV-480

Module resolution still worked correctly after `npm ci` (the common package was symlinked in the `node_modules` folder). However, GitHub dependabot showed an error because it could not resolve the dependency.