### PR TITLE
IRP-79: continued prisma indexing

### DIFF
--- a/packages/applications-service-api/prisma/migrations/20260506135533_remove_unused_index_and_add_missing_primary_keys/migration.sql
+++ b/packages/applications-service-api/prisma/migrations/20260506135533_remove_unused_index_and_add_missing_primary_keys/migration.sql
@@ -1,0 +1,34 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropForeignKey
+ALTER TABLE [dbo].[ExaminationTimetableEventItem] DROP CONSTRAINT [ExaminationTimetableEventItem_eventId_fkey];
+
+-- DropIndex
+DROP INDEX [Document_representationId_idx] ON [dbo].[Document];
+
+-- AlterTable
+ALTER TABLE [dbo].[Advice] ADD CONSTRAINT Advice_pkey PRIMARY KEY CLUSTERED ([adviceId]);
+
+-- DropIndex
+ALTER TABLE [dbo].[Advice] DROP CONSTRAINT [Advice_adviceId_key];
+
+-- AlterTable
+ALTER TABLE [dbo].[ExaminationTimetableEventItem] ADD CONSTRAINT ExaminationTimetableEventItem_pkey PRIMARY KEY CLUSTERED ([id]);
+
+-- DropIndex
+ALTER TABLE [dbo].[ExaminationTimetableEventItem] DROP CONSTRAINT [ExaminationTimetableEventItem_id_key];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/applications-service-api/prisma/migrations/20260506135637_add_foreign_key_back_to_examinationtimetableeventitem_for_primary_key_addition/migration.sql
+++ b/packages/applications-service-api/prisma/migrations/20260506135637_add_foreign_key_back_to_examinationtimetableeventitem_for_primary_key_addition/migration.sql
@@ -1,0 +1,25 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[ExaminationTimetable] ADD CONSTRAINT ExaminationTimetable_pkey PRIMARY KEY CLUSTERED ([eventId]);
+
+-- DropIndex
+ALTER TABLE [dbo].[ExaminationTimetable] DROP CONSTRAINT [ExaminationTimetable_eventId_key];
+
+-- AddForeignKey
+ALTER TABLE [dbo].[ExaminationTimetableEventItem] ADD CONSTRAINT [ExaminationTimetableEventItem_eventId_fkey] FOREIGN KEY ([eventId]) REFERENCES [dbo].[ExaminationTimetable]([eventId]) ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/applications-service-api/prisma/schema.prisma
+++ b/packages/applications-service-api/prisma/schema.prisma
@@ -62,7 +62,6 @@ model Document {
 	modifiedAt             DateTime? @default(now())
 
 	@@index([caseRef])
-	@@index([representationId])
 	@@index([documentType])
 }
 
@@ -195,7 +194,7 @@ model ProjectUpdate {
 }
 
 model ExaminationTimetable {
-	eventId                Int                             @unique
+	eventId                Int                             @id
 	caseReference          String
 	type                   String
 	eventTitle             String
@@ -213,7 +212,7 @@ model ExaminationTimetable {
 }
 
 model ExaminationTimetableEventItem {
-	id                            Int                   @unique @default(autoincrement())
+	id                            Int                   @id @default(autoincrement())
 	eventLineItemDescription      String                @db.NText
 	eventLineItemDescriptionWelsh String?               @db.NText
 	eventId                       Int
@@ -221,7 +220,7 @@ model ExaminationTimetableEventItem {
 }
 
 model Advice {
-	adviceId            Int       @unique
+	adviceId            Int       @id
 	adviceReference     String?
 	caseReference       String?
 	caseId              Int


### PR DESCRIPTION
## Describe your changes
Note: i have done two migrations because it was throwing a foreign key violation when deleting the @unique constraint on ExaminationTimetable. The two-part migration lets us avoid any conflicts in production database by first removing the foreign key constraint, then adding it back in after the unique constraint has been swapped for a primary key
<!--
    Issue ticket number and link
-->
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/IRP/boards/1363?selectedIssue=IRP-79
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
