### PR TITLE
fix(web): correct padding around boundary download link (idas-50)

### DIFF
--- a/packages/forms-web-app/src/pages/projects/index/_includes/location.njk
+++ b/packages/forms-web-app/src/pages/projects/index/_includes/location.njk
@@ -11,12 +11,14 @@
 {% endif %}
 
 {% if boundaryDocument %}
-	<a
-		class="govuk-link"
-		href="{{ boundaryDownloadURL }}"
-	>
-		{{ t('projectsIndex.projectLocation.boundaryDownloadText') }}
-	</a>
+	<p class="govuk-body">
+		<a
+			class="govuk-link"
+			href="{{ boundaryDownloadURL }}"
+		>
+			{{ t('projectsIndex.projectLocation.boundaryDownloadText') }}
+		</a>
+	</p>
 {% endif %}
 
 {% if mapAccessToken %}


### PR DESCRIPTION
## Describe your changes
correct padding around boundary download link using correct text class

<!--
    Issue ticket number and link
-->
[idas 50](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-50)

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test
previously link text was immediately above project map. With the change it puts some space between the link and the map

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
