### PR TITLE
IRP-2: postcode validation

### DIFF
--- a/packages/forms-web-app/src/locales/__snapshots__/common.test.js.snap
+++ b/packages/forms-web-app/src/locales/__snapshots__/common.test.js.snap
@@ -81,6 +81,7 @@ exports[`locales/common should return the correct English common translations 1`
     "address": {
       "countryEmpty": "Enter a country",
       "countryLength": "Country must be 64 characters or less",
+      "invalidPostcode": "Enter a postcode in the correct format, like SW1A 1AA",
       "line1Empty": "Enter address line 1",
       "line1Length": "Address line 1 must be 255 characters or less",
       "line2Length": "Address line 2 must be 96 characters or less",
@@ -196,6 +197,7 @@ exports[`locales/common should return the correct Welsh common translations 1`] 
     "address": {
       "countryEmpty": "Nodwch wlad",
       "countryLength": "Mae'n rhaid i'r wlad gynnwys 64 o nodau neu lai",
+      "invalidPostcode": "Rhowch god post yn y fformat cywir, fel SW1A 1AA",
       "line1Empty": "Nodwch linell gyfeiriad 1",
       "line1Length": "Mae'n rhaid i linell gyfeiriad 1 gynnwys 255 o nodau neu lai",
       "line2Length": "Mae'n rhaid i linell gyfeiriad 2 gynnwys 96 o nodau neu lai",

--- a/packages/forms-web-app/src/locales/cy/common.json
+++ b/packages/forms-web-app/src/locales/cy/common.json
@@ -88,6 +88,7 @@
 			"line3Length": "Mae'n rhaid i'r dref neu'r ddinas gynnwys 64 o nodau neu lai",
 			"postcodeEmpty": "Nodwch god post",
 			"postcodeLength": "Mae'n rhaid i'r cod post gynnwys 16 o nodau neu lai",
+			"invalidPostcode": "Rhowch god post yn y fformat cywir, fel SW1A 1AA",
 			"countryEmpty": "Nodwch wlad",
 			"countryLength": "Mae'n rhaid i'r wlad gynnwys 64 o nodau neu lai"
 		},

--- a/packages/forms-web-app/src/locales/en/common.json
+++ b/packages/forms-web-app/src/locales/en/common.json
@@ -88,6 +88,7 @@
 			"line3Length": "Town or city must be 64 characters or less",
 			"postcodeEmpty": "Enter a postcode",
 			"postcodeLength": "Postcode must be 16 characters or less",
+			"invalidPostcode": "Enter a postcode in the correct format, like SW1A 1AA",
 			"countryEmpty": "Enter a country",
 			"countryLength": "Country must be 64 characters or less"
 		},

--- a/packages/forms-web-app/src/validators/shared/address.js
+++ b/packages/forms-web-app/src/validators/shared/address.js
@@ -33,6 +33,13 @@ const rules = () => {
 			.withMessage((_, { req }) => {
 				return req.i18n.t('common.validationErrors.address.postcodeLength');
 			}),
+		body('postcode')
+			.trim()
+			.customSanitizer((value) => value.toUpperCase().replace(/\s+/g, ' '))
+			.matches(/^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i)
+			.withMessage((_, { req }) => {
+				return req.i18n.t('common.validationErrors.address.invalidPostcode');
+			}),
 		body('country')
 			.notEmpty()
 			.withMessage((_, { req }) => {


### PR DESCRIPTION
## Describe your changes
Implemented a validation regex on postcodes via the express-validation validator that the app uses
<!--
    Issue ticket number and link
-->
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/IRP/boards/1363?selectedIssue=IRP-2

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

Note that this is for the applications-service repository. Seems like back-office does have a postcode format validator in place in packages/platform/postcode.js but please confirm with Eoin as I believe he raised this ticket

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
