### PR TITLE
refactor(web): change warning label to inset text for maps (idas-671)

### DIFF
--- a/packages/forms-web-app/src/pages/projects-map/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/projects-map/_translations/__snapshots__/translations.test.js.snap
@@ -13,6 +13,7 @@ exports[`pages/projects-map/_translations should return the correct English tran
   "filteredResults": "Filtered results",
   "heading1": "Projects map",
   "hideFilters": "Hide filters",
+  "insetText": "Project boundaries and markers are approximate. Some projects may not have boundaries available. For exact locations, check a project's latest plans and drawings.",
   "markers": "Markers",
   "pageTitle": "Projects map",
   "paragraph1": "Explore our map to find a national infrastructure project in England and Wales. You can filter by application stage, location or sector.",
@@ -27,7 +28,6 @@ exports[`pages/projects-map/_translations should return the correct English tran
   },
   "switchToListView": "Switch to list view",
   "switchToMapView": "Switch to map view",
-  "warningText": "Project boundaries and markers are approximate. Some projects may not have boundaries available. For exact locations, check a project's latest plans and drawings.",
 }
 `;
 
@@ -44,6 +44,7 @@ exports[`pages/projects-map/_translations should return the correct Welsh transl
   "filteredResults": "Canlyniadau wedi'u hidlo",
   "heading1": "Map prosiectau",
   "hideFilters": "Cuddio hidlwyr",
+  "insetText": "Mae ffiniau a marcwyr prosiectau yn rhai bras. Efallai na fydd ffiniau ar gael ar gyfer rhai prosiectau. I gael lleoliadau union, gwiriwch gynlluniau a lluniadau diweddaraf y prosiect.",
   "markers": "Marcwyr",
   "pageTitle": "Map prosiectau",
   "paragraph1": "Archwiliwch ein map i ddod o hyd i brosiect seilwaith cenedlaethol yng Nghymru a Lloegr. Gallwch hidlo yn ôl cam y cais, lleoliad neu sector.",
@@ -58,6 +59,5 @@ exports[`pages/projects-map/_translations should return the correct Welsh transl
   },
   "switchToListView": "Newid i'r golwg rhestr",
   "switchToMapView": "Newid i'r golwg map",
-  "warningText": "Mae ffiniau a marcwyr prosiectau yn rhai bras. Efallai na fydd ffiniau ar gael ar gyfer rhai prosiectau. I gael lleoliadau union, gwiriwch gynlluniau a lluniadau diweddaraf y prosiect.",
 }
 `;

--- a/packages/forms-web-app/src/pages/projects-map/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects-map/_translations/cy.json
@@ -15,7 +15,7 @@
 	"filteredResults": "Canlyniadau wedi'u hidlo",
 	"projectSelected": "prosiect wedi'i ddewis",
 	"projectsSelected": "prosiect wedi'u dewis",
-	"warningText": "Mae ffiniau a marcwyr prosiectau yn rhai bras. Efallai na fydd ffiniau ar gael ar gyfer rhai prosiectau. I gael lleoliadau union, gwiriwch gynlluniau a lluniadau diweddaraf y prosiect.",
+	"insetText": "Mae ffiniau a marcwyr prosiectau yn rhai bras. Efallai na fydd ffiniau ar gael ar gyfer rhai prosiectau. I gael lleoliadau union, gwiriwch gynlluniau a lluniadau diweddaraf y prosiect.",
 	"filterLabels": {
 		"region": "Lleoliad",
 		"sector": "Sector",

--- a/packages/forms-web-app/src/pages/projects-map/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects-map/_translations/en.json
@@ -15,7 +15,7 @@
 	"filteredResults": "Filtered results",
 	"projectSelected": "project selected",
 	"projectsSelected": "projects selected",
-	"warningText": "Project boundaries and markers are approximate. Some projects may not have boundaries available. For exact locations, check a project's latest plans and drawings.",
+	"insetText": "Project boundaries and markers are approximate. Some projects may not have boundaries available. For exact locations, check a project's latest plans and drawings.",
 	"filterLabels": {
 		"region": "Location",
 		"sector": "Sector",

--- a/packages/forms-web-app/src/pages/projects-map/view.njk
+++ b/packages/forms-web-app/src/pages/projects-map/view.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/default.njk" %}
 
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
 {% set pageTitle = t('projectsMap.pageTitle') %}
 
 {% if mapAccessToken %}
@@ -68,13 +70,7 @@
 				</div>
 			</div>
 
-			<div class="govuk-warning-text govuk-!-margin-top-4">
-				<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-				<strong class="govuk-warning-text__text">
-					<span class="govuk-visually-hidden">Warning</span>
-					{{ t('projectsMap.warningText') }}
-				</strong>
-			</div>
+			{{ govukInsetText({ text: t('projectsMap.insetText') }) }}
 		</div>
 	</div>
 {% endblock %}

--- a/packages/forms-web-app/src/pages/projects/index/_includes/location.njk
+++ b/packages/forms-web-app/src/pages/projects/index/_includes/location.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 <h2 class="govuk-heading-m">
   {{ t('projectsIndex.projectLocation.heading1') }}
@@ -30,15 +30,14 @@
 {% endif %}
 
 {% if boundaryDocument %}
-	{% set warningText = t('projectsIndex.projectLocation.warningText1') %}
+	{% set insetText = t('projectsIndex.projectLocation.insetText1') %}
 {% else %}
-	{% set warningText = t('projectsIndex.projectLocation.warningText2') %}
+	{% set insetText = t('projectsIndex.projectLocation.insetText2') %}
 {% endif %}
 
 <div class="govuk-!-margin-top-4">
-	{{ govukWarningText({
-		iconFallbackText: t('projectsIndex.projectLocation.iconFallbackText'),
-		text: warningText
+	{{ govukInsetText({
+		text: insetText
 	}) }}
 </div>
 

--- a/packages/forms-web-app/src/pages/projects/index/_translations/__snapshots__/translations.test.js.snap
+++ b/packages/forms-web-app/src/pages/projects/index/_translations/__snapshots__/translations.test.js.snap
@@ -99,9 +99,8 @@ exports[`pages/examination/_translations should return the correct English trans
   "projectLocation": {
     "boundaryDownloadText": "Download the geospatial map boundary file (JSON)",
     "heading1": "Project location",
-    "iconFallbackText": "Warning",
-    "warningText1": "Project boundaries shown are for illustrative purposes only. To view the exact boundaries, refer to latest relevant plans and drawings.",
-    "warningText2": "Map view boundaries are currently unavailable for this project. Refer to the latest plans and drawings to view the project's boundaries.",
+    "insetText1": "Project boundaries shown are for illustrative purposes only. To view the exact boundaries, refer to latest relevant plans and drawings.",
+    "insetText2": "Map view boundaries are currently unavailable for this project. Refer to the latest plans and drawings to view the project's boundaries.",
   },
   "projectStage": {
     "acceptance": {
@@ -316,9 +315,8 @@ exports[`pages/examination/_translations should return the correct Welsh transla
   "projectLocation": {
     "boundaryDownloadText": "Lawrlwythwch y ffeil ffiniau map geo-ofodol (JSON)",
     "heading1": "Lleoliad y prosiect",
-    "iconFallbackText": "Rhybudd",
-    "warningText1": "Mae'r ffiniau prosiect a ddangosir er diben darluniadol yn unig. I weld y ffiniau union, cyfeiriwch at y cynlluniau a'r lluniadau perthnasol diweddaraf.",
-    "warningText2": "Nid yw ffiniau'r golwg map ar gael ar hyn o bryd ar gyfer y prosiect. Cyfeiriwch at y cynlluniau a'r lluniadau diweddaraf i weld ffiniau'r prosiect.",
+    "insetText1": "Mae'r ffiniau prosiect a ddangosir er diben darluniadol yn unig. I weld y ffiniau union, cyfeiriwch at y cynlluniau a'r lluniadau perthnasol diweddaraf.",
+    "insetText2": "Nid yw ffiniau'r golwg map ar gael ar hyn o bryd ar gyfer y prosiect. Cyfeiriwch at y cynlluniau a'r lluniadau diweddaraf i weld ffiniau'r prosiect.",
   },
   "projectStage": {
     "acceptance": {

--- a/packages/forms-web-app/src/pages/projects/index/_translations/cy.json
+++ b/packages/forms-web-app/src/pages/projects/index/_translations/cy.json
@@ -13,9 +13,8 @@
 	"projectLocation": {
 		"heading1": "Lleoliad y prosiect",
 		"boundaryDownloadText": "Lawrlwythwch y ffeil ffiniau map geo-ofodol (JSON)",
-		"warningText1": "Mae'r ffiniau prosiect a ddangosir er diben darluniadol yn unig. I weld y ffiniau union, cyfeiriwch at y cynlluniau a'r lluniadau perthnasol diweddaraf.",
-		"warningText2": "Nid yw ffiniau'r golwg map ar gael ar hyn o bryd ar gyfer y prosiect. Cyfeiriwch at y cynlluniau a'r lluniadau diweddaraf i weld ffiniau'r prosiect.",
-		"iconFallbackText": "Rhybudd"
+		"insetText1": "Mae'r ffiniau prosiect a ddangosir er diben darluniadol yn unig. I weld y ffiniau union, cyfeiriwch at y cynlluniau a'r lluniadau perthnasol diweddaraf.",
+		"insetText2": "Nid yw ffiniau'r golwg map ar gael ar hyn o bryd ar gyfer y prosiect. Cyfeiriwch at y cynlluniau a'r lluniadau diweddaraf i weld ffiniau'r prosiect."
 	},
 	"getUpdates": {
 		"heading1": "Cael diweddariadau",

--- a/packages/forms-web-app/src/pages/projects/index/_translations/en.json
+++ b/packages/forms-web-app/src/pages/projects/index/_translations/en.json
@@ -13,9 +13,8 @@
 	"projectLocation": {
 		"heading1": "Project location",
 		"boundaryDownloadText": "Download the geospatial map boundary file (JSON)",
-		"warningText1": "Project boundaries shown are for illustrative purposes only. To view the exact boundaries, refer to latest relevant plans and drawings.",
-		"warningText2": "Map view boundaries are currently unavailable for this project. Refer to the latest plans and drawings to view the project's boundaries.",
-		"iconFallbackText": "Warning"
+		"insetText1": "Project boundaries shown are for illustrative purposes only. To view the exact boundaries, refer to latest relevant plans and drawings.",
+		"insetText2": "Map view boundaries are currently unavailable for this project. Refer to the latest plans and drawings to view the project's boundaries."
 	},
 	"getUpdates": {
 		"heading1": "Get updates",


### PR DESCRIPTION
## Describe your changes

updates the warning label below the map on all projects map page and individual project page. Replaces the warning label and changes it to inset text on both pages as per the prototype

<!--
    Issue ticket number and link
-->

[ticket 671](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-671)


<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
