### PR TITLE
fix(web): preserve users filter display choice (idas-685)

### DIFF
--- a/packages/forms-web-app/src/pages/projects-map/controller.js
+++ b/packages/forms-web-app/src/pages/projects-map/controller.js
@@ -79,8 +79,9 @@ const getProjectsMapController = async (req, res, next) => {
  */
 const postProjectsMapController = (req, res, next) => {
 	try {
-		// Flip the boolean: 'true' → false, 'false' → true
-		req.session.projectsMapShowFilters = req.body.filterToggleValue === 'false';
+		if (req.body.filterToggleValue !== undefined) {
+			req.session.projectsMapShowFilters = req.body.filterToggleValue === 'false';
+		}
 
 		const boundariesMapView = 'boundaries';
 		const markersMapView = 'markers';

--- a/packages/forms-web-app/src/pages/projects-map/controller.test.js
+++ b/packages/forms-web-app/src/pages/projects-map/controller.test.js
@@ -180,6 +180,31 @@ describe('pages/projects-map/controller', () => {
 			expect(req.session.projectsMapShowFilters).toBe(true);
 			expect(res.redirect).toHaveBeenCalledWith('/projects-map');
 		});
+
+		it('preserves filter visibility when switching map views', async () => {
+			req.session.projectsMapShowFilters = true;
+			req.body = { mapView: 'boundaries' };
+			req.get = jest.fn().mockReturnValue('');
+			res.redirect = jest.fn();
+
+			await postProjectsMapController(req, res, next);
+
+			expect(req.session.projectsMapShowFilters).toBe(true);
+			expect(req.session.projectsMapActiveMapView).toBe('boundaries');
+			expect(res.redirect).toHaveBeenCalledWith('/projects-map');
+		});
+
+		it('keeps filters hidden when switching map views if they were already hidden', async () => {
+			req.session.projectsMapShowFilters = false;
+			req.body = { mapView: 'boundaries' };
+			req.get = jest.fn().mockReturnValue('');
+			res.redirect = jest.fn();
+
+			await postProjectsMapController(req, res, next);
+
+			expect(req.session.projectsMapShowFilters).toBe(false);
+			expect(req.session.projectsMapActiveMapView).toBe('boundaries');
+		});
 	});
 
 	describe('downloadMasterGeoJsonController', () => {


### PR DESCRIPTION
## Describe your changes

Preserves users choice on the projects-map page for displaying filter panel. 
If user has clicked 'show filters' button and switches to boundary or marker view, the filter panel will remain displayed, if hidden and they switch view it will remain hidden.

<!--
    Issue ticket number and link
-->

[ticket 685](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-685)

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Useful information to review or test

<!--
    Add any useful information that will help the reviewer test your changes.
    This could include example payloads, steps to reproduce, etc.
-->

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
