### PR TITLE
feat(web): redirect legacy ni home pages (IDAS-415)

### DIFF
--- a/packages/ni-redirects/src/index.js
+++ b/packages/ni-redirects/src/index.js
@@ -58,6 +58,14 @@ export default {
 			// else fallthrough - no redirect
 		}
 
+		// Home page redirects (exact matches only)
+		if (path === '/') {
+			return Response.redirect(`${config.frontOfficeUrl}/`, 301);
+		}
+		if (path === '/cy/') {
+			return Response.redirect(`${config.frontOfficeUrl}/?lang=cy`, 301);
+		}
+
 		// if no redirect configured, return the original request
 		return fetch(request);
 	}


### PR DESCRIPTION
## Describe your changes

Add home page redirects to migrate traffic from the legacy infrastructure.planninginspectorate.gov.uk site to the new Find a national infrastructure service.

This implements exact-match redirects for:
- English home page: `/` → `frontOfficeUrl/`
- Welsh home page: `/cy/` → `frontOfficeUrl/?lang=cy`

Existing project and document redirects remain unchanged and functional.

## TO DO AFTER MERGED Testing & Deployment Process 

1. **Deploy to TEST environment** via NI Redirect Deploy pipeline (definition 176)
2. **Verify in TEST:**
   - AC1: English home page redirect works
   - AC2: Welsh home page redirect works
   - AC3: Existing project redirects still work
   - AC4: Existing document redirects still work
3. **Deploy to PROD** only after all ACs pass in TEST


https://pins-ds.atlassian.net/browse/IDAS-415

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
