### PR TITLE
feat(subscriber): prevent race conditions in service user query (idas-314)

### DIFF
--- a/packages/back-office-subscribers/lib/queries.js
+++ b/packages/back-office-subscribers/lib/queries.js
@@ -1,8 +1,10 @@
+// Static date set for modifiedAt to avoid a race condition as the buildMergeQuery function checks this field
+
 const serviceUserQuery = `
-		MERGE INTO [dbo].[serviceUser] AS Target 
+		MERGE INTO [dbo].[serviceUser] AS Target
 		USING (SELECT @P1 AS serviceUserId) AS Source
 		ON Target.[serviceUserId] = Source.[serviceUserId]
 		WHEN MATCHED THEN UPDATE SET Target.[serviceUserId] = Source.[serviceUserId]
-		WHEN NOT MATCHED THEN INSERT ([serviceUserId]) VALUES (@P1);`;
+		WHEN NOT MATCHED THEN INSERT ([serviceUserId], [modifiedAt]) VALUES (@P1, '1900-01-01 12:00:00');`;
 
 module.exports = { serviceUserQuery };


### PR DESCRIPTION
## Describe your changes
[IDAS-314](https://pins-ds.atlassian.net/browse/IDAS-314): Prevent a race condition in serviceUser query

This PR sets a static modifiedAt date in the service user query that is referenced by the back office subscriber functions that publish projects and relevant representations to Front Office. This change is to avoid a race condition that may occur when the buildMergeQuery function compares this timestamp with the timestamp of incoming messages. By setting the modifiedAt date as `1900-01-01 12:00:00` when the record is initially inserted into the ServiceUser table, we can ensure that the next message  will always be 'newer', allowing the update to be completed.

## Useful information to review or test
This change was tested by deploying the feature branch to the Test env and manually testing that associated existing functionality continued to work as expected. This included publishing projects and relevant representations to Front Office and editing service user data and republishing the project.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[IDAS-314]: https://pins-ds.atlassian.net/browse/IDAS-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ