### PR TITLE
chore: remove pre-push git hook to align with other projects

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run test


### PR DESCRIPTION
Remove the pre-push git hook which ran tests. The tests should already be run as part of the developer workflow, and they are run on PR anyway. This also aligns more closely to other projects.

https://pins-ds.atlassian.net/browse/RDSD-114