### PR TITLE
chore: set 'user: root' for azure-sql-edge to fix running in WSL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,6 +175,7 @@ services:
     image: mcr.microsoft.com/azure-sql-edge:latest
     container_name: mssql
     cap_add: [ 'SYS_PTRACE' ]
+    user: root
     environment:
       - 'ACCEPT_EULA=1'
       - 'MSSQL_SA_PASSWORD=dbPASSw0_rd'


### PR DESCRIPTION
'mssql' container, running azure-sql-edge fails to start on WSL with an error around a 'master.mdf' file with a Windows path.

Adding `user: root` solves this, and aligns with other projects using this image.