### PR TITLE
feat(web): link glossary of words we use via ni website (IDAS-16)

### DIFF
--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -97,6 +97,10 @@ module.exports = {
 			'https://www.gov.uk/government/collections/national-infrastructure-planning-advice-notes',
 		advicePagesWelsh:
 			'https://www.gov.uk/government/collections/prosiectau-seilwaith-o-arwyddocad-cenedlaethol-tudalennau-cyngor',
+		commonTerms:
+			'https://www.gov.uk/guidance/nationally-significant-infrastructure-projects-terms-commonly-used-in-the-process',
+		commonTermsWelsh:
+			'https://www.gov.uk/guidance/nationally-significant-infrastructure-projects-terms-commonly-used-in-the-process.cy',
 		administrativeCourtURL: 'https://www.gov.uk/courts-tribunals/administrative-court',
 		crownCopyright:
 			'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/',

--- a/packages/forms-web-app/src/pages/_utils/get-govuk-urls.js
+++ b/packages/forms-web-app/src/pages/_utils/get-govuk-urls.js
@@ -6,6 +6,8 @@ const getGovUkUrls = (locale = 'en') => {
 		developmentConsentWelsh,
 		developmentConsentAndAdvice,
 		developmentConsentAndAdviceWelsh,
+		commonTerms,
+		commonTermsWelsh,
 		nationalPolicyStatements,
 		nationalPolicyStatementsWelsh,
 		planningGuidance,
@@ -20,6 +22,7 @@ const getGovUkUrls = (locale = 'en') => {
 			developmentConsentAndAdvice,
 			developmentConsentAndAdviceWelsh
 		),
+		commonTermsUrl: getGovUkUrl(locale, commonTerms, commonTermsWelsh),
 		planningGuidanceUrl: planningGuidance,
 		advicePagesUrl: getGovUkUrl(locale, advicePages, advicePagesWelsh),
 		nationalPolicyStatementsUrl: getGovUkUrl(

--- a/packages/forms-web-app/src/pages/_utils/get-govuk-urls.test.js
+++ b/packages/forms-web-app/src/pages/_utils/get-govuk-urls.test.js
@@ -7,11 +7,13 @@ jest.mock('../../../src/config', () => {
 			developmentConsentWelsh: 'Welsh URL 1',
 			developmentConsentAndAdvice: 'URL 2',
 			developmentConsentAndAdviceWelsh: 'Welsh URL 2',
-			planningGuidance: 'URL 3',
-			advicePages: 'URL 4',
-			advicePagesWelsh: 'Welsh URL 4',
-			nationalPolicyStatements: 'URL 5',
-			nationalPolicyStatementsWelsh: 'Welsh URL 5'
+			commonTerms: 'URL 3',
+			commonTermsWelsh: 'Welsh URL 3',
+			planningGuidance: 'URL 4',
+			advicePages: 'URL 5',
+			advicePagesWelsh: 'Welsh URL 5',
+			nationalPolicyStatements: 'URL 6',
+			nationalPolicyStatementsWelsh: 'Welsh URL 6'
 		}
 	};
 });
@@ -21,18 +23,20 @@ describe('pages/_utils/get-govuk-urls', () => {
 		expect(getGovUkUrls()).toEqual({
 			developmentConsentUrl: 'URL 1',
 			developmentConsentAndAdviceUrl: 'URL 2',
-			planningGuidanceUrl: 'URL 3',
-			advicePagesUrl: 'URL 4',
-			nationalPolicyStatementsUrl: 'URL 5'
+			commonTermsUrl: 'URL 3',
+			planningGuidanceUrl: 'URL 4',
+			advicePagesUrl: 'URL 5',
+			nationalPolicyStatementsUrl: 'URL 6'
 		});
 	}),
 		it('returns correct URLs - cy', () => {
 			expect(getGovUkUrls('cy')).toEqual({
 				developmentConsentUrl: 'Welsh URL 1',
 				developmentConsentAndAdviceUrl: 'Welsh URL 2',
-				planningGuidanceUrl: 'URL 3',
-				advicePagesUrl: 'Welsh URL 4',
-				nationalPolicyStatementsUrl: 'Welsh URL 5'
+				commonTermsUrl: 'Welsh URL 3',
+				planningGuidanceUrl: 'URL 4',
+				advicePagesUrl: 'Welsh URL 5',
+				nationalPolicyStatementsUrl: 'Welsh URL 6'
 			});
 		});
 });

--- a/packages/forms-web-app/src/pages/detailed-information/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/detailed-information/_translations/__snapshots__/translations.test.js.snap
@@ -11,6 +11,7 @@ exports[`pages/detailed-information/_translations should return the correct Engl
   "linkParagraph6": "The Planning Inspectorate has a series of advice pages covering a range of process details.",
   "linkParagraph7": "Find out what National Policy Statements (NPSs) are, what they include and how they fit into the Planning Act 2008 process.",
   "linkParagraph8": "Here you can view all advice provided by the Planning Inspectorate since 2008.",
+  "linkParagraph9": "Words we use to talk about aspects of the application and decision-making process.",
   "linkTitle1": "See the process",
   "linkTitle2": "How to have your say on a project",
   "linkTitle3": "Guide for applicants",
@@ -19,6 +20,7 @@ exports[`pages/detailed-information/_translations should return the correct Engl
   "linkTitle6": "See advice pages",
   "linkTitle7": "National Policy Statements",
   "linkTitle8": "Register of advice",
+  "linkTitle9": "Common terms",
   "paragraph1": "Find further legislation and guidance resources. Information on this page may be useful for those applying to use the service and the general public.",
 }
 `;
@@ -34,6 +36,7 @@ exports[`pages/detailed-information/_translations should return the correct Wels
   "linkParagraph6": "Mae gan yr Arolygiaeth Gynllunio gyfres o tudalennau cyngor sy'n ymdrin ag ystod o fanylion proses.",
   "linkParagraph7": "Dysgwch beth yw Datganiadau Polisi Cenedlaethol (NPSau), beth maen nhw'n ei gynnwys a sut maen nhw'n berthnasol i broses Deddf Cynllunio 2008.",
   "linkParagraph8": "Gallwch weld yr holl gyngor a roddwyd gan yr Arolygiaeth Gynllunio ers 2008.",
+  "linkParagraph9": "Geiriau a ddefnyddiwn i siarad am agweddau ar y broses ymgeisio a gwneud penderfyniadau.",
   "linkTitle1": "Gweld y broses",
   "linkTitle2": "Sut i leisio'ch barn am brosiect",
   "linkTitle3": "Canllaw i ymgeiswyr",
@@ -42,6 +45,7 @@ exports[`pages/detailed-information/_translations should return the correct Wels
   "linkTitle6": "Gweld tudalennau cyngor",
   "linkTitle7": "Datganiadau Polisi Cenedlaethol",
   "linkTitle8": "Cofrestr gyngor",
+  "linkTitle9": "Termau cyffredin",
   "paragraph1": "Dewch o hyd i ragor o ddeddfwriaeth ac adnoddau canllaw. Gallai'r wybodaeth ar y dudalen hon fod yn ddefnyddiol i'r rhai sy'n gwneud cais i ddefnyddio'r gwasanaeth ac i'r cyhoedd.",
 }
 `;

--- a/packages/forms-web-app/src/pages/detailed-information/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/detailed-information/_translations/cy.json
@@ -16,5 +16,7 @@
 	"linkTitle7": "Datganiadau Polisi Cenedlaethol",
 	"linkParagraph7": "Dysgwch beth yw Datganiadau Polisi Cenedlaethol (NPSau), beth maen nhw'n ei gynnwys a sut maen nhw'n berthnasol i broses Deddf Cynllunio 2008.",
 	"linkTitle8": "Cofrestr gyngor",
-	"linkParagraph8": "Gallwch weld yr holl gyngor a roddwyd gan yr Arolygiaeth Gynllunio ers 2008."
+	"linkParagraph8": "Gallwch weld yr holl gyngor a roddwyd gan yr Arolygiaeth Gynllunio ers 2008.",
+	"linkTitle9": "Termau cyffredin",
+	"linkParagraph9": "Geiriau a ddefnyddiwn i siarad am agweddau ar y broses ymgeisio a gwneud penderfyniadau."
 }

--- a/packages/forms-web-app/src/pages/detailed-information/_translations/en.json
+++ b/packages/forms-web-app/src/pages/detailed-information/_translations/en.json
@@ -16,5 +16,7 @@
 	"linkTitle7": "National Policy Statements",
 	"linkParagraph7": "Find out what National Policy Statements (NPSs) are, what they include and how they fit into the Planning Act 2008 process.",
 	"linkTitle8": "Register of advice",
-	"linkParagraph8": "Here you can view all advice provided by the Planning Inspectorate since 2008."
+	"linkParagraph8": "Here you can view all advice provided by the Planning Inspectorate since 2008.",
+	"linkTitle9": "Common terms",
+	"linkParagraph9": "Words we use to talk about aspects of the application and decision-making process."
 }

--- a/packages/forms-web-app/src/pages/detailed-information/view.njk
+++ b/packages/forms-web-app/src/pages/detailed-information/view.njk
@@ -101,6 +101,15 @@
 						t('detailedInformation.linkParagraph8')
 					) }}
 				</div>
+
+				<div class="govuk-grid-column-one-third">
+					{{ chevronCard(
+						'2',
+						t('detailedInformation.linkTitle9'),
+						detailedInformationUrls.commonTermsUrl,
+						t('detailedInformation.linkParagraph9')
+					) }}
+				</div>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
Summary
Adds a new “Common terms / Termau cyffredin” tile to the bottom right of the Detailed information page on the National Infrastructure website.

The tile helps citizens understand terminology used in the NI application and decision-making process by linking directly to the GOV.UK glossary page:
“Nationally Significant Infrastructure Projects: Terms commonly used in the process”.

The link opens in the same tab, in line with the tech note.

Changes
adds a new “Common terms / Termau cyffredin” tile on the Detailed information page
adds the agreed bilingual description text
links the tile title to the GOV.UK glossary page
uses the GOV.UK-hosted guidance approach noted in the investigation
Content
Title
Common terms / Termau cyffredin

Description
Words we use to talk about aspects of the application and decision-making process.

Geiriau a ddefnyddiwn i siarad am agweddau ar y broses ymgeisio a gwneud penderfyniadau.

Ticket
Jira: https://pins-ds.atlassian.net/browse/IDAS-16

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
