### PR TITLE
Feature/applics 1647 remove expected close date

### DIFF
--- a/packages/forms-web-app/__tests__/unit/utils/is-before-or-after-date.test.js
+++ b/packages/forms-web-app/__tests__/unit/utils/is-before-or-after-date.test.js
@@ -118,7 +118,7 @@ describe('#utils/is-before-or-after-date', () => {
 					result = getDateTimeExaminationEnds(date, undefined, undefined, i18n);
 				});
 				it('should return the correct before date sentence. ', () => {
-					expect(result).toEqual('The examination is expected to close on 1 January 2022');
+					expect(result).toEqual('');
 				});
 			});
 
@@ -147,7 +147,7 @@ describe('#utils/is-before-or-after-date', () => {
 						result = getDateTimeExaminationEnds(date, extensionDate, '2022-09-14', i18n);
 					});
 					it('should return the correct before date sentence. ', () => {
-						expect(result).toEqual('The examination is expected to close on 14 March 2023');
+						expect(result).toEqual('');
 					});
 				});
 				describe('is after', () => {
@@ -186,7 +186,7 @@ describe('#utils/is-before-or-after-date', () => {
 						result = getDateTimeExaminationEnds(date, extensionDate, '2022-09-14', i18n);
 					});
 					it('should return the correct before date sentence. ', () => {
-						expect(result).toEqual('The examination is expected to close on 22 April 2022');
+						expect(result).toEqual('');
 					});
 				});
 
@@ -199,7 +199,7 @@ describe('#utils/is-before-or-after-date', () => {
 						result = getDateTimeExaminationEnds(date, extensionDate, '2022-09-14', i18n);
 					});
 					it('should return the correct before date sentence. ', () => {
-						expect(result).toEqual('The examination is expected to close on 22 April 2022');
+						expect(result).toEqual('');
 					});
 				});
 
@@ -212,7 +212,7 @@ describe('#utils/is-before-or-after-date', () => {
 						result = getDateTimeExaminationEnds(date, extensionDate, '2022-09-14', i18n);
 					});
 					it('should return the correct before date sentence. ', () => {
-						expect(result).toEqual('The examination is expected to close on 22 April 2022');
+						expect(result).toEqual('');
 					});
 				});
 
@@ -225,7 +225,7 @@ describe('#utils/is-before-or-after-date', () => {
 						result = getDateTimeExaminationEnds(date, extensionDate, '2022-09-14', i18n);
 					});
 					it('should return the correct before date sentence. ', () => {
-						expect(result).toEqual('The examination is expected to close on 22 April 2022');
+						expect(result).toEqual('');
 					});
 				});
 			});

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/_translations/cy.json
@@ -6,7 +6,6 @@
 	"examinationOpenedOn": "Agorodd yr archwiliad ar",
 	"examinationClosedOn": "Caeodd yr archwiliad ar",
 	"examinationOpensOn": "Mae'r archwiliad yn agor ar",
-	"examinationClosesOn": "Mae disgwyl i'r archwiliad gau",
 	"examinationExtendedTo": "Mae'r dyddiad cau ar gyfer cau'r Archwiliad wedi'i ymestyn i",
 	"heading3": "Terfynau amser a digwyddiadau i ddod",
 	"heading4": "Terfynau amser a digwyddiadau blaenorol",

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/_translations/en.json
@@ -6,7 +6,6 @@
 	"examinationOpenedOn": "The examination opened on",
 	"examinationClosedOn": "The examination closed on",
 	"examinationOpensOn": "The examination opens on",
-	"examinationClosesOn": "The examination is expected to close on",
 	"examinationExtendedTo": "The deadline for the close of the Examination has been extended to",
 	"heading3": "Upcoming deadlines and events",
 	"heading4": "Past deadlines and events",

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/controller.test.js
@@ -173,7 +173,7 @@ describe('pages/projects/examination-timetable/controller', () => {
 							}
 						},
 						examination: {
-							closeDate: 'The examination is expected to close on 3 January 2023',
+							closeDate: '',
 							startDate: 'The examination opened on 1 January 2023'
 						},
 						pageTitle:

--- a/packages/forms-web-app/src/utils/is-before-or-after-date.js
+++ b/packages/forms-web-app/src/utils/is-before-or-after-date.js
@@ -44,7 +44,7 @@ const isInvalidDate = (date) =>
 
 const isBeforeOrAfterSentence = (date, i18n) =>
 	isBeforeTodayUTC(date)
-		? `${i18n.t('examinationTimetable.examinationClosesOn')} ${formatDate(date)}` //The examination is expected to close on
+		? '' // The examination has not yet closed; display nothing
 		: `${i18n.t('examinationTimetable.examinationClosedOn')} ${formatDate(date)}`; //The examination closed on
 
 const getDateTimeExaminationEnds = (closeDate, extensionCloseDate, startDate, i18n) => {


### PR DESCRIPTION
## Describe your changes

[applics-1647](https://pins-ds.atlassian.net/jira/software/c/projects/APPLICS/boards/269?selectedIssue=APPLICS-1647)

This PR removes the text from the examination timetable that gives a predicted close date. We previously calculated the close date if the examination hadn't closed, and we'd display this expected close date. We now just provide a blank value if the examination hasn't closed, not informing the user when the examination is expected to close.

## Useful information to review or test

If testing locally you'll have to amend your data to have a case with a future close date.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
