### PR TITLE
Fix/idas 28 prevent duplicate rhys reps

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/views.test.js
@@ -23,6 +23,7 @@ describe('lib/views', () => {
 					EMAIL_ADDRESS: 'register/myself/email-address',
 					CHECK_YOUR_ANSWERS: 'register/myself/check-answers',
 					DECLARATION: 'register/myself/declaration',
+					PROCESS_SUBMISSION: 'register/myself/process-submission',
 					REGISTRATION_COMPLETE: 'register/myself/registration-complete',
 					ALREADY_REGISTERED: 'register/myself/already-registered'
 				},
@@ -33,6 +34,7 @@ describe('lib/views', () => {
 					EMAIL: 'register/organisation/email-address',
 					CHECK_YOUR_ANSWERS: 'register/organisation/check-answers',
 					DECLARATION: 'register/organisation/declaration',
+					PROCESS_SUBMISSION: 'register/organisation/process-submission',
 					REGISTRATION_COMPLETE: 'register/organisation/registration-complete',
 					ALREADY_REGISTERED: 'register/organisation/already-registered'
 				},
@@ -44,6 +46,7 @@ describe('lib/views', () => {
 					ORGANISATION_NAME: 'register/agent/name-of-organisation',
 					CHECK_YOUR_ANSWERS: 'register/agent/check-answers',
 					DECLARATION: 'register/agent/declaration',
+					PROCESS_SUBMISSION: 'register/agent/process-submission',
 					REGISTRATION_COMPLETE: 'register/agent/registration-complete',
 					ALREADY_REGISTERED: 'register/agent/already-registered'
 				}

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -19,6 +19,7 @@ const VIEW = {
 			EMAIL_ADDRESS: 'register/myself/email-address',
 			CHECK_YOUR_ANSWERS: 'register/myself/check-answers',
 			DECLARATION: 'register/myself/declaration',
+			PROCESS_SUBMISSION: 'register/myself/process-submission',
 			REGISTRATION_COMPLETE: 'register/myself/registration-complete',
 			ALREADY_REGISTERED: 'register/myself/already-registered'
 		},
@@ -29,6 +30,7 @@ const VIEW = {
 			EMAIL: 'register/organisation/email-address',
 			CHECK_YOUR_ANSWERS: 'register/organisation/check-answers',
 			DECLARATION: 'register/organisation/declaration',
+			PROCESS_SUBMISSION: 'register/organisation/process-submission',
 			REGISTRATION_COMPLETE: 'register/organisation/registration-complete',
 			ALREADY_REGISTERED: 'register/organisation/already-registered'
 		},
@@ -40,6 +42,7 @@ const VIEW = {
 			ORGANISATION_NAME: 'register/agent/name-of-organisation',
 			CHECK_YOUR_ANSWERS: 'register/agent/check-answers',
 			DECLARATION: 'register/agent/declaration',
+			PROCESS_SUBMISSION: 'register/agent/process-submission',
 			REGISTRATION_COMPLETE: 'register/agent/registration-complete',
 			ALREADY_REGISTERED: 'register/agent/already-registered'
 		}

--- a/packages/forms-web-app/src/pages/examination/process-submission/view.njk
+++ b/packages/forms-web-app/src/pages/examination/process-submission/view.njk
@@ -22,14 +22,14 @@
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-two-thirds">
 			<div class="visible-on visible-on--js-enabled">
+				{{ centredTitleSubtitle(t("examination.processingSubmission.heading1"), submittingItemsSubtitle) }}
+
+				{{ indicatorLoadingSpinner() }}
+
 				{{ govukWarningText({
 					text: t("examination.processingSubmission.warningTextJSEnabled"),
 					iconFallbackText: t("common.warning")
 				}) }}
-
-				{{ indicatorLoadingSpinner() }}
-
-				{{ centredTitleSubtitle(t("examination.processingSubmission.heading1"), submittingItemsSubtitle) }}
 
 				<form method="POST">
 					{{ govukButton({

--- a/packages/forms-web-app/src/pages/projects/register/_common/declaration/_utils/get-redirect-url.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/declaration/_utils/get-redirect-url.js
@@ -1,5 +1,5 @@
 const { VIEW } = require('../../../../../../lib/views');
-const getRedirectUrl = (key) => `/${VIEW.REGISTER[key.toUpperCase()].REGISTRATION_COMPLETE}`;
+const getRedirectUrl = (key) => `/${VIEW.REGISTER[key.toUpperCase()].PROCESS_SUBMISSION}`;
 
 const getAlreadySubmittedUrl = (key) => `/${VIEW.REGISTER[key.toUpperCase()].ALREADY_REGISTERED}`;
 

--- a/packages/forms-web-app/src/pages/projects/register/_common/declaration/controller.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/declaration/controller.js
@@ -1,15 +1,9 @@
-const { postRegistration } = require('../../../../../lib/application-api-wrapper');
 const logger = require('../../../../../lib/logger');
 const { getKeyFromUrl } = require('../../../../../controllers/register/common/get-key-from-url');
-const {
-	getSessionBase,
-	setSession,
-	getSession
-} = require('../../../../../controllers/register/common/session');
+const { getSession } = require('../../../../../controllers/register/common/session');
 const { getRedirectUrl, getAlreadySubmittedUrl } = require('./_utils/get-redirect-url');
 
 const view = 'projects/register/_common/declaration/view.njk';
-const hasSubmittedKey = 'hasSubmitted';
 
 const getRegisterDeclarationController = (req, res) => {
 	try {
@@ -22,7 +16,8 @@ const getRegisterDeclarationController = (req, res) => {
 		}
 
 		return res.render(view, {
-			key
+			key,
+			nextPageUrl: `${res.locals.baseUrl}${getRedirectUrl(key)}`
 		});
 	} catch (e) {
 		logger.error(e);
@@ -30,32 +25,6 @@ const getRegisterDeclarationController = (req, res) => {
 	}
 };
 
-const postRegisterDeclarationController = async (req, res) => {
-	try {
-		const { session, params } = req;
-		const { case_ref } = params;
-		const key = getKeyFromUrl(req.originalUrl);
-
-		const sessionForKey = getSessionBase(session, key);
-		sessionForKey.case_ref = case_ref;
-
-		const registrationData = {
-			...sessionForKey,
-			comment: session.comment
-		};
-
-		const response = await postRegistration(JSON.stringify(registrationData));
-		sessionForKey.ipRefNo = response.data?.referenceId;
-
-		setSession(session, key, hasSubmittedKey, true);
-		return res.redirect(`${res.locals.baseUrl}${getRedirectUrl(key)}`);
-	} catch (e) {
-		logger.error(`Could not Post declaration, internal error occurred ${e}`);
-		return res.status(500).render('error/have-your-say-journey-error');
-	}
-};
-
 module.exports = {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
+	getRegisterDeclarationController
 };

--- a/packages/forms-web-app/src/pages/projects/register/_common/declaration/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/declaration/controller.test.js
@@ -1,12 +1,5 @@
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('./controller');
-const { postRegistration } = require('../../../../../lib/application-api-wrapper');
+const { getRegisterDeclarationController } = require('./controller');
 
-jest.mock('../../../../../../src/lib/application-api-wrapper', () => ({
-	postRegistration: jest.fn()
-}));
 describe('pages/projects/register/_common/declaration/controller', () => {
 	describe('#getRegisterDeclarationController', () => {
 		describe('When getting the declaration', () => {
@@ -30,7 +23,8 @@ describe('pages/projects/register/_common/declaration/controller', () => {
 					expect(res.render).toHaveBeenCalledWith(
 						'projects/register/_common/declaration/view.njk',
 						{
-							key: 'myself'
+							key: 'myself',
+							nextPageUrl: '/mock-base-url/mock-case-ref/register/myself/process-submission'
 						}
 					);
 				});
@@ -49,7 +43,8 @@ describe('pages/projects/register/_common/declaration/controller', () => {
 					expect(res.render).toHaveBeenCalledWith(
 						'projects/register/_common/declaration/view.njk',
 						{
-							key: 'organisation'
+							key: 'organisation',
+							nextPageUrl: '/mock-base-url/mock-case-ref/register/organisation/process-submission'
 						}
 					);
 				});
@@ -68,7 +63,8 @@ describe('pages/projects/register/_common/declaration/controller', () => {
 					expect(res.render).toHaveBeenCalledWith(
 						'projects/register/_common/declaration/view.njk',
 						{
-							key: 'agent'
+							key: 'agent',
+							nextPageUrl: '/mock-base-url/mock-case-ref/register/agent/process-submission'
 						}
 					);
 				});
@@ -149,54 +145,6 @@ describe('pages/projects/register/_common/declaration/controller', () => {
 				expect(() => getRegisterDeclarationController(req, res)).toThrowError(
 					"Cannot read properties of undefined (reading 'split')"
 				);
-			});
-		});
-	});
-
-	describe('#postRegisterDeclarationController', () => {
-		describe('When posting declaration', () => {
-			const res = {
-				locals: { baseUrl: '/mock-base-url/mock-case-ref' },
-				render: jest.fn(),
-				redirect: jest.fn(),
-				status: jest.fn(() => res),
-				send: jest.fn()
-			};
-			describe('and there is an unrecoverable error', () => {
-				const req = { params: { case_ref: 'mock case ref' } };
-				beforeEach(() => {
-					postRegisterDeclarationController(req, res);
-				});
-
-				it('should render the error page', () => {
-					expect(res.render).toHaveBeenCalledWith('error/have-your-say-journey-error');
-				});
-			});
-			describe('and the user has submitted a declaration for myself', () => {
-				const req = {
-					originalUrl: '/mock-base-url/mock-case-ref/register/myself/declaration',
-					params: { case_ref: 'mock case ref' },
-					session: {
-						comment: 'mock comment',
-						mode: 'mock session mode',
-						caseRef: 'mock case ref',
-						mySelfRegdata: { text: 'mock session key data' }
-					}
-				};
-				beforeEach(async () => {
-					postRegistration.mockResolvedValue({ data: 'mock ip ref no from endpoint' });
-					await postRegisterDeclarationController(req, res);
-				});
-				it('should get he ip ref no from the interested party endpoint ', () => {
-					expect(postRegistration).toHaveBeenCalledWith(
-						'{"text":"mock session key data","case_ref":"mock case ref","comment":"mock comment"}'
-					);
-				});
-				it('should redirect to the next page for myself', () => {
-					expect(res.redirect).toHaveBeenCalledWith(
-						'/mock-base-url/mock-case-ref/register/myself/registration-complete'
-					);
-				});
 			});
 		});
 	});

--- a/packages/forms-web-app/src/pages/projects/register/_common/declaration/view.njk
+++ b/packages/forms-web-app/src/pages/projects/register/_common/declaration/view.njk
@@ -43,16 +43,9 @@
 				{{ t('register.declaration.paragraph5') }}
 			</p>
 
-			<form autocomplete="off" method="post" novalidate>
-				<input type="hidden" name="declaration-confirmed" value="true">
-
-				{{ govukButton({
-					text: t('common.acceptAndContinue'),
-					type: "Submit",
-  				preventDoubleClick: true,
-					attributes: { "data-cy": "button-accept-and-register"}
-				}) }}
-			</form>
+			<a class="govuk-button" data-cy="button-accept-and-register" href="{{ nextPageUrl }}">
+				{{ t('common.acceptAndContinue') }}
+			</a>
 		</div>
 	</div>
 {% endblock %}

--- a/packages/forms-web-app/src/pages/projects/register/_common/process-submission/_utils/get-redirect-url.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/process-submission/_utils/get-redirect-url.js
@@ -1,0 +1,5 @@
+const { VIEW } = require('../../../../../../lib/views');
+const getRedirectUrl = (key) => `/${VIEW.REGISTER[key.toUpperCase()].REGISTRATION_COMPLETE}`;
+module.exports = {
+	getRedirectUrl
+};

--- a/packages/forms-web-app/src/pages/projects/register/_common/process-submission/config.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/process-submission/config.js
@@ -1,0 +1,3 @@
+const registerProcessSubmissionRoute = 'process-submission';
+
+module.exports = { registerProcessSubmissionRoute };

--- a/packages/forms-web-app/src/pages/projects/register/_common/process-submission/controller.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/process-submission/controller.js
@@ -1,0 +1,50 @@
+const { postRegistration } = require('../../../../../lib/application-api-wrapper');
+const logger = require('../../../../../lib/logger');
+const { getKeyFromUrl } = require('../../../../../controllers/register/common/get-key-from-url');
+const {
+	getSessionBase,
+	setSession
+} = require('../../../../../controllers/register/common/session');
+const { getRedirectUrl } = require('./_utils/get-redirect-url');
+
+const view = 'projects/register/_common/process-submission/view.njk';
+const hasSubmittedKey = 'hasSubmitted';
+
+const getProcessSubmission = (req, res) => {
+	try {
+		const key = getKeyFromUrl(req.originalUrl);
+		return res.render(view, { key });
+	} catch (e) {
+		logger.error(e);
+		return res.status(500).render('error/unhandled-exception');
+	}
+};
+
+const postProcessSubmission = async (req, res) => {
+	try {
+		const { session, params } = req;
+		const { case_ref } = params;
+		const key = getKeyFromUrl(req.originalUrl);
+
+		const sessionForKey = getSessionBase(session, key);
+		sessionForKey.case_ref = case_ref;
+
+		const registrationData = {
+			...sessionForKey,
+			comment: session.comment
+		};
+
+		const response = await postRegistration(JSON.stringify(registrationData));
+		sessionForKey.ipRefNo = response.data?.referenceId;
+
+		setSession(session, key, hasSubmittedKey, true);
+		return res.redirect(`${res.locals.baseUrl}${getRedirectUrl(key)}`);
+	} catch (e) {
+		logger.error(`Could not process registration submission, internal error occurred ${e}`);
+		return res.status(500).render('error/have-your-say-journey-error');
+	}
+};
+module.exports = {
+	getProcessSubmission,
+	postProcessSubmission
+};

--- a/packages/forms-web-app/src/pages/projects/register/_common/process-submission/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects/register/_common/process-submission/controller.test.js
@@ -1,0 +1,83 @@
+const { getProcessSubmission, postProcessSubmission } = require('./controller');
+const { postRegistration } = require('../../../../../lib/application-api-wrapper');
+jest.mock('../../../../../lib/application-api-wrapper', () => ({
+	postRegistration: jest.fn()
+}));
+describe('pages/projects/register/_common/process-submission/controller', () => {
+	describe('#getProcessSubmission', () => {
+		const res = {
+			render: jest.fn(),
+			status: jest.fn(() => res)
+		};
+		describe('and the user has selected myself', () => {
+			const req = {
+				originalUrl: '/mock-base-url/mock-case-ref/register/myself/process-submission'
+			};
+			beforeEach(() => {
+				getProcessSubmission(req, res);
+			});
+			it('should render the process-submission view', () => {
+				expect(res.render).toHaveBeenCalledWith(
+					'projects/register/_common/process-submission/view.njk',
+					{ key: 'myself' }
+				);
+			});
+		});
+	});
+	describe('#postProcessSubmission', () => {
+		describe('when submission is successful', () => {
+			const res = {
+				locals: { baseUrl: '/mock-base-url/mock-case-ref' },
+				render: jest.fn(),
+				redirect: jest.fn(),
+				status: jest.fn(() => res)
+			};
+			const req = {
+				originalUrl: '/mock-base-url/mock-case-ref/register/myself/process-submission',
+				params: { case_ref: 'mock-case-ref' },
+				session: {
+					comment: 'mock comment',
+					mySelfRegdata: { text: 'mock data' }
+				}
+			};
+			beforeEach(async () => {
+				postRegistration.mockResolvedValue({ data: { referenceId: 'IP-REF-123' } });
+				await postProcessSubmission(req, res);
+			});
+			it('should call postRegistration with the correct data', () => {
+				expect(postRegistration).toHaveBeenCalledWith(
+					expect.stringContaining('"case_ref":"mock-case-ref"')
+				);
+			});
+			it('should redirect to the registration-complete page', () => {
+				expect(res.redirect).toHaveBeenCalledWith(
+					'/mock-base-url/mock-case-ref/register/myself/registration-complete'
+				);
+			});
+		});
+		describe('when submission fails', () => {
+			const res = {
+				locals: { baseUrl: '/mock-base-url/mock-case-ref' },
+				render: jest.fn(),
+				redirect: jest.fn(),
+				status: jest.fn(() => res)
+			};
+			const req = {
+				originalUrl: '/mock-base-url/mock-case-ref/register/myself/process-submission',
+				params: { case_ref: 'mock-case-ref' },
+				session: {
+					comment: 'mock comment',
+					mySelfRegdata: { text: 'mock data' }
+				}
+			};
+			beforeEach(async () => {
+				postRegistration.mockRejectedValue(new Error('API error'));
+				await postProcessSubmission(req, res);
+			});
+			it('should render the error page', () => {
+				expect(res.status).toHaveBeenCalledWith(500);
+				expect(res.render).toHaveBeenCalledWith('error/have-your-say-journey-error');
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/src/pages/projects/register/_common/process-submission/view.njk
+++ b/packages/forms-web-app/src/pages/projects/register/_common/process-submission/view.njk
@@ -1,0 +1,70 @@
+{% extends "layouts/default.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% from "components/indicator/loading-spinner.njk" import indicatorLoadingSpinner %}
+{% from "components/text/centred-title-subtitle.njk" import centredTitleSubtitle %}
+
+{% set pageTitle = t("register.processSubmission.title") %}
+
+{% block script %}
+	{% set initiateScriptsConfig = (initiateScriptsConfig.push(
+		{
+			callback: "var simulateUser = new appScripts.simulateUserAction(); simulateUser.click('#page-process-submission-submit-button')",
+			src: "/public/scripts/simulateUserAction.script.js"
+		}
+	), initiateScriptsConfig) %}
+{% endblock %}
+
+{% block content %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds">
+			<div class="visible-on visible-on--js-enabled">
+				{{ centredTitleSubtitle(t("register.processSubmission.heading1"), t("register.processSubmission.subTitle")) }}
+
+				{{ indicatorLoadingSpinner() }}
+
+				{{ govukWarningText({
+					text: t("register.processSubmission.warningTextJSEnabled"),
+					iconFallbackText: t("common.warning")
+				}) }}
+
+				<form method="POST">
+					{{ govukButton({
+						attributes: { id: 'page-process-submission-submit-button', style: 'display: none;' },
+						preventDoubleClick: true,
+						text: t("register.processSubmission.ctaText1"),
+						type: "Submit"
+						}) }}
+				</form>
+
+			</div>
+
+			<noscript>
+				<h1 class="govuk-heading-l">
+					{{ t("register.processSubmission.heading1NoScript") }}
+				</h1>
+
+				<p class="govuk-body">
+					{{ t("register.processSubmission.paragraph1") }}
+				</p>
+
+				{{ govukWarningText({
+					text: t("register.processSubmission.warningTextNoScript"),
+					iconFallbackText: t("common.warning")
+					}) }}
+
+				<form method="POST">
+					{{ govukButton({
+						attributes: { id: 'page-process-submission-submit-button' },
+						preventDoubleClick: true,
+						text: t("register.processSubmission.ctaText1"),
+						type: "Submit"
+						}) }}
+
+				</form>
+			</noscript>
+		</div>
+	</div>
+{% endblock %}

--- a/packages/forms-web-app/src/pages/projects/register/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/projects/register/_translations/__snapshots__/translations.test.js.snap
@@ -201,6 +201,16 @@ exports[`pages/cookies/_translations should return the correct English translati
     "hint": "We will publish your organisation name on the website along with your comments about the project.",
     "pageHeading": "What is the name of your organisation or charity?",
   },
+  "processSubmission": {
+    "ctaText1": "Process registration",
+    "heading1": "Processing registration",
+    "heading1NoScript": "Process registration",
+    "paragraph1": "This may take several minutes.",
+    "subTitle": "This may take several minutes",
+    "title": "Processing registration",
+    "warningTextJSEnabled": " Do not refresh or navigate away from this page.",
+    "warningTextNoScript": "Do not refresh or navigate away from this page.",
+  },
   "registerFor": {
     "option1": "Myself",
     "option2": "An organisation I work or volunteer for",
@@ -481,6 +491,16 @@ exports[`pages/cookies/_translations should return the correct Welsh translation
   "organisationOrCharityName": {
     "hint": "Byddwn yn cyhoeddi enw eich sefydliad ar y wefan ynghyd â'ch sylwadau ynglŷn â'r prosiect.",
     "pageHeading": "Beth yw enw eich sefydliad neu'ch elusen?",
+  },
+  "processSubmission": {
+    "ctaText1": "Prosesu cofrestriad",
+    "heading1": "Wrthi’n prosesu’r cofrestriad",
+    "heading1NoScript": "Prosesu cofrestriad",
+    "paragraph1": "Gall hyn gymryd ychydig funudau.",
+    "subTitle": "Gall hyn gymryd ychydig funudau",
+    "title": "Wrthi’n prosesu’r cofrestriad",
+    "warningTextJSEnabled": "Peidiwch â diweddaru na symud i ffwrdd o’r dudalen hon.",
+    "warningTextNoScript": "Peidiwch â diweddaru na symud i ffwrdd o’r dudalen hon.",
   },
   "registerFor": {
     "option1": "Fi fy hun",

--- a/packages/forms-web-app/src/pages/projects/register/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/register/_translations/cy.json
@@ -207,6 +207,16 @@
 		"comments": "Sylwadau cofrestru",
 		"changeCommentsHiddenText": "sylwadau cofrestru"
 	},
+	"processSubmission": {
+		"title": "Wrthi’n prosesu’r cofrestriad",
+		"heading1": "Wrthi’n prosesu’r cofrestriad",
+		"heading1NoScript": "Prosesu cofrestriad",
+		"subTitle": "Gall hyn gymryd ychydig funudau",
+		"paragraph1": "Gall hyn gymryd ychydig funudau.",
+		"ctaText1": "Prosesu cofrestriad",
+		"warningTextJSEnabled": "Peidiwch â diweddaru na symud i ffwrdd o’r dudalen hon.",
+		"warningTextNoScript": "Peidiwch â diweddaru na symud i ffwrdd o’r dudalen hon."
+	},
 	"declaration": {
 		"pageHeading": "Datganiad",
 		"paragraph1": "Trwy gyflwyno'r ffurflen hon, rydych yn cofrestru i leisio'ch barn a rhoi eich sylwadau cofrestru i ni.",

--- a/packages/forms-web-app/src/pages/projects/register/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/register/_translations/en.json
@@ -207,6 +207,16 @@
 		"comments": "Registration comments",
 		"changeCommentsHiddenText": "registration comments"
 	},
+	"processSubmission": {
+		"title": "Processing registration",
+		"heading1": "Processing registration",
+		"heading1NoScript": "Process registration",
+		"subTitle": "This may take several minutes",
+		"paragraph1": "This may take several minutes.",
+		"ctaText1": "Process registration",
+		"warningTextJSEnabled": " Do not refresh or navigate away from this page.",
+		"warningTextNoScript": "Do not refresh or navigate away from this page."
+	},
 	"declaration": {
 		"pageHeading": "Declaration",
 		"paragraph1": "By submitting this form, you are registering to have your say and telling us your registration comments.",

--- a/packages/forms-web-app/src/pages/projects/register/agent/process-submission/_utils/get-register-agent-process-submission-url.js
+++ b/packages/forms-web-app/src/pages/projects/register/agent/process-submission/_utils/get-register-agent-process-submission-url.js
@@ -1,0 +1,7 @@
+const { registerProcessSubmissionRoute } = require('../../../_common/process-submission/config');
+const { getRegisterAgentURL } = require('../../_utils/get-register-agent-url');
+const getRegisterAgentProcessSubmissionURL = (caseRef) => {
+	const registerAgentURL = getRegisterAgentURL(caseRef);
+	return `${registerAgentURL}/${registerProcessSubmissionRoute}`;
+};
+module.exports = { getRegisterAgentProcessSubmissionURL };

--- a/packages/forms-web-app/src/pages/projects/register/agent/router.js
+++ b/packages/forms-web-app/src/pages/projects/register/agent/router.js
@@ -49,11 +49,12 @@ const {
 	postRegisterAgentTheirTelephoneController
 } = require('./their-telephone/controller');
 const { getRegisterAgentCheckAnswersController } = require('./check-answers/controller');
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('../_common/declaration/controller');
+const { getRegisterDeclarationController } = require('../_common/declaration/controller');
 const { getRegisterCompleteController } = require('../_common/complete/controller');
+const {
+	getProcessSubmission,
+	postProcessSubmission
+} = require('../_common/process-submission/controller');
 const {
 	getRegisterAlreadyRegisteredController
 } = require('../_common/already-registered/controller');
@@ -98,6 +99,9 @@ const {
 const {
 	getRegisterAgentDeclarationURL
 } = require('./declaration/_utils/get-register-agent-declaration-url');
+const {
+	getRegisterAgentProcessSubmissionURL
+} = require('./process-submission/_utils/get-register-agent-process-submission-url');
 const {
 	getRegisterAgentCompleteURL
 } = require('./complete/_utils/get-register-agent-complete-url');
@@ -156,6 +160,7 @@ const registerAgentAboutProjectURL = getRegisterAgentAboutProjectURL();
 const registerAgentTheirTelephoneURL = getRegisterAgentTheirTelephoneURL();
 const registerAgentCheckAnswersURL = getRegisterAgentCheckAnswersURL();
 const registerAgentDeclarationURL = getRegisterAgentDeclarationURL();
+const registerAgentProcessSubmissionURL = getRegisterAgentProcessSubmissionURL();
 const registerAgentCompleteURL = getRegisterAgentCompleteURL();
 const registerAgentAlreadyRegisteredURL = getRegisterAgentAlreadyRegisteredURL();
 
@@ -387,11 +392,19 @@ registerAgentRouter.get(
 	registerMiddleware,
 	getRegisterDeclarationController
 );
+
+registerAgentRouter.get(
+	registerAgentProcessSubmissionURL,
+	registerStartRedirectMiddleware,
+	noCache,
+	registerMiddleware,
+	getProcessSubmission
+);
 registerAgentRouter.post(
-	registerAgentDeclarationURL,
+	registerAgentProcessSubmissionURL,
 	registerStartRedirectMiddleware,
 	registerMiddleware,
-	postRegisterDeclarationController
+	postProcessSubmission
 );
 
 registerAgentRouter.get(

--- a/packages/forms-web-app/src/pages/projects/register/agent/router.test.js
+++ b/packages/forms-web-app/src/pages/projects/register/agent/router.test.js
@@ -47,11 +47,12 @@ const {
 	postRegisterAgentTheirTelephoneController
 } = require('./their-telephone/controller');
 const { getRegisterAgentCheckAnswersController } = require('./check-answers/controller');
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('../_common/declaration/controller');
+const { getRegisterDeclarationController } = require('../_common/declaration/controller');
 const { getRegisterCompleteController } = require('../_common/complete/controller');
+const {
+	getProcessSubmission,
+	postProcessSubmission
+} = require('../_common/process-submission/controller');
 const {
 	getRegisterAlreadyRegisteredController
 } = require('../_common/already-registered/controller');
@@ -401,11 +402,19 @@ describe('pages/projects/register/agent/router', () => {
 				registerMiddleware,
 				getRegisterDeclarationController
 			);
+
+			expect(get).toHaveBeenCalledWith(
+				'/projects/:case_ref/register/agent/process-submission',
+				registerStartRedirectMiddleware,
+				noCache,
+				registerMiddleware,
+				getProcessSubmission
+			);
 			expect(post).toHaveBeenCalledWith(
-				'/projects/:case_ref/register/agent/declaration',
+				'/projects/:case_ref/register/agent/process-submission',
 				registerStartRedirectMiddleware,
 				registerMiddleware,
-				postRegisterDeclarationController
+				postProcessSubmission
 			);
 
 			expect(get).toHaveBeenCalledWith(
@@ -422,7 +431,7 @@ describe('pages/projects/register/agent/router', () => {
 				getRegisterAlreadyRegisteredController
 			);
 
-			expect(get).toBeCalledTimes(18);
+			expect(get).toBeCalledTimes(19);
 			expect(post).toBeCalledTimes(15);
 			expect(use).toBeCalledTimes(0);
 		});

--- a/packages/forms-web-app/src/pages/projects/register/myself/process-submission/_utils/get-register-myself-process-submission-url.js
+++ b/packages/forms-web-app/src/pages/projects/register/myself/process-submission/_utils/get-register-myself-process-submission-url.js
@@ -1,0 +1,7 @@
+const { registerProcessSubmissionRoute } = require('../../../_common/process-submission/config');
+const { getRegisterMyselfURL } = require('../../_utils/get-register-myself-url');
+const getRegisterMyselfProcessSubmissionURL = (caseRef) => {
+	const registerMyselfURL = getRegisterMyselfURL(caseRef);
+	return `${registerMyselfURL}/${registerProcessSubmissionRoute}`;
+};
+module.exports = { getRegisterMyselfProcessSubmissionURL };

--- a/packages/forms-web-app/src/pages/projects/register/myself/router.js
+++ b/packages/forms-web-app/src/pages/projects/register/myself/router.js
@@ -25,11 +25,12 @@ const {
 	postRegisterMyselfAboutProjectController
 } = require('./about-project/controller');
 const { getRegisterMyselfCheckAnswersController } = require('./check-answers/controller');
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('../_common/declaration/controller');
+const { getRegisterDeclarationController } = require('../_common/declaration/controller');
 const { getRegisterCompleteController } = require('../_common/complete/controller');
+const {
+	getProcessSubmission,
+	postProcessSubmission
+} = require('../_common/process-submission/controller');
 const {
 	getRegisterAlreadyRegisteredController
 } = require('../_common/already-registered/controller');
@@ -50,6 +51,9 @@ const {
 const {
 	getRegisterMyselfDeclarationURL
 } = require('./declaration/_utils/get-register-myself-declaration-url');
+const {
+	getRegisterMyselfProcessSubmissionURL
+} = require('./process-submission/_utils/get-register-myself-process-submission-url');
 const {
 	getRegisterMyselfCompleteURL
 } = require('./complete/_utils/get-register-myself-complete-url');
@@ -81,6 +85,7 @@ const registerMyselfEmailURL = getRegisterMyselfEmailURL();
 const registerMyselfAddressURL = getRegisterMyselfAddressURL();
 const registerMyselfNumberURL = getRegisterMyselfNumberURL();
 const registerMyselfDeclarationURL = getRegisterMyselfDeclarationURL();
+const registerMyselfProcessSubmissionURL = getRegisterMyselfProcessSubmissionURL();
 const registerMyselfCompleteURL = getRegisterMyselfCompleteURL();
 const registerMyselfAboutProjectURL = getRegisterMyselfAboutProjectURL();
 const registerMyselfCheckAnswersURL = getRegisterMyselfCheckAnswersURL();
@@ -194,11 +199,19 @@ registerMyselfRouter.get(
 	registerMiddleware,
 	getRegisterDeclarationController
 );
+
+registerMyselfRouter.get(
+	registerMyselfProcessSubmissionURL,
+	registerStartRedirectMiddleware,
+	noCache,
+	registerMiddleware,
+	getProcessSubmission
+);
 registerMyselfRouter.post(
-	registerMyselfDeclarationURL,
+	registerMyselfProcessSubmissionURL,
 	registerStartRedirectMiddleware,
 	registerMiddleware,
-	postRegisterDeclarationController
+	postProcessSubmission
 );
 
 registerMyselfRouter.get(

--- a/packages/forms-web-app/src/pages/projects/register/myself/router.test.js
+++ b/packages/forms-web-app/src/pages/projects/register/myself/router.test.js
@@ -23,11 +23,12 @@ const {
 	postRegisterMyselfAboutProjectController
 } = require('./about-project/controller');
 const { getRegisterMyselfCheckAnswersController } = require('./check-answers/controller');
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('../_common/declaration/controller');
+const { getRegisterDeclarationController } = require('../_common/declaration/controller');
 const { getRegisterCompleteController } = require('../_common/complete/controller');
+const {
+	getProcessSubmission,
+	postProcessSubmission
+} = require('../_common/process-submission/controller');
 const {
 	getRegisterAlreadyRegisteredController
 } = require('../_common/already-registered/controller');
@@ -214,11 +215,19 @@ describe('pages/projects/register/myself/router', () => {
 				registerMiddleware,
 				getRegisterDeclarationController
 			);
+
+			expect(get).toHaveBeenCalledWith(
+				'/projects/:case_ref/register/myself/process-submission',
+				registerStartRedirectMiddleware,
+				noCache,
+				registerMiddleware,
+				getProcessSubmission
+			);
 			expect(post).toHaveBeenCalledWith(
-				'/projects/:case_ref/register/myself/declaration',
+				'/projects/:case_ref/register/myself/process-submission',
 				registerStartRedirectMiddleware,
 				registerMiddleware,
-				postRegisterDeclarationController
+				postProcessSubmission
 			);
 
 			expect(get).toHaveBeenCalledWith(
@@ -235,7 +244,7 @@ describe('pages/projects/register/myself/router', () => {
 				getRegisterAlreadyRegisteredController
 			);
 
-			expect(get).toBeCalledTimes(10);
+			expect(get).toBeCalledTimes(11);
 			expect(post).toBeCalledTimes(7);
 			expect(use).toBeCalledTimes(0);
 		});

--- a/packages/forms-web-app/src/pages/projects/register/organisation/process-submission/_utils/get-register-organisation-process-submission-url.js
+++ b/packages/forms-web-app/src/pages/projects/register/organisation/process-submission/_utils/get-register-organisation-process-submission-url.js
@@ -1,0 +1,7 @@
+const { registerProcessSubmissionRoute } = require('../../../_common/process-submission/config');
+const { getRegisterOrganisationURL } = require('../../_utils/get-register-organisation-url');
+const getRegisterOrganisationProcessSubmissionURL = (caseRef) => {
+	const registerOrganisationURL = getRegisterOrganisationURL(caseRef);
+	return `${registerOrganisationURL}/${registerProcessSubmissionRoute}`;
+};
+module.exports = { getRegisterOrganisationProcessSubmissionURL };

--- a/packages/forms-web-app/src/pages/projects/register/organisation/router.js
+++ b/packages/forms-web-app/src/pages/projects/register/organisation/router.js
@@ -33,11 +33,12 @@ const {
 	postRegisterOrganisationAboutProjectController
 } = require('./about-project/controller');
 const { getRegisterOrganisationCheckAnswersController } = require('./check-answers/controller');
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('../_common/declaration/controller');
+const { getRegisterDeclarationController } = require('../_common/declaration/controller');
 const { getRegisterCompleteController } = require('../_common/complete/controller');
+const {
+	getProcessSubmission,
+	postProcessSubmission
+} = require('../_common/process-submission/controller');
 const {
 	getRegisterAlreadyRegisteredController
 } = require('../_common/already-registered/controller');
@@ -72,6 +73,9 @@ const {
 const {
 	getRegisterOrganisationDeclarationURL
 } = require('./declaration/_utils/get-register-organisation-declaration-url');
+const {
+	getRegisterOrganisationProcessSubmissionURL
+} = require('./process-submission/_utils/get-register-organisation-process-submission-url');
 const {
 	getRegisterOrganisationCompleteURL
 } = require('./complete/_utils/get-register-organisation-complete-url');
@@ -113,6 +117,7 @@ const registerOrganisationNumberURL = getRegisterOrganisationNumberURL();
 const registerOrganisationAboutProjectURL = getRegisterOrganisationAboutProjectURL();
 const registerOrganisationCheckAnswersURL = getRegisterOrganisationCheckAnswersURL();
 const registerOrganisationDeclarationURL = getRegisterOrganisationDeclarationURL();
+const registerOrganisationProcessSubmissionURL = getRegisterOrganisationProcessSubmissionURL();
 const registerOrganisationCompleteURL = getRegisterOrganisationCompleteURL();
 const registerOrganisationAlreadyRegisteredURL = getRegisterOrganisationAlreadyRegisteredURL();
 
@@ -255,11 +260,19 @@ registerOrganisationRouter.get(
 	registerMiddleware,
 	getRegisterDeclarationController
 );
+
+registerOrganisationRouter.get(
+	registerOrganisationProcessSubmissionURL,
+	registerStartRedirectMiddleware,
+	noCache,
+	registerMiddleware,
+	getProcessSubmission
+);
 registerOrganisationRouter.post(
-	registerOrganisationDeclarationURL,
+	registerOrganisationProcessSubmissionURL,
 	registerStartRedirectMiddleware,
 	registerMiddleware,
-	postRegisterDeclarationController
+	postProcessSubmission
 );
 
 registerOrganisationRouter.get(

--- a/packages/forms-web-app/src/pages/projects/register/organisation/router.test.js
+++ b/packages/forms-web-app/src/pages/projects/register/organisation/router.test.js
@@ -31,11 +31,12 @@ const {
 	postRegisterOrganisationAboutProjectController
 } = require('./about-project/controller');
 const { getRegisterOrganisationCheckAnswersController } = require('./check-answers/controller');
-const {
-	getRegisterDeclarationController,
-	postRegisterDeclarationController
-} = require('../_common/declaration/controller');
+const { getRegisterDeclarationController } = require('../_common/declaration/controller');
 const { getRegisterCompleteController } = require('../_common/complete/controller');
+const {
+	getProcessSubmission,
+	postProcessSubmission
+} = require('../_common/process-submission/controller');
 const {
 	getRegisterAlreadyRegisteredController
 } = require('../_common/already-registered/controller');
@@ -270,11 +271,19 @@ describe('pages/projects/register/organisation/router', () => {
 				registerMiddleware,
 				getRegisterDeclarationController
 			);
+
+			expect(get).toHaveBeenCalledWith(
+				'/projects/:case_ref/register/organisation/process-submission',
+				registerStartRedirectMiddleware,
+				noCache,
+				registerMiddleware,
+				getProcessSubmission
+			);
 			expect(post).toHaveBeenCalledWith(
-				'/projects/:case_ref/register/organisation/declaration',
+				'/projects/:case_ref/register/organisation/process-submission',
 				registerStartRedirectMiddleware,
 				registerMiddleware,
-				postRegisterDeclarationController
+				postProcessSubmission
 			);
 
 			expect(get).toHaveBeenCalledWith(
@@ -291,7 +300,7 @@ describe('pages/projects/register/organisation/router', () => {
 				getRegisterAlreadyRegisteredController
 			);
 
-			expect(get).toBeCalledTimes(12);
+			expect(get).toBeCalledTimes(13);
 			expect(post).toBeCalledTimes(9);
 			expect(use).toBeCalledTimes(0);
 		});


### PR DESCRIPTION
## Describe your changes

Aim of the ticket was to prevent duplicate reps for the register to have your say journey. Initial solution was to add 'preventDoubleClick' attribute to the submit button which did not work. 

I have aligned the RHYS to now use a process-submission page which aligns with the exam HYS journey flow. This page uses a script to submit a hidden form which actually submits the journey, preventing the user from clicking the button more than once. A fallback is in place if JS is not enabled, as it is for the exam HYS journey

<!--
    Issue ticket number and link
-->

[idas-28](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-28&sprint=5966)

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test
going through the RHYS journey, the user should now see the processing page after the declaration page.

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
