### PR TITLE
chore(app): remove migration code from forms web app

### DIFF
--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -66,7 +66,6 @@ module.exports = {
 		openRegistrationCaseReferences: splitStringToArray(
 			process.env.OPEN_REGISTRATION_CASE_REFERENCES
 		),
-		allowApplicationsPagination: process.env.BACK_OFFICE_INTEGRATION_GET_APPLICATIONS !== 'MERGE',
 		allowWelshTranslation: process.env.FEATURE_ALLOW_WELSH_TRANSLATION === 'true',
 		allowWelshCases: process.env.FEATURE_ALLOW_WELSH_CASES === 'true',
 		enableProjectsMap: process.env.FEATURE_ENABLE_PROJECTS_MAP === 'true',

--- a/packages/forms-web-app/src/pages/project-search/view.njk
+++ b/packages/forms-web-app/src/pages/project-search/view.njk
@@ -47,17 +47,9 @@
 				{% include "./includes/active-filters.njk" %}
 
 				{% if applications | length %}
-
-					{% if featureFlag.allowApplicationsPagination == true %}
-						{% include "./includes/results-per-page.njk" %}
-					{% endif %}
-
+					{% include "./includes/results-per-page.njk" %}
 					{% include "./includes/projects.njk" %}
-
-					{% if featureFlag.allowApplicationsPagination == true %}
-						{% include "./includes/pagination.njk" %}
-					{% endif %}
-
+					{% include "./includes/pagination.njk" %}
 				{% else %}
 
 					{% include "./includes/no-matching-results.njk" %}

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/controller.js
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/controller.js
@@ -1,5 +1,4 @@
 const logger = require('../../../lib/logger');
-const { getProjectData } = require('../../../lib/application-api-wrapper');
 const { getPageData } = require('./_utils/get-page-data');
 const {
 	routesConfig: {
@@ -22,9 +21,8 @@ const getProjectsExaminationTimetableController = async (req, res) => {
 	try {
 		const { params, i18n } = req;
 		const { case_ref } = params;
-		const { data } = await getProjectData(case_ref);
-		const examinationTimetableData = data;
-		const projectName = res.locals.applicationData.projectName;
+		const examinationTimetableData = res.locals.applicationData;
+		const projectName = examinationTimetableData.projectName;
 		const pageData = getPageData(case_ref, projectName, examinationTimetableData, i18n);
 
 		return res.render(view, {

--- a/packages/forms-web-app/src/pages/projects/examination-timetable/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects/examination-timetable/controller.test.js
@@ -3,7 +3,6 @@ const {
 	postProjectsExaminationTimetableController
 } = require('./controller');
 
-const { getProjectData } = require('../../../lib/application-api-wrapper');
 const { getTimetables } = require('../../../lib/application-api-wrapper');
 const { mockI18n } = require('../../_mocks/i18n');
 
@@ -42,7 +41,13 @@ describe('pages/projects/examination-timetable/controller', () => {
 				render: jest.fn(),
 				locals: {
 					applicationData: {
-						projectName: 'mock project name'
+						projectName: 'mock project name',
+						CaseReference: 'mock_case_ref',
+						ConfirmedStartOfExamination: '2023-01-01',
+						DateTimeExaminationEnds: '2023-01-03',
+						dateOfNonAcceptance: '2023-01-01',
+						ProjectName: 'mock project name',
+						PromoterName: 'mock promoter name'
 					}
 				}
 			};
@@ -50,17 +55,6 @@ describe('pages/projects/examination-timetable/controller', () => {
 		describe('When getting the examination table page', () => {
 			describe('and there are no issues', () => {
 				beforeEach(async () => {
-					getProjectData.mockResolvedValue({
-						data: {
-							CaseReference: 'mock_case_ref',
-							ConfirmedStartOfExamination: '2023-01-01',
-							DateTimeExaminationEnds: '2023-01-03',
-							dateOfNonAcceptance: '2023-01-01',
-							ProjectName: 'mock project name',
-							PromoterName: 'mock promoter name'
-						}
-					});
-
 					getTimetables.mockResolvedValue({
 						data: {
 							timetables: [
@@ -188,13 +182,11 @@ describe('pages/projects/examination-timetable/controller', () => {
 				});
 			});
 			describe('and there is an issue', () => {
-				beforeEach(async () => {
-					getProjectData.mockResolvedValue(() => {
-						throw new Error('something went wrong');
-					});
+				it('should render the error page', async () => {
+					res.locals.applicationData = null;
+
 					await getProjectsExaminationTimetableController(req, res);
-				});
-				it('should render the error page', () => {
+
 					expect(res.render).toHaveBeenCalledWith('error/unhandled-exception');
 					expect(res.status).toHaveBeenLastCalledWith(500);
 				});

--- a/packages/forms-web-app/src/pages/register-of-applications/view.njk
+++ b/packages/forms-web-app/src/pages/register-of-applications/view.njk
@@ -27,17 +27,9 @@
 		{% include "./includes/search.njk" %}
 
 		{% if applications | length %}
-
-			{% if featureFlag.allowApplicationsPagination == true %}
-				{% include "./includes/results-per-page.njk" %}
-			{% endif %}
-
+			{% include "./includes/results-per-page.njk" %}
 			{% include "./includes/applications-table.njk" %}
-
-			{% if featureFlag.allowApplicationsPagination == true %}
-				{% include "./includes/pagination.njk" %}
-			{% endif %}
-
+			{% include "./includes/pagination.njk" %}
 		{% else %}
 			{% include "./includes/no-matching-results.njk" %}
 		{% endif %}


### PR DESCRIPTION
## Describe your changes

https://pins-ds.atlassian.net/browse/IRP-71
https://pins-ds.atlassian.net/browse/IRP-72

Remove API call from examination controller and use res.locals data instead
Remove usage of BACK_OFFICE_INTEGRATION_GET_APPLICATIONS flag
Update tests to reflect change to examinationTimetableData source 