### PR TITLE
fix: npm run db:seed command runs successfully, db is populated

### DIFF
--- a/packages/applications-service-api/prisma/seed.js
+++ b/packages/applications-service-api/prisma/seed.js
@@ -67,29 +67,6 @@ const main = async () => {
 		}
 	});
 
-	await prismaClient.advice.upsert({
-		where: { adviceId: 1 },
-		update: {},
-		create: {
-			adviceId: 1,
-			adviceReference: 'TR0200007-0005',
-			caseReference,
-			caseId: 130,
-			title: 'Advice title',
-			from: 'Advice from',
-			agent: 'Advice agent',
-			method: 'Advice method',
-			enquiryDate: new Date('2021-06-01'),
-			enquiryDetails: 'Advice enquiry details',
-			adviceGivenBy: 'Advice given by',
-			adviceDate: new Date('2021-08-01'),
-			adviceDetails: 'Advice details',
-			status: 'Advice status',
-			redactionStatus: 'Advice redaction status',
-			attachmentIds: '1,2,3'
-		}
-	});
-
 	await prismaClient.project.deleteMany(deleteFilter);
 	await prismaClient.examinationTimetableEventItem.deleteMany();
 	await prismaClient.examinationTimetable.deleteMany(deleteFilter);
@@ -155,6 +132,32 @@ const main = async () => {
 			webAddress: 'https://example.com',
 			phoneNumber: '01234567890',
 			organisationName: 'Example Organisation'
+		}
+	});
+
+	await prismaClient.advice.upsert({
+		where: { adviceId: 1 },
+		update: {},
+		create: {
+			adviceId: 1,
+			adviceReference: 'TR0200007-0005',
+			caseReference,
+			// caseId: 130,
+			title: 'Advice title',
+			from: 'Advice from',
+			agent: 'Advice agent',
+			method: 'Advice method',
+			enquiryDate: new Date('2021-06-01'),
+			enquiryDetails: 'Advice enquiry details',
+			adviceGivenBy: 'Advice given by',
+			adviceDate: new Date('2021-08-01'),
+			adviceDetails: 'Advice details',
+			status: 'Advice status',
+			redactionStatus: 'Advice redaction status',
+			attachmentIds: '1,2,3',
+			project: {
+				connect: { caseId: 130 }
+			}
 		}
 	});
 

--- a/packages/applications-service-api/prisma/utils.js
+++ b/packages/applications-service-api/prisma/utils.js
@@ -34,18 +34,20 @@ async function createProjectWithServiceUsers(data) {
 				...applicantData
 			}
 		});
-
-		await tx.project.create({
-			data: {
-				...projectData,
-				applicant: {
-					create: {
-						serviceUserId: applicantId,
-						...applicantData
+		try {
+			await tx.project.create({
+				data: {
+					...projectData,
+					applicant: {
+						connect: {
+							serviceUserId: applicantId
+						}
 					}
 				}
-			}
-		});
+			});
+		} catch (e) {
+			console.error('FAILED TO INSERT serviceUser', e.message);
+		}
 	});
 }
 
@@ -91,16 +93,12 @@ async function createRepresentationWithServiceUsers(data) {
 			data: {
 				...representationData,
 				represented: {
-					create: {
-						serviceUserId: represented.representedId,
-						firstName: represented.firstName,
-						lastName: represented.lastName,
-						organisationName: represented.organisationName,
-						caseReference: representationData.caseReference
+					connect: {
+						serviceUserId: represented.representedId
 					}
 				},
 				representative: {
-					create: {
+					connect: {
 						serviceUserId: representative.representativeId,
 						firstName: representative.firstName,
 						lastName: representative.lastName,


### PR DESCRIPTION
## Describe your changes
`npm run db:seed` was not working within `applications-service/packages/applications-service-api/`, the DB was not being populated. I noticed this whilst working on a ticket related to translations for `/register-of-advice`, I needed some data in the database to know if the translations were working. Before I made the changes, the script was crashing because in a few places duplicate entries were being attempted on fields that are meant to be unique for the table. To avoid this, instead of inserting values for foreign keys, it is connecting to the foreign that already exists.


<!--
No ticket number, this is resolving a problem I was having on my machine, and I am not sure if other's are having it too....
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
