### PR TITLE
APPLICS-1251 - Front Office Doc Upload File Dialog Filters do not include .xlsx and .docx

### DIFF
--- a/packages/forms-web-app/src/pages/examination/select-file/view.njk
+++ b/packages/forms-web-app/src/pages/examination/select-file/view.njk
@@ -183,7 +183,7 @@
 							id="file-upload"
 							type="file"
 							multiple
-							accept=".pdf,.png,.doc,.jpg,.jpeg,.tif,.tiff,.xls"
+							accept=".pdf,.png,.doc,.docx,.jpg,.jpeg,.tif,.tiff,.xls,.xslx"
 							name="documents"
 						>
 


### PR DESCRIPTION

[APPLICS-1251](https://pins-ds.atlassian.net/browse/APPLICS-1251)

## Describe your changes

- .xslx and .docx added to the list of acceptable file extensions choosing a file to upload

<!--
    Issue ticket number and link
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
