### PR TITLE
fix(infrastructure): removing un-used tooling azurerm provider

### DIFF
--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -26,9 +26,3 @@ provider "azurerm" {
 
   features {}
 }
-
-provider "azurerm" {
-  alias           = "tooling"
-  subscription_id = var.tooling_config.subscription_id
-  features {}
-}


### PR DESCRIPTION
## Describe your changes

Removing un-used tooling provider from provider.tf file to resolve tflint issue - [failed pipeline](https://dev.azure.com/planninginspectorate/applications-service/_build/results?buildId=175576&view=logs&j=411e81f9-6350-50fb-4b77-6c70635528e1&t=38a4cfa0-e111-53c6-c364-da5bd3ea42f4&l=21)

Currently this provider is not in use, one data block refereeing to azurerm.tooling is commented in data.tf file

<!--
    Issue ticket number and link
-->

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
