### PR TITLE
fix(api): update utils.js in prisma folder (applics-1556)

### DIFF
--- a/packages/applications-service-api/prisma/utils.js
+++ b/packages/applications-service-api/prisma/utils.js
@@ -22,42 +22,94 @@ async function createExaminationTimetableWithEventItems(data) {
 async function createProjectWithServiceUsers(data) {
 	const { applicant, ...projectData } = data;
 	const { applicantId, ...applicantData } = applicant;
-	await prismaClient.project.create({
-		data: {
-			...projectData,
-			applicant: {
-				create: {
-					...applicantData,
-					serviceUserId: applicantId
+
+	await prismaClient.$transaction(async (tx) => {
+		await tx.serviceUser.upsert({
+			where: { serviceUserId: applicantId },
+			update: {
+				...applicantData
+			},
+			create: {
+				serviceUserId: applicantId,
+				...applicantData
+			}
+		});
+
+		await tx.project.create({
+			data: {
+				...projectData,
+				applicant: {
+					create: {
+						serviceUserId: applicantId,
+						...applicantData
+					}
 				}
 			}
-		}
+		});
 	});
 }
+
 async function createRepresentationWithServiceUsers(data) {
 	const { represented, representative, ...representationData } = data;
-	await prismaClient.representation.create({
-		data: {
-			...representationData,
-			represented: {
-				create: {
-					serviceUserId: represented.representedId,
-					firstName: represented.firstName,
-					lastName: represented.lastName,
-					organisationName: represented.organisationName,
-					caseReference: representationData.caseReference
-				}
+
+	await prismaClient.$transaction(async (tx) => {
+		await tx.serviceUser.upsert({
+			where: { serviceUserId: represented.representedId },
+			update: {
+				firstName: represented.firstName,
+				lastName: represented.lastName,
+				organisationName: represented.organisationName,
+				caseReference: representationData.caseReference
 			},
-			representative: {
-				create: {
-					serviceUserId: representative.representativeId,
-					firstName: representative.firstName,
-					lastName: representative.lastName,
-					organisationName: representative.organisationName,
-					caseReference: data.caseReference
+			create: {
+				serviceUserId: represented.representedId,
+				firstName: represented.firstName,
+				lastName: represented.lastName,
+				organisationName: represented.organisationName,
+				caseReference: representationData.caseReference
+			}
+		});
+
+		await tx.serviceUser.upsert({
+			where: { serviceUserId: representative.representativeId },
+			update: {
+				firstName: representative.firstName,
+				lastName: representative.lastName,
+				organisationName: representative.organisationName,
+				caseReference: representationData.caseReference
+			},
+			create: {
+				serviceUserId: representative.representativeId,
+				firstName: representative.firstName,
+				lastName: representative.lastName,
+				organisationName: representative.organisationName,
+				caseReference: representationData.caseReference
+			}
+		});
+
+		await tx.representation.create({
+			data: {
+				...representationData,
+				represented: {
+					create: {
+						serviceUserId: represented.representedId,
+						firstName: represented.firstName,
+						lastName: represented.lastName,
+						organisationName: represented.organisationName,
+						caseReference: representationData.caseReference
+					}
+				},
+				representative: {
+					create: {
+						serviceUserId: representative.representativeId,
+						firstName: representative.firstName,
+						lastName: representative.lastName,
+						organisationName: representative.organisationName,
+						caseReference: representationData.caseReference
+					}
 				}
 			}
-		}
+		});
 	});
 }
 


### PR DESCRIPTION
alternative solution for db:reset in  troubleshooting

## Describe your changes

Ticket info: [applics-1556](https://pins-ds.atlassian.net/jira/software/c/projects/APPLICS/boards/269?assignee=712020%3Aba8d1ca6-3808-4688-95c8-74fe19f585b1&selectedIssue=APPLICS-1556) : FO Service user avoid conflicts in seed script Prisma/seed.js
If the user reruns the database seed will be no issue that stops the migration.
Tested and is fully compatible with the current seed.js file.
Tested in Windows internally with MSSQL and as public user with temp MySQL DB in macOS.
I run the database migration as internal and as public user in both Windows and macOS.

## Useful information to review or test

<!--

-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes