### PR TITLE
feat(web): align FO maps with new boundary GeoJSON schema

### DIFF
--- a/packages/forms-web-app/src/scripts/projects-map/__tests__/fixtures/boundaries-new-schema.json
+++ b/packages/forms-web-app/src/scripts/projects-map/__tests__/fixtures/boundaries-new-schema.json
@@ -1,0 +1,121 @@
+{
+	"type": "FeatureCollection",
+	"features": [
+		{
+			"type": "Feature",
+			"properties": {
+				"caseReference": "EN010201",
+				"projectName": "Northvale Solar Farm",
+				"fileName": "northvale-boundary.geojson",
+				"receivedDate": "2026-06-24T09:15:00.000Z"
+			},
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[-0.7412, 51.412],
+						[-0.7125, 51.412],
+						[-0.7125, 51.43],
+						[-0.7412, 51.43],
+						[-0.7412, 51.412]
+					]
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+				"caseReference": "EN010202",
+				"projectName": "East Haven Wind Extension",
+				"fileName": "east-haven-boundary.geojson",
+				"receivedDate": "2026-06-24T09:20:00.000Z"
+			},
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[-1.205, 52.875],
+						[-1.168, 52.875],
+						[-1.168, 52.901],
+						[-1.205, 52.901],
+						[-1.205, 52.875]
+					]
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+				"caseReference": "EN010203",
+				"projectName": "Southport Grid Connection",
+				"fileName": "southport-grid-boundary.geojson",
+				"receivedDate": "2026-06-24T09:25:00.000Z"
+			},
+			"geometry": {
+				"type": "MultiPolygon",
+				"coordinates": [
+					[
+						[
+							[-2.997, 53.597],
+							[-2.97, 53.597],
+							[-2.97, 53.614],
+							[-2.997, 53.614],
+							[-2.997, 53.597]
+						]
+					],
+					[
+						[
+							[-2.955, 53.584],
+							[-2.937, 53.584],
+							[-2.937, 53.596],
+							[-2.955, 53.596],
+							[-2.955, 53.584]
+						]
+					]
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+				"caseReference": "EN010204",
+				"projectName": "Riverside Port Upgrade",
+				"fileName": "riverside-port-boundary.geojson",
+				"receivedDate": "2026-06-24T09:30:00.000Z"
+			},
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[-0.505, 53.62],
+						[-0.475, 53.62],
+						[-0.475, 53.645],
+						[-0.505, 53.645],
+						[-0.505, 53.62]
+					]
+				]
+			}
+		},
+		{
+			"type": "Feature",
+			"properties": {
+				"caseReference": "EN010205",
+				"projectName": "Westmoor Hydrogen Facility",
+				"fileName": "westmoor-h2-boundary.geojson",
+				"receivedDate": "2026-06-24T09:35:00.000Z"
+			},
+			"geometry": {
+				"type": "Polygon",
+				"coordinates": [
+					[
+						[-3.212, 51.51],
+						[-3.18, 51.51],
+						[-3.18, 51.532],
+						[-3.212, 51.532],
+						[-3.212, 51.51]
+					]
+				]
+			}
+		}
+	]
+}

--- a/packages/forms-web-app/src/scripts/projects-map/__tests__/normalize-map.test.js
+++ b/packages/forms-web-app/src/scripts/projects-map/__tests__/normalize-map.test.js
@@ -6,6 +6,7 @@ import {
 	randomPointFeature,
 	randomPolygonFeature
 } from './test-helpers';
+import boundariesNewSchema from './fixtures/boundaries-new-schema.json';
 
 jest.mock('ol/format/GeoJSON.js', () => {
 	return jest.fn().mockImplementation(() => ({
@@ -143,6 +144,13 @@ describe('scripts/projects-map/normalize-map-input', () => {
 	});
 
 	describe('FeatureCollection with Polygon geometries', () => {
+		it('should return geojson mode for provided boundary GeoJSON fixture', () => {
+			const result = normalizeMapInput(boundariesNewSchema);
+
+			expect(result.mode).toBe('geojson');
+			expect(result.features).toHaveLength(boundariesNewSchema.features.length);
+		});
+
 		it('should return geojson mode', () => {
 			const input = {
 				type: 'FeatureCollection',

--- a/packages/forms-web-app/src/scripts/projects-map/__tests__/popup.test.js
+++ b/packages/forms-web-app/src/scripts/projects-map/__tests__/popup.test.js
@@ -5,8 +5,13 @@ jest.mock('ol-ext/src/overlay/Popup.js', () => {
 	}));
 });
 
-const { renderPopupHTML } = require('../popup');
+const {
+	renderPopupHTML,
+	mapFeaturePropertiesToPopupProject,
+	showProjectPopup
+} = require('../popup');
 const { NUM_ITERATIONS, randomProjects } = require('./test-helpers');
+const boundariesNewSchema = require('./fixtures/boundaries-new-schema.json');
 
 const popupText = {
 	projectSelected: 'project selected',
@@ -14,6 +19,62 @@ const popupText = {
 };
 
 describe('scripts/projects-map/popup', () => {
+	describe('#mapFeaturePropertiesToPopupProject', () => {
+		it('should use new schema keys', () => {
+			const result = mapFeaturePropertiesToPopupProject({
+				caseReference: 'EN010101',
+				projectName: 'New Schema Project',
+				stage: 'Examination'
+			});
+
+			expect(result).toEqual({
+				caseReference: 'EN010101',
+				projectName: 'New Schema Project',
+				stage: 'Examination'
+			});
+		});
+
+		it('should ignore legacy keys when only legacy keys are provided', () => {
+			const result = mapFeaturePropertiesToPopupProject({
+				caseRef: 'EN010102',
+				projName: 'Legacy Project',
+				geomStage: 'Pre-application'
+			});
+
+			expect(result).toEqual({
+				caseReference: undefined,
+				projectName: 'Unknown project',
+				stage: ''
+			});
+		});
+
+		it('should provide safe fallback values for mixed and missing fields', () => {
+			const result = mapFeaturePropertiesToPopupProject({
+				caseReference: 'EN010103',
+				projectName: '   ',
+				stage: 'Accepted'
+			});
+
+			expect(result).toEqual({
+				caseReference: 'EN010103',
+				projectName: 'EN010103',
+				stage: 'Accepted'
+			});
+		});
+
+		it('should use Unknown project when both projectName and caseReference are missing', () => {
+			const result = mapFeaturePropertiesToPopupProject({
+				projectName: ''
+			});
+
+			expect(result).toEqual({
+				caseReference: undefined,
+				projectName: 'Unknown project',
+				stage: ''
+			});
+		});
+	});
+
 	describe('#renderPopupHTML', () => {
 		describe('single project', () => {
 			it('should contain the project name, case reference and stage', () => {
@@ -141,6 +202,66 @@ describe('scripts/projects-map/popup', () => {
 				expect(html).toContain('No Stage Project');
 				expect(html).toContain('cluster-popup-cell-stage');
 			});
+
+			it('should not render undefined when caseReference and projectName are missing', () => {
+				const projects = [
+					{
+						caseReference: undefined,
+						projectName: undefined,
+						stage: 'Accepted'
+					}
+				];
+
+				const html = renderPopupHTML(projects, popupText);
+
+				expect(html).toContain('Unknown project');
+				expect(html).not.toContain('undefined');
+				expect(html).not.toContain('href="/projects/undefined"');
+			});
+		});
+	});
+
+	describe('#showProjectPopup', () => {
+		it('should render boundary popup text from new schema feature properties without undefined', () => {
+			const popup = { show: jest.fn(), hide: jest.fn() };
+			const features = [
+				{
+					getProperties: () => ({
+						caseReference: 'EN010201',
+						projectName: 'Boundary Wind Farm',
+						receivedDate: '2026-06-01'
+					})
+				}
+			];
+
+			showProjectPopup(popup, features, [0, 0], popupText);
+
+			expect(popup.show).toHaveBeenCalledTimes(1);
+			const html = popup.show.mock.calls[0][1];
+			expect(html).toContain('Boundary Wind Farm');
+			expect(html).toContain('href="/projects/EN010201"');
+			expect(html).not.toContain('undefined');
+		});
+
+		it('should render popup rows correctly for provided boundary GeoJSON fixture', () => {
+			const popup = { show: jest.fn(), hide: jest.fn() };
+			const features = boundariesNewSchema.features.map((feature) => ({
+				getProperties: () => feature.properties
+			}));
+
+			showProjectPopup(popup, features, [100, 200], popupText);
+
+			expect(popup.show).toHaveBeenCalledTimes(1);
+			const html = popup.show.mock.calls[0][1];
+			expect(html).toContain('5 projects selected');
+			expect(html).toContain('Northvale Solar Farm');
+			expect(html).toContain('East Haven Wind Extension');
+			expect(html).toContain('Southport Grid Connection');
+			expect(html).toContain('Riverside Port Upgrade');
+			expect(html).toContain('Westmoor Hydrogen Facility');
+			expect(html).toContain('href="/projects/EN010201"');
+			expect(html).toContain('href="/projects/EN010205"');
+			expect(html).not.toContain('undefined');
 		});
 	});
 

--- a/packages/forms-web-app/src/scripts/projects-map/constants.js
+++ b/packages/forms-web-app/src/scripts/projects-map/constants.js
@@ -34,10 +34,9 @@ export const SOURCE_PROJECTION = 'EPSG:4326';
 export const TARGET_PROJECTION = 'EPSG:27700';
 
 // Feature property keys (as stored in GeoJSON from the server)
-export const PROP_CASE_REF = 'caseRef';
 export const PROP_CASE_REFERENCE = 'caseReference';
-export const PROP_PROJECT_NAME = 'projName';
-export const PROP_STAGE = 'geomStage';
+export const PROP_PROJECT_NAME = 'projectName';
+export const PROP_STAGE = 'stage';
 
 // Interaction
 export const CIRCLE_MAX_OBJECTS = 10;

--- a/packages/forms-web-app/src/scripts/projects-map/index.js
+++ b/packages/forms-web-app/src/scripts/projects-map/index.js
@@ -2,7 +2,6 @@ import Map from 'ol/Map.js';
 import View from 'ol/View.js';
 import VectorSource from 'ol/source/Vector.js';
 import GeoJSON from 'ol/format/GeoJSON.js';
-import Feature from 'ol/Feature.js';
 import SelectCluster from 'ol-ext/src/interaction/SelectCluster.js';
 import {
 	UK_CENTRE_EPSG27700,
@@ -12,7 +11,6 @@ import {
 	ANIMATION_DURATION,
 	SOURCE_PROJECTION,
 	TARGET_PROJECTION,
-	PROP_CASE_REF,
 	PROP_CASE_REFERENCE,
 	PROP_PROJECT_NAME,
 	PROP_STAGE,
@@ -26,6 +24,14 @@ import { createPopup, showProjectPopup } from './popup.js';
 import { normalizeMapInput } from './normalize-map-input.js';
 
 const logger = window.appLogger || { debug: () => {}, error: console.error };
+
+const getCaseReference = (feature) => feature.get(PROP_CASE_REFERENCE) || undefined;
+
+const getBoundaryPopupProperties = (feature) => ({
+	caseReference: getCaseReference(feature),
+	projectName: feature.get(PROP_PROJECT_NAME),
+	stage: feature.get(PROP_STAGE)
+});
 
 /**
  * Fetches boundary polygons from the server, removes duplicate point markers
@@ -44,10 +50,12 @@ async function loadBoundaries(map, pointSource, boundaryGeoJsonUrl) {
 			featureProjection: TARGET_PROJECTION
 		});
 
-		const polygonProjects = new Set(boundaryFeatures.map((feature) => feature.get(PROP_CASE_REF)));
+		const polygonProjects = new Set(
+			boundaryFeatures.map((feature) => getCaseReference(feature)).filter(Boolean)
+		);
 
 		pointSource.getFeatures().forEach((feature) => {
-			if (polygonProjects.has(feature.get(PROP_CASE_REFERENCE))) {
+			if (polygonProjects.has(getCaseReference(feature))) {
 				pointSource.removeFeature(feature);
 			}
 		});
@@ -174,11 +182,7 @@ function projectsMap() {
 
 						if (geometryType === 'Polygon' || geometryType === 'MultiPolygon') {
 							featureClicked = true;
-							const popupFeature = new Feature({
-								caseReference: feature.get(PROP_CASE_REF),
-								projectName: feature.get(PROP_PROJECT_NAME),
-								stage: feature.get(PROP_STAGE)
-							});
+							const popupFeature = { getProperties: () => getBoundaryPopupProperties(feature) };
 							showProjectPopup(popup, [popupFeature], event.coordinate, popupText);
 						}
 					});

--- a/packages/forms-web-app/src/scripts/projects-map/popup.js
+++ b/packages/forms-web-app/src/scripts/projects-map/popup.js
@@ -1,5 +1,25 @@
 import Popup from 'ol-ext/src/overlay/Popup.js';
 
+const UNKNOWN_PROJECT_LABEL = 'Unknown project';
+
+const toValue = (value) => {
+	if (typeof value !== 'string') return value || undefined;
+	const trimmedValue = value.trim();
+	return trimmedValue || undefined;
+};
+
+export function mapFeaturePropertiesToPopupProject(properties = {}) {
+	const caseReference = toValue(properties.caseReference);
+	const projectName = toValue(properties.projectName) || caseReference || UNKNOWN_PROJECT_LABEL;
+	const stage = toValue(properties.stage) || '';
+
+	return {
+		caseReference,
+		projectName,
+		stage
+	};
+}
+
 /** Creates an ol-ext Popup overlay. */
 export function createPopup() {
 	return new Popup({
@@ -21,11 +41,14 @@ export function renderPopupHTML(projects, popupText) {
 	const formattedPopupText = formatPopupText(count, popupText);
 	const rows = projects
 		.map(({ caseReference, projectName, stage }) => {
+			const projectLabel = projectName || caseReference || UNKNOWN_PROJECT_LABEL;
+			const projectCell = caseReference
+				? `<a href="/projects/${caseReference}" class="govuk-link cluster-popup-link">${projectLabel}</a>`
+				: `<span class="cluster-popup-link">${projectLabel}</span>`;
+
 			return `<tr class="cluster-popup-row">
 				<td class="cluster-popup-cell-name">
-					<a href="/projects/${caseReference}" class="govuk-link cluster-popup-link">${
-				projectName || caseReference
-			}</a>
+					${projectCell}
 				</td>
 				<td class="cluster-popup-cell-stage">${stage || ''}</td>
 			</tr>`;
@@ -40,10 +63,7 @@ export function renderPopupHTML(projects, popupText) {
 
 /** Shows a popup at the given coordinate with project info from the features. */
 export function showProjectPopup(popup, features, coordinate, popupText) {
-	const projects = features.map((f) => {
-		const { caseReference, projectName, stage } = f.getProperties();
-		return { caseReference, projectName, stage };
-	});
+	const projects = features.map((f) => mapFeaturePropertiesToPopupProject(f.getProperties()));
 
 	const html = renderPopupHTML(projects, popupText);
 	popup.show(coordinate, html);


### PR DESCRIPTION
## Describe your changes

<!--
    Issue ticket number and link
-->

[[IDAS-664] Front Office maps: align maps with GeoJSON schema update](https://pins-ds.atlassian.net/browse/IDAS-664)

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

Front Office map popup handling currently reads legacy boundary keys for some boundary interactions, which can cause undefined values in popup title/link text.

This PR ensures boundary popups always show correct, user-friendly project metadata and avoids undefined labels/links in production.

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[IDAS-664]: https://pins-ds.atlassian.net/browse/IDAS-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ